### PR TITLE
mc-9122 Add to edit history when a user is added to or removed from a…

### DIFF
--- a/mdm-security/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUser.groovy
+++ b/mdm-security/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUser.groovy
@@ -24,6 +24,7 @@ import uk.ac.ox.softeng.maurodatamapper.gorm.constraint.callable.CreatorAwareCon
 import uk.ac.ox.softeng.maurodatamapper.security.utils.SecureRandomStringGenerator
 import uk.ac.ox.softeng.maurodatamapper.security.utils.SecurityUtils
 import uk.ac.ox.softeng.maurodatamapper.traits.domain.CreatorAware
+import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.EditHistoryAware
 
 import grails.databinding.BindUsing
 import grails.gorm.DetachedCriteria
@@ -33,7 +34,7 @@ import java.security.Principal
 import java.time.OffsetDateTime
 
 @Resource(readOnly = false, formats = ['json', 'xml'])
-class CatalogueUser implements Principal, CreatorAware, User {
+class CatalogueUser implements Principal, EditHistoryAware, CreatorAware, User {
 
     UUID id
     String emailAddress
@@ -116,6 +117,11 @@ class CatalogueUser implements Principal, CreatorAware, User {
 
     String toString() {
         "${getClass().getName()} (${emailAddress})[${id ?: '(unsaved)'}]"
+    }
+
+    @Override
+    String getEditLabel() {
+        "CatalogueUser:${id}"
     }
 
     @Override

--- a/mdm-security/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/security/UserGroupFunctionalSpec.groovy
+++ b/mdm-security/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/security/UserGroupFunctionalSpec.groovy
@@ -240,6 +240,41 @@ class UserGroupFunctionalSpec extends ResourceFunctionalSpec<UserGroup> implemen
     }
   ]
 }'''
+
+        when:
+        GET("$id/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 2,
+  "items": [
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "[UserGroup:testers] created"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
+
+        when:
+        GET("${baseUrl}catalogueUsers/${getUserId(userEmailAddresses.authenticated)}/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 1,
+  "items": [
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
     }
 
     void 'test removing a user from a group'() {
@@ -278,6 +313,56 @@ class UserGroupFunctionalSpec extends ResourceFunctionalSpec<UserGroup> implemen
       "pending": false,
       "disabled": false,
       "createdBy": "unlogged_user@mdm-core.com"
+    }
+  ]
+}'''
+
+        when:
+        GET("$id/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 3,
+  "items": [
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "[UserGroup:testers] created"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
+
+        when:
+        GET("${baseUrl}catalogueUsers/${getUserId(userEmailAddresses.authenticated)}/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 3,
+  "items": [
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "unlogged_user@mdm-core.com",
+      "description": "${json-unit.any-string}"
     }
   ]
 }'''

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/security/UserGroupFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/security/UserGroupFunctionalSpec.groovy
@@ -338,6 +338,41 @@ class UserGroupFunctionalSpec extends UserAccessFunctionalSpec {
         then:
         verifyJsonResponse OK, showJson
 
+        when: 'listing edits for the group, expect to see 2 edits. One create and one PUT.'
+        GET("$id/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 2,
+  "items": [
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "[UserGroup:testers] created"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
+
+        when: 'listing edits for the user who was added to the group'
+        GET("${baseUrl}catalogueUsers/${authenticatedId}/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 1,
+  "items": [
+     {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
+
         when: 'logged in as user in group'
         loginAuthenticated()
         PUT("${id}/catalogueUsers/${reviewerId}", [:])
@@ -409,6 +444,55 @@ class UserGroupFunctionalSpec extends UserAccessFunctionalSpec {
 
         then:
         verifyJsonResponse OK, showJson
+
+        when: 'listing edits for the group expect to see 4 edits. One create, two PUTs and a DELETE'
+        GET("$id/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 4,
+  "items": [
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "[UserGroup:testers] created"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
+        when: 'listing edits for the user who was removed from the group'
+        GET("${baseUrl}catalogueUsers/${reviewerId}/edits", STRING_ARG)
+
+        then:
+        verifyJsonResponse OK, '''{
+  "count": 2,
+  "items": [
+     {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    },
+    {
+      "dateCreated": "${json-unit.matches:offsetDateTime}",
+      "createdBy": "editor@test.com",
+      "description": "${json-unit.any-string}"
+    }
+  ]
+}'''
 
         when: 'logged in as user in group'
         loginEditor()


### PR DESCRIPTION
… User Group.

If the count of Users in a User Group changes on a PUT or DELETE then make edit records for both the User Group and the User. Add functional and integration tests to count the edits.