### PR TITLE
Feature/gh 64

### DIFF
--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/controller/CatalogueItemController.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/controller/CatalogueItemController.groovy
@@ -37,6 +37,10 @@ abstract class CatalogueItemController<T extends CatalogueItem> extends EditLogg
 
     abstract protected void serviceInsertResource(T resource)
 
+    protected void serviceUpdateResource(T resource) {
+        serviceInsertResource(resource)
+    }
+
     @Override
     protected T saveResource(T resource) {
         log.trace('save resource')
@@ -49,7 +53,7 @@ abstract class CatalogueItemController<T extends CatalogueItem> extends EditLogg
     protected T updateResource(T resource) {
         log.trace('update {}', resource.ident())
         List<String> dirtyPropertyNames = resource.getDirtyPropertyNames()
-        serviceInsertResource(resource)
+        serviceUpdateResource(resource)
         if (!params.boolean('noHistory')) resource.addUpdatedEdit(getCurrentUser(), dirtyPropertyNames)
         resource
     }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/controller/ModelController.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/controller/ModelController.groovy
@@ -689,6 +689,11 @@ abstract class ModelController<T extends Model> extends CatalogueItemController<
     }
 
     @Override
+    protected void serviceUpdateResource(T resource) {
+        getModelService().save(DEFAULT_SAVE_ARGS, resource) as T
+    }
+
+    @Override
     protected T updateResource(T resource) {
         long start = System.currentTimeMillis()
         Set<String> changedProperties = resource.getDirtyPropertyNames()

--- a/mdm-security/grails-app/i18n/messages.properties
+++ b/mdm-security/grails-app/i18n/messages.properties
@@ -31,3 +31,4 @@ invalid.grouprole.cannot.be.application.level.message=Property [{0}] of class [{
 invalid.grouprole.cannot.change.usergroup.message=Property [{0}] of class [{1}] cannot be changed once set
 invalid.grouprole.application.level.sergroups.message=Property [{0}] must be empty for non-application level GroupRoles
 invalid.apikey.cannot.refresh.unrefreshable.message=Cannot refresh ApiKey as it is not marked refreshable
+invalid.securableresourcegrouprole.not.unique.message=Property [{0}] of class [{1}] with value [{2}] must be unique by usergroup with value [{3}]

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
@@ -70,6 +70,12 @@ class SecurableResourceGroupRoleService {
             createdBy: createdBy.emailAddress
         )
         userGroup.addToSecurableResourceGroupRoles(securableResourceGroupRole)
+        updateAndSaveSecurableResourceGroupRole(securableResourceGroupRole, groupRole)
+    }
+
+    SecurableResourceGroupRole updateAndSaveSecurableResourceGroupRole(SecurableResourceGroupRole securableResourceGroupRole,
+                                                                       GroupRole groupRole) {
+
         groupRole.addToSecuredResourceGroupRoles(securableResourceGroupRole)
 
         if (!securableResourceGroupRole.validate()) {
@@ -89,6 +95,10 @@ class SecurableResourceGroupRoleService {
 
     SecurableResourceGroupRole findByUserGroupIdAndId(UUID userGroupId, UUID id) {
         SecurableResourceGroupRole.byUserGroupIdAndId(userGroupId, id).get()
+    }
+
+    SecurableResourceGroupRole findBySecurableResourceAndUserGroup(String securableResourceDomainType, UUID securableResourceId, UUID userGroupId) {
+        SecurableResourceGroupRole.bySecurableResourceAndUserGroupId(securableResourceDomainType, securableResourceId, userGroupId).get()
     }
 
     SecurableResourceGroupRole findBySecurableResourceAndGroupRoleIdAndUserGroupId(String securableResourceDomainType, UUID securableResourceId,
@@ -121,7 +131,7 @@ class SecurableResourceGroupRoleService {
     }
 
     def <R extends SecurableResource> R findSecurableResource(Class<R> clazz, UUID id) {
-        SecurableResourceService service = securableResourceServices.find { it.handles(clazz) }
+        SecurableResourceService service = securableResourceServices.find {it.handles(clazz)}
         if (!service) throw new ApiBadRequestException('SRGRS01',
                                                        "SecurableResourceGroupRole retrieval for securable resource [${clazz.simpleName}] with no " +
                                                        "supporting service")
@@ -129,12 +139,12 @@ class SecurableResourceGroupRoleService {
     }
 
     void updateModelFinalisationCapabilities() {
-        modelServices.each { service ->
+        modelServices.each {service ->
             List<SecurableResourceGroupRole> modelRoles = findAllBySecurableResourceDomainType(service.getModelClass().simpleName)
             if (modelRoles) {
 
                 // SQL migration has taken care of finalised models, we need to take care of branches
-                modelRoles.each { role ->
+                modelRoles.each {role ->
                     Model model = service.get(role.securableResourceId) as Model
                     role.canFinaliseModel = model.branchName == VersionAwareConstraints.DEFAULT_BRANCH_NAME
                     role.save(validate: false)

--- a/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleControllerSpec.groovy
+++ b/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleControllerSpec.groovy
@@ -40,6 +40,7 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
     GroupRole editorRole
     UserGroup editors
     UserGroup readers
+    UserGroup addtl
 
     def setup() {
         log.debug('Setting up SecurableResourceGroupRoleControllerSpec')
@@ -54,6 +55,8 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
         readers = new UserGroup(createdBy: userEmailAddresses.unitTest, name: 'readers').addToGroupMembers(reader).
             addToGroupMembers(reviewer)
         checkAndSave(readers)
+        addtl = new UserGroup(createdBy: userEmailAddresses.unitTest, name: 'addtl').addToGroupMembers(reader)
+        checkAndSave(addtl)
         UserGroup folderAdmins = new UserGroup(createdBy: userEmailAddresses.unitTest, name: 'folderAdmins').addToGroupMembers(admin)
         checkAndSave(folderAdmins)
 
@@ -181,10 +184,15 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
 
     @Override
     String getExpectedInvalidSavedJson() {
-        '{"total": 1, "errors": [' +
-        '{"message": "Property [groupRole] of class [class uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole]' +
-        ' cannot be an application level GroupRole"}' +
-        ']}'
+        '''{
+  "total": 2,
+  "errors": [
+    {"message": "Property [securableResourceId] of class [class uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole] ''' +
+        """with value [${folder.id}] must be unique by usergroup with value [${readers.id}]"},
+    {"message": "Property [groupRole] of class [class uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole] """ +
+        '''cannot be an application level GroupRole"}
+  ]
+}'''
     }
 
     @Override
@@ -196,7 +204,7 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
   "availableActions": ["delete","show","update"],
   "id": "${json-unit.matches:id}",
   "userGroup": {
-    "name": "readers",
+    "name": "addtl",
     "id": "${json-unit.matches:id}"
   },
   "groupRole": {
@@ -229,10 +237,19 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
 
     @Override
     String getExpectedInvalidUpdatedJson() {
-        '{"total": 1,"errors": [' +
-        '{"message": "Property [userGroup] of class [class uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole] cannot be ' +
-        'changed once set"}' +
-        ']}'
+        '''{
+  "total": 2,
+  "errors": [
+    {
+      "message": "Property [securableResourceId] of class [class uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole] ''' +
+        """with value [${folder.id}] must be unique by usergroup with value [${readers.id}]"
+    },
+    {
+      "message": "Property [userGroup] of class [class uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole] """ +
+        '''cannot be changed once set"
+    }
+  ]
+}'''
     }
 
     @Override
@@ -274,7 +291,7 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
 
     @Override
     SecurableResourceGroupRole getValidUnsavedInstance() {
-        new SecurableResourceGroupRole(securableResource: folder, userGroup: readers, groupRole: GroupRole.findByName('reader'))
+        new SecurableResourceGroupRole(securableResource: folder, userGroup: addtl, groupRole: GroupRole.findByName('reader'))
     }
 
     @Override

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/container/ClassifierFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/container/ClassifierFunctionalSpec.groovy
@@ -128,6 +128,11 @@ class ClassifierFunctionalSpec extends UserAccessAndPermissionChangingFunctional
     }
 
     @Override
+    int getExpectedCountOfGroupsWithAccess() {
+        2
+    }
+
+    @Override
     String getEditorIndexJson() {
         '''{
   "count": 4,

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/container/FolderFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/container/FolderFunctionalSpec.groovy
@@ -200,6 +200,11 @@ class FolderFunctionalSpec extends UserAccessAndPermissionChangingFunctionalSpec
         assert response.body().readableByAuthenticatedUsers == false
     }
 
+    @Override
+    int getExpectedCountOfGroupsWithAccess() {
+        2
+    }
+
     @Transactional
     @Override
     void removeValidIdObjectUsingTransaction(String id) {

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/container/VersionedFolderFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/container/VersionedFolderFunctionalSpec.groovy
@@ -169,6 +169,11 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
     }
 
     @Override
+    int getExpectedCountOfGroupsWithAccess() {
+        2
+    }
+
+    @Override
     void verifyL01Response(HttpResponse<Map> response) {
         verifyResponse OK, response
         assert response.body().count == 0

--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessAndPermissionChangingFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessAndPermissionChangingFunctionalSpec.groovy
@@ -121,6 +121,10 @@ abstract class UserAccessAndPermissionChangingFunctionalSpec extends UserAccessF
     }'''
     }
 
+    int getExpectedCountOfGroupsWithAccess() {
+        1
+    }
+
     /*
     * Logged in as editor testing
     */
@@ -129,14 +133,28 @@ abstract class UserAccessAndPermissionChangingFunctionalSpec extends UserAccessF
         given:
         String id = getValidId()
         def endpoint = "$id/readByEveryone"
-
-        when: 'logged in as user with write access'
         loginEditor()
+
+        when: 'getting the list of groups'
+        GET("$id/securableResourceGroupRoles")
+
+        then:
+        verifyResponse(OK, response)
+        responseBody().count == getExpectedCountOfGroupsWithAccess()
+
+        when: 'logged in as user with write access add the read by everyone'
         PUT(endpoint, [:])
 
         then:
         verifyResponse(OK, response)
         response.body().readableByEveryone == true
+
+        when: 'getting the list of groups'
+        GET("$id/securableResourceGroupRoles")
+
+        then:
+        verifyResponse(OK, response)
+        responseBody().count == getExpectedCountOfGroupsWithAccess()
 
         cleanup:
         removeValidIdObject(id)


### PR DESCRIPTION
When a secured resource was updated we were adding more security using the same group or creating a new group.
We fix this by having unique constraint on the domain and making sure that if we call "add security" we check for an existing security access first
We also dont add security to an already existing model on an update which is what we were doing as we were calling serviceInsertResource which was adding security

Add a test to prove this all works