### PR TITLE
include reason for pending feature annotation, ensure clean up user groups logs state

### DIFF
--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/ModelUserAccessAndPermissionChangingFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/ModelUserAccessAndPermissionChangingFunctionalSpec.groovy
@@ -569,7 +569,7 @@ abstract class ModelUserAccessAndPermissionChangingFunctionalSpec extends UserAc
         cleanUpRoles(branchId)
     }
 
-    @PendingFeature
+    @PendingFeature(reason = 'Finalise needs to be removed from available actions after model is finalised')
     void 'E19d : test creating a new branch model version of a Model<T> and trying to finalise(as editor)'() {
         given:
         String id = getValidFinalisedId()

--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessWithoutUpdatingFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessWithoutUpdatingFunctionalSpec.groovy
@@ -250,11 +250,10 @@ abstract class UserAccessWithoutUpdatingFunctionalSpec extends ReadOnlyUserAcces
 
             // This is purely here to provide info about roles and resources which havent been cleaned up
             // It should not be used to perform cleanp of these roles and resources
-            Number rolesLeftOver = SecurableResourceGroupRole.byUserGroupIds(groupsToDelete*.id).count()
+            List<SecurableResourceGroupRole> rolesLeftOver = SecurableResourceGroupRole.byUserGroupIds(groupsToDelete*.id).list()
             if (rolesLeftOver) {
-                log.warn('Roles not cleaned up : {}', rolesLeftOver)
-                List<SecurableResourceGroupRole> leftOverRoles = SecurableResourceGroupRole.byUserGroupIds(groupsToDelete*.id).list()
-                leftOverRoles.each { role ->
+                log.warn('Roles not cleaned up : {}', rolesLeftOver.count())
+                rolesLeftOver.each { role ->
                     log.warn('Left over role resource {}:{}', role.securableResourceDomainType, role.securableResourceId)
                 }
                 Assert.fail('Roles remaining these need to be cleaned up from another test.' +


### PR DESCRIPTION
cleanupUserGroups had a race condition where SecurableResourceGroupRole.byUserGroupIds(groupsToDelete*.id).count() could return a non-zero count, but SecurableResourceGroupRole.byUserGroupIds(groupsToDelete*.id).list() could then return null

This depends on PR #39 