### PR TITLE
Feature/mc 9537

### DIFF
--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/model/CopyInformation.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/model/CopyInformation.groovy
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model
 
 import grails.validation.Validateable

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/model/CopyInformation.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/model/CopyInformation.groovy
@@ -1,0 +1,12 @@
+package uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model
+
+import grails.validation.Validateable
+
+class CopyInformation implements Validateable {
+
+    String copyLabel
+
+    static constraints = {
+        copyLabel blank: false
+    }
+}

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -151,11 +151,11 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
             copy.label = original.label
             log.debug('Creating Copy with original label as provided label is empty or Invalid')
         }
-        classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each { copy.addToClassifiers(it) }
-        metadataService.findAllByMultiFacetAwareItemId(original.id).each { copy.addToMetadata(it.namespace, it.key, it.value, copier) }
-        ruleService.findAllByMultiFacetAwareItemId(original.id).each { rule ->
+        classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each {copy.addToClassifiers(it) }
+        metadataService.findAllByMultiFacetAwareItemId(original.id).each {copy.addToMetadata(it.namespace, it.key, it.value, copier) }
+        ruleService.findAllByMultiFacetAwareItemId(original.id).each {rule ->
             Rule copiedRule = new Rule(name: rule.name, description: rule.description, createdBy: copier.emailAddress)
-            rule.ruleRepresentations.each { ruleRepresentation ->
+            rule.ruleRepresentations.each {ruleRepresentation ->
                 copiedRule.addToRuleRepresentations(language: ruleRepresentation.language,
                                                     representation: ruleRepresentation.representation,
                                                     createdBy: copier.emailAddress)
@@ -163,7 +163,7 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
             copy.addToRules(copiedRule)
         }
 
-        semanticLinkService.findAllBySourceMultiFacetAwareItemId(original.id).each { link ->
+        semanticLinkService.findAllBySourceMultiFacetAwareItemId(original.id).each {link ->
             copy.addToSemanticLinks(createdBy: copier.emailAddress, linkType: link.linkType,
                                     targetMultiFacetAwareItemId: link.targetMultiFacetAwareItemId,
                                     targetMultiFacetAwareItemDomainType: link.targetMultiFacetAwareItemDomainType,
@@ -204,18 +204,18 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
                                         UserSecurityPolicyManager userSecurityPolicyManager) {
         log.debug('Merging Metadata into Catalogue Item')
         // call metadataService version of below
-        mergeFieldDiff.deleted.each { mergeItemData ->
+        mergeFieldDiff.deleted.each {mergeItemData ->
             Metadata metadata = metadataService.get(mergeItemData.id)
             metadataService.delete(metadata)
         }
 
         // copy additions from source to target object
-        mergeFieldDiff.created.each { mergeItemData ->
+        mergeFieldDiff.created.each {mergeItemData ->
             Metadata metadata = metadataService.get(mergeItemData.id)
             metadataService.copy(targetCatalogueItem, metadata, userSecurityPolicyManager)
         }
         // for modifications, recursively call this method
-        mergeFieldDiff.modified.each { mergeObjectDiffData ->
+        mergeFieldDiff.modified.each {mergeObjectDiffData ->
             metadataService.mergeMetadataIntoCatalogueItem(targetCatalogueItem, mergeObjectDiffData)
         }
     }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -142,20 +142,12 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
 
     K copyCatalogueItemInformation(K original, K copy, User copier, UserSecurityPolicyManager userSecurityPolicyManager,
                                    CopyInformation copyInformation = new CopyInformation()) {
-        copy.createdBy = copier.emailAddress
-        copy.description = original.description
-
-        if (copyInformation.validate()) {
-            copy.label = copyInformation.copyLabel
-        } else {
-            copy.label = original.label
-            log.debug('Creating Copy with original label as provided label is empty or Invalid')
-        }
-        classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each {copy.addToClassifiers(it) }
-        metadataService.findAllByMultiFacetAwareItemId(original.id).each {copy.addToMetadata(it.namespace, it.key, it.value, copier) }
-        ruleService.findAllByMultiFacetAwareItemId(original.id).each {rule ->
+        copy = populateCopyData(original, copy, copier, copyInformation)
+        classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each { copy.addToClassifiers(it) }
+        metadataService.findAllByMultiFacetAwareItemId(original.id).each { copy.addToMetadata(it.namespace, it.key, it.value, copier) }
+        ruleService.findAllByMultiFacetAwareItemId(original.id).each { rule ->
             Rule copiedRule = new Rule(name: rule.name, description: rule.description, createdBy: copier.emailAddress)
-            rule.ruleRepresentations.each {ruleRepresentation ->
+            rule.ruleRepresentations.each { ruleRepresentation ->
                 copiedRule.addToRuleRepresentations(language: ruleRepresentation.language,
                                                     representation: ruleRepresentation.representation,
                                                     createdBy: copier.emailAddress)
@@ -163,7 +155,7 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
             copy.addToRules(copiedRule)
         }
 
-        semanticLinkService.findAllBySourceMultiFacetAwareItemId(original.id).each {link ->
+        semanticLinkService.findAllBySourceMultiFacetAwareItemId(original.id).each { link ->
             copy.addToSemanticLinks(createdBy: copier.emailAddress, linkType: link.linkType,
                                     targetMultiFacetAwareItemId: link.targetMultiFacetAwareItemId,
                                     targetMultiFacetAwareItemDomainType: link.targetMultiFacetAwareItemDomainType,
@@ -204,19 +196,31 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
                                         UserSecurityPolicyManager userSecurityPolicyManager) {
         log.debug('Merging Metadata into Catalogue Item')
         // call metadataService version of below
-        mergeFieldDiff.deleted.each {mergeItemData ->
+        mergeFieldDiff.deleted.each { mergeItemData ->
             Metadata metadata = metadataService.get(mergeItemData.id)
             metadataService.delete(metadata)
         }
 
         // copy additions from source to target object
-        mergeFieldDiff.created.each {mergeItemData ->
+        mergeFieldDiff.created.each { mergeItemData ->
             Metadata metadata = metadataService.get(mergeItemData.id)
             metadataService.copy(targetCatalogueItem, metadata, userSecurityPolicyManager)
         }
         // for modifications, recursively call this method
-        mergeFieldDiff.modified.each {mergeObjectDiffData ->
+        mergeFieldDiff.modified.each { mergeObjectDiffData ->
             metadataService.mergeMetadataIntoCatalogueItem(targetCatalogueItem, mergeObjectDiffData)
         }
+    }
+
+    K populateCopyData(K original, K copy, User copier, CopyInformation copyInformation) {
+        copy.createdBy = copier.emailAddress
+        copy.description = original.description
+        if (copyInformation.validate()) {
+            copy.label = copyInformation.copyLabel
+        } else {
+            copy.label = original.label
+            log.debug('Creating Copy with original label as provided label is empty or Invalid')
+        }
+        return copy
     }
 }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -141,12 +141,12 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
     }
 
     K copyCatalogueItemInformation(K original, K copy, User copier, UserSecurityPolicyManager userSecurityPolicyManager,
-                                   CopyInformation copyInformation = null) {
+                                   CopyInformation copyInformation = new CopyInformation()) {
         copy.createdBy = copier.emailAddress
         copy.description = original.description
         // might relabel all elements in a DataClass, May need to specify by Id
-        if (!copyInformation.label.equals(original.label)){
-            copy.label = original.label
+        if (!copyInformation.copyLabel.blank){
+            copy.label = copyInformation.copyLabel
         }
 
         classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each {copy.addToClassifiers(it)}

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -28,6 +28,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.facet.Rule
 import uk.ac.ox.softeng.maurodatamapper.core.facet.RuleService
 import uk.ac.ox.softeng.maurodatamapper.core.facet.SemanticLinkService
 import uk.ac.ox.softeng.maurodatamapper.core.facet.SemanticLinkType
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.MergeFieldDiffData
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.DomainService
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MultiFacetAwareService
@@ -139,10 +140,14 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
         removeFacetFromDomain(catalogueItemId, classifier.id, 'classifiers')
     }
 
-    K copyCatalogueItemInformation(K original, K copy, User copier, UserSecurityPolicyManager userSecurityPolicyManager) {
+    K copyCatalogueItemInformation(K original, K copy, User copier, UserSecurityPolicyManager userSecurityPolicyManager,
+                                   CopyInformation copyInformation = null) {
         copy.createdBy = copier.emailAddress
-        copy.label = original.label
         copy.description = original.description
+        // might relabel all elements in a DataClass, May need to specify by Id
+        if (!copyInformation.label.equals(original.label)){
+            copy.label = original.label
+        }
 
         classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each {copy.addToClassifiers(it)}
         metadataService.findAllByMultiFacetAwareItemId(original.id).each {copy.addToMetadata(it.namespace, it.key, it.value, copier)}

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -144,16 +144,18 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
                                    CopyInformation copyInformation = new CopyInformation()) {
         copy.createdBy = copier.emailAddress
         copy.description = original.description
-        // might relabel all elements in a DataClass, May need to specify by Id
-        if (!copyInformation.copyLabel.blank){
-            copy.label = copyInformation.copyLabel
-        }
 
-        classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each {copy.addToClassifiers(it)}
-        metadataService.findAllByMultiFacetAwareItemId(original.id).each {copy.addToMetadata(it.namespace, it.key, it.value, copier)}
-        ruleService.findAllByMultiFacetAwareItemId(original.id).each {rule ->
+        if (copyInformation.validate()) {
+            copy.label = copyInformation.copyLabel
+        } else {
+            copy.label = original.label
+            log.debug('Creating Copy with original label as provided label is empty or Invalid')
+        }
+        classifierService.findAllByCatalogueItemId(userSecurityPolicyManager, original.id).each { copy.addToClassifiers(it) }
+        metadataService.findAllByMultiFacetAwareItemId(original.id).each { copy.addToMetadata(it.namespace, it.key, it.value, copier) }
+        ruleService.findAllByMultiFacetAwareItemId(original.id).each { rule ->
             Rule copiedRule = new Rule(name: rule.name, description: rule.description, createdBy: copier.emailAddress)
-            rule.ruleRepresentations.each {ruleRepresentation ->
+            rule.ruleRepresentations.each { ruleRepresentation ->
                 copiedRule.addToRuleRepresentations(language: ruleRepresentation.language,
                                                     representation: ruleRepresentation.representation,
                                                     createdBy: copier.emailAddress)
@@ -161,7 +163,7 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
             copy.addToRules(copiedRule)
         }
 
-        semanticLinkService.findAllBySourceMultiFacetAwareItemId(original.id).each {link ->
+        semanticLinkService.findAllBySourceMultiFacetAwareItemId(original.id).each { link ->
             copy.addToSemanticLinks(createdBy: copier.emailAddress, linkType: link.linkType,
                                     targetMultiFacetAwareItemId: link.targetMultiFacetAwareItemId,
                                     targetMultiFacetAwareItemDomainType: link.targetMultiFacetAwareItemDomainType,
@@ -202,18 +204,18 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements DomainSe
                                         UserSecurityPolicyManager userSecurityPolicyManager) {
         log.debug('Merging Metadata into Catalogue Item')
         // call metadataService version of below
-        mergeFieldDiff.deleted.each {mergeItemData ->
+        mergeFieldDiff.deleted.each { mergeItemData ->
             Metadata metadata = metadataService.get(mergeItemData.id)
             metadataService.delete(metadata)
         }
 
         // copy additions from source to target object
-        mergeFieldDiff.created.each {mergeItemData ->
+        mergeFieldDiff.created.each { mergeItemData ->
             Metadata metadata = metadataService.get(mergeItemData.id)
             metadataService.copy(targetCatalogueItem, metadata, userSecurityPolicyManager)
         }
         // for modifications, recursively call this method
-        mergeFieldDiff.modified.each {mergeObjectDiffData ->
+        mergeFieldDiff.modified.each { mergeObjectDiffData ->
             metadataService.mergeMetadataIntoCatalogueItem(targetCatalogueItem, mergeObjectDiffData)
         }
     }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelItemService.groovy
@@ -19,6 +19,7 @@ package uk.ac.ox.softeng.maurodatamapper.core.model
 
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiNotYetImplementedException
 import uk.ac.ox.softeng.maurodatamapper.core.container.Classifier
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.MergeFieldDiffData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.MergeObjectDiffData
 import uk.ac.ox.softeng.maurodatamapper.security.UserSecurityPolicyManager
@@ -52,6 +53,10 @@ abstract class ModelItemService<K extends ModelItem> extends CatalogueItemServic
 
     K copy(Model copiedModelInto, K original, UserSecurityPolicyManager userSecurityPolicyManager, UUID parentId) {
         throw new ApiNotYetImplementedException('MIS03', "copy [for ModelItem ${getModelItemClass().simpleName}] (with parent id)")
+    }
+
+    K copy(Model copiedModelInto, K original, UserSecurityPolicyManager userSecurityPolicyManager, UUID parentId, CopyInformation copyInformation) {
+        throw new ApiNotYetImplementedException('MIS03', "copy [for ModelItem ${getModelItemClass().simpleName}] (with parent id), and relabel")
     }
 
     Model mergeObjectDiffIntoModelItem(MergeObjectDiffData mergeObjectDiff, K targetModelItem, Model targetModel,

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassController.groovy
@@ -24,6 +24,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.search.SearchParams
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModelService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.SearchService
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.search.PaginatedLuceneResult
 
 import grails.gorm.transactions.Transactional
@@ -104,7 +105,8 @@ class DataClassController extends CatalogueItemController<DataClass> {
     }
 
     @Transactional
-    def copyDataClass() {
+    def copyDataClass(CopyInformation copyInformation) {
+
         if (handleReadOnly()) {
             return
         }
@@ -117,7 +119,7 @@ class DataClassController extends CatalogueItemController<DataClass> {
         DataClass copy
         try {
             copy = dataClassService.copyDataClassMatchingAllReferenceTypes(dataModel, original, currentUser, currentUserSecurityPolicyManager,
-                                                                           params.dataClassId)
+                                                                           params.dataClassId, copyInformation)
         } catch (ApiInvalidModelException ex) {
             transactionStatus.setRollbackOnly()
             respond ex.errors, view: 'create' // STATUS CODE 422

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementController.groovy
@@ -19,6 +19,7 @@ package uk.ac.ox.softeng.maurodatamapper.datamodel.item
 
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiInvalidModelException
 import uk.ac.ox.softeng.maurodatamapper.core.controller.CatalogueItemController
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModelService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataTypeService
@@ -55,7 +56,7 @@ class DataElementController extends CatalogueItemController<DataElement> {
     }
 
     @Transactional
-    def copyDataElement() {
+    def copyDataElement(CopyInformation copyInformation) {
         if (handleReadOnly()) {
             return
         }
@@ -68,7 +69,7 @@ class DataElementController extends CatalogueItemController<DataElement> {
         if (!originalDataElement) return notFound(params.dataElementId)
         DataElement copy
         try {
-            copy = dataElementService.copyDataElement(destinationDataModel, originalDataElement, currentUser, currentUserSecurityPolicyManager)
+            copy = dataElementService.copyDataElement(destinationDataModel, originalDataElement, currentUser, currentUserSecurityPolicyManager, copyInformation)
             destinationDataClass.addToDataElements(copy)
             dataClassService.matchUpAndAddMissingReferenceTypeClasses(destinationDataModel, sourceDataModel, currentUser,
                                                                       currentUserSecurityPolicyManager)

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeController.groovy
@@ -20,6 +20,7 @@ package uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiInvalidModelException
 import uk.ac.ox.softeng.maurodatamapper.core.controller.CatalogueItemController
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModelService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.databinding.converters.DataTypeValueConverter
@@ -57,7 +58,7 @@ class DataTypeController extends CatalogueItemController<DataType> {
     }
 
     @Transactional
-    def copyDataType() {
+    def copyDataType(CopyInformation copyInformation) {
         if (handleReadOnly()) {
             return
         }
@@ -68,7 +69,7 @@ class DataTypeController extends CatalogueItemController<DataType> {
         if (!original) return notFound(params.dataTypeId)
         DataType copy
         try {
-            copy = dataTypeService.copyDataType(dataModel, original, currentUser, currentUserSecurityPolicyManager)
+            copy = dataTypeService.copyDataType(dataModel, original, currentUser, currentUserSecurityPolicyManager, false, copyInformation)
         } catch (ApiInvalidModelException ex) {
             transactionStatus.setRollbackOnly()
             respond ex.errors, view: 'create' // STATUS CODE 422

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -102,13 +102,13 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         Set<DataType> dataTypes = extractAllUsedNewOrDirtyDataTypes(dataClass)
         log.debug('{} new or dirty used datatypes inside dataclass', dataTypes.size())
         // Validation should have already been done
-        dataTypes.each {it.skipValidation(true) }
+        dataTypes.each {it.skipValidation(true)}
         dataTypeService.saveAll(dataTypes, false)
     }
 
     Set<DataType> extractAllUsedNewOrDirtyDataTypes(DataClass dataClass) {
-        Set<DataType> dataTypes = dataClass.dataElements.collect {it.dataType }.findAll {it.isDirty() || !it.ident() }.toSet()
-        dataTypes.addAll(dataClass.dataClasses.collect {extractAllUsedNewOrDirtyDataTypes(it) }.flatten().toSet() as Collection<DataType>)
+        Set<DataType> dataTypes = dataClass.dataElements.collect {it.dataType}.findAll {it.isDirty() || !it.ident()}.toSet()
+        dataTypes.addAll(dataClass.dataClasses.collect {extractAllUsedNewOrDirtyDataTypes(it)}.flatten().toSet() as Collection<DataType>)
         dataTypes
     }
 
@@ -221,10 +221,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     DataClass checkFacetsAfterImportingCatalogueItem(DataClass catalogueItem) {
         super.checkFacetsAfterImportingCatalogueItem(catalogueItem)
         if (catalogueItem.summaryMetadata) {
-            catalogueItem.summaryMetadata.each {sm ->
+            catalogueItem.summaryMetadata.each { sm ->
                 sm.multiFacetAwareItemId = catalogueItem.id
                 sm.createdBy = sm.createdBy ?: catalogueItem.createdBy
-                sm.summaryMetadataReports.each {smr ->
+                sm.summaryMetadataReports.each { smr ->
                     smr.createdBy = catalogueItem.createdBy
                 }
             }
@@ -242,14 +242,14 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     Collection<DataElement> saveAllAndGetDataElements(Collection<DataClass> dataClasses) {
 
-        List<Classifier> classifiers = dataClasses.collectMany {it.classifiers ?: [] } as List<Classifier>
+        List<Classifier> classifiers = dataClasses.collectMany {it.classifiers ?: []} as List<Classifier>
         if (classifiers) {
             log.trace('Saving {} classifiers')
             classifierService.saveAll(classifiers)
         }
 
-        Collection<DataClass> alreadySaved = dataClasses.findAll {it.ident() && it.isDirty() }
-        Collection<DataClass> notSaved = dataClasses.findAll {!it.ident() }
+        Collection<DataClass> alreadySaved = dataClasses.findAll {it.ident() && it.isDirty()}
+        Collection<DataClass> notSaved = dataClasses.findAll {!it.ident()}
 
         Collection<DataElement> dataElements = []
 
@@ -264,7 +264,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
             int count = 0
 
             // Find all DCs which are either top level or have their parent DC already saved
-            Collection<DataClass> parentIsSaved = notSaved.findAll {!it.parentDataClass || it.parentDataClass.id }
+            Collection<DataClass> parentIsSaved = notSaved.findAll {!it.parentDataClass || it.parentDataClass.id}
             log.trace('Ready to save on first run {}', parentIsSaved.size())
             while (parentIsSaved) {
                 parentIsSaved.each {dc ->
@@ -285,7 +285,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
                 batch.clear()
                 // Find all DCs which have a saved parent DC
                 notSaved.removeAll(parentIsSaved)
-                parentIsSaved = notSaved.findAll {it.parentDataClass && it.parentDataClass.id }
+                parentIsSaved = notSaved.findAll {it.parentDataClass && it.parentDataClass.id}
                 log.trace('Ready to save on subsequent run {}', parentIsSaved.size())
             }
         }
@@ -298,28 +298,28 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         dataClass.breadcrumbTree.removeFromParent()
         dataClass.dataModel.removeFromDataClasses(dataClass)
         dataClass.extendedDataClasses
-        dataClass.dataClasses?.each {removeAssociations(it) }
+        dataClass.dataClasses?.each {removeAssociations(it)}
     }
 
     private void removeSemanticLinks(DataClass dataClass) {
         List<SemanticLink> semanticLinks = semanticLinkService.findAllByMultiFacetAwareItemId(dataClass.id)
-        semanticLinks.each {semanticLinkService.delete(it) }
+        semanticLinks.each {semanticLinkService.delete(it)}
     }
 
     private void removeReferenceTypes(DataClass dataClass) {
         List<ReferenceType> referenceTypes = new ArrayList<>(dataClass.referenceTypes.findAll())
-        referenceTypes.each {dataTypeService.delete(it) }
+        referenceTypes.each {dataTypeService.delete(it)}
     }
 
     private void removeAllDataElementsWithNoLabel(DataClass dataClass) {
-        List<DataElement> dataElements = new ArrayList<>(dataClass.dataElements.findAll {!it.label })
-        dataElements.each {dataElementService.delete(it) }
+        List<DataElement> dataElements = new ArrayList<>(dataClass.dataElements.findAll {!it.label})
+        dataElements.each {dataElementService.delete(it)}
     }
 
     private void removeAllDataElementsWithSameLabel(DataClass dataClass) {
 
         if (dataClass.dataElements) {
-            Map<String, List<DataElement>> identicalDataElements = dataClass.dataElements.groupBy {it.label }.findAll {it.value.size() > 1 }
+            Map<String, List<DataElement>> identicalDataElements = dataClass.dataElements.groupBy {it.label}.findAll {it.value.size() > 1}
             identicalDataElements.each {label, dataElements ->
                 for (int i = 1; i < dataElements.size(); i++) {
                     dataElementService.delete(dataElements[i])
@@ -330,7 +330,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     private void ensureChildDataClassesHaveUniqueNames(DataClass dataClass) {
         if (dataClass.dataClasses) {
-            dataClass.dataClasses.groupBy {it.label }.findAll {it.value.size() > 1 }.each {label, dataClasses ->
+            dataClass.dataClasses.groupBy {it.label}.findAll {it.value.size() > 1}.each {label, dataClasses ->
                 dataClasses.eachWithIndex {DataClass child, int i ->
                     child.label = "${child.label}-$i"
                 }
@@ -341,10 +341,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     private void collapseReferenceTypes(DataClass dataClass) {
         if (!dataClass.referenceTypes || dataClass.referenceTypes.size() == 1) return
         DataModel dataModel = dataClass.dataModel
-        Map<String, List<ReferenceType>> labelGroupedReferenceTypes = dataClass.referenceTypes.groupBy {it.label }
+        Map<String, List<ReferenceType>> labelGroupedReferenceTypes = dataClass.referenceTypes.groupBy {it.label}
 
-        labelGroupedReferenceTypes.findAll {it.value.size() > 1 }.each {label, labelReferenceTypes ->
-            Map<String, List<ReferenceType>> dmGrouped = labelReferenceTypes.groupBy {it.dataModel ? 'dataModel' : 'noDataModel' }
+        labelGroupedReferenceTypes.findAll {it.value.size() > 1}.each {label, labelReferenceTypes ->
+            Map<String, List<ReferenceType>> dmGrouped = labelReferenceTypes.groupBy {it.dataModel ? 'dataModel' : 'noDataModel'}
 
             // There will be only 1 datamodel owned type as we've already merged datamodel owned datatypes
             if (dmGrouped.dataModel) {
@@ -394,7 +394,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     }
 
     DataClass findSameLabelTree(DataModel dataModel, DataClass searchFor) {
-        dataModel.dataClasses.find {hasSameLabelTree(it, searchFor) }
+        dataModel.dataClasses.find {hasSameLabelTree(it, searchFor)}
     }
 
     private boolean hasSameLabelTree(DataClass left, DataClass right) {
@@ -548,11 +548,11 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     }
 
     DataClass findDataClass(DataModel dataModel, String label) {
-        dataModel.dataClasses.find {!it.parentDataClass && it.label == label.trim() }
+        dataModel.dataClasses.find {!it.parentDataClass && it.label == label.trim()}
     }
 
     DataClass findDataClass(DataClass parentDataClass, String label) {
-        parentDataClass.dataClasses.find {it.label == label.trim() }
+        parentDataClass.dataClasses.find {it.label == label.trim()}
     }
 
     DataClass findDataClassByPath(DataModel dataModel, List<String> pathLabels) {
@@ -692,7 +692,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     private Set<ReferenceType> getAllNestedReferenceTypes(DataClass dataClass) {
         Set<ReferenceType> referenceTypes = []
         referenceTypes.addAll(dataClass.referenceTypes ?: [])
-        referenceTypes.addAll(dataClass.dataElements.dataType.findAll {it.instanceOf(ReferenceType) })
+        referenceTypes.addAll(dataClass.dataElements.dataType.findAll {it.instanceOf(ReferenceType)})
         dataClass.dataClasses.each {
             referenceTypes.addAll(getAllNestedReferenceTypes(it))
         }
@@ -701,7 +701,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
 
     private Set<ReferenceType> findAllEmptyReferenceTypes(DataModel dataModel) {
-        dataModel.referenceTypes.findAll {!(it as ReferenceType).referenceClass } as Set<ReferenceType>
+        dataModel.referenceTypes.findAll {!(it as ReferenceType).referenceClass} as Set<ReferenceType>
     }
 
 
@@ -740,7 +740,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     @Override
     List<DataClass> findAllReadableByClassifier(UserSecurityPolicyManager userSecurityPolicyManager, Classifier classifier) {
-        DataClass.byClassifierId(classifier.id).list().findAll {userSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, it.model.id) }
+        DataClass.byClassifierId(classifier.id).list().findAll {userSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, it.model.id)}
     }
 
     @Override
@@ -781,7 +781,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         dataClasses.each {de ->
             fromDataClasses.each {fde ->
                 // If no link already exists then add a new one
-                if (!alreadyExistingLinks.any {it.multiFacetAwareItemId == de.id && it.targetMultiFacetAwareItemId == fde.id }) {
+                if (!alreadyExistingLinks.any {it.multiFacetAwareItemId == de.id && it.targetMultiFacetAwareItemId == fde.id}) {
                     setDataClassIsFromDataClass(de, fde, user)
                 }
             }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -582,8 +582,8 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     DataClass copyDataClassMatchingAllReferenceTypes(DataModel copiedDataModel, DataClass original, User copier,
                                                      UserSecurityPolicyManager userSecurityPolicyManager, Serializable parentDataClassId,
-                                                     CopyInformation copyInformation = null) {
-        DataClass copiedDataClass = copyDataClass(copiedDataModel, original, copier, userSecurityPolicyManager, parentDataClassId, false,
+                                                     CopyInformation copyInformation = new CopyInformation()) {
+        DataClass copiedDataClass = copyDataClass(copiedDataModel, original, copier, userSecurityPolicyManager, parentDataClassId,
                                                   copyInformation)
         log.debug('Copied required DataClass, now checking for reference classes which haven\'t been matched or added')
         matchUpAndAddMissingReferenceTypeClasses(copiedDataModel, original.dataModel, copier, userSecurityPolicyManager)
@@ -594,13 +594,14 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     @Override
     DataClass copy(Model copiedDataModel, DataClass original, UserSecurityPolicyManager userSecurityPolicyManager,
-                   UUID parentDataClassId = null) {
-        copyDataClass(copiedDataModel as DataModel, original, userSecurityPolicyManager.user, userSecurityPolicyManager, parentDataClassId)
+                   UUID parentDataClassId = null, CopyInformation copyInformation = null) {
+        copyDataClass(copiedDataModel as DataModel, original, userSecurityPolicyManager.user, userSecurityPolicyManager,
+                      parentDataClassId, copyInformation)
     }
 
     DataClass copyDataClass(DataModel copiedDataModel, DataClass original, User copier,
                             UserSecurityPolicyManager userSecurityPolicyManager,
-                            Serializable parentDataClassId = null, boolean copySummaryMetadata = false, CopyInformation copyInformation = null) {
+                            Serializable parentDataClassId = null, boolean copySummaryMetadata = false, CopyInformation copyInformation) {
         if (!original) throw new ApiInternalException('DCSXX', 'Cannot copy non-existent DataClass')
 
         DataClass copy = new DataClass(

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -102,13 +102,13 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         Set<DataType> dataTypes = extractAllUsedNewOrDirtyDataTypes(dataClass)
         log.debug('{} new or dirty used datatypes inside dataclass', dataTypes.size())
         // Validation should have already been done
-        dataTypes.each { it.skipValidation(true) }
+        dataTypes.each {it.skipValidation(true) }
         dataTypeService.saveAll(dataTypes, false)
     }
 
     Set<DataType> extractAllUsedNewOrDirtyDataTypes(DataClass dataClass) {
-        Set<DataType> dataTypes = dataClass.dataElements.collect { it.dataType }.findAll { it.isDirty() || !it.ident() }.toSet()
-        dataTypes.addAll(dataClass.dataClasses.collect { extractAllUsedNewOrDirtyDataTypes(it) }.flatten().toSet() as Collection<DataType>)
+        Set<DataType> dataTypes = dataClass.dataElements.collect {it.dataType }.findAll {it.isDirty() || !it.ident() }.toSet()
+        dataTypes.addAll(dataClass.dataClasses.collect {extractAllUsedNewOrDirtyDataTypes(it) }.flatten().toSet() as Collection<DataType>)
         dataTypes
     }
 
@@ -133,7 +133,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         dataClass.save(flush: false, validate: false)
 
         // Recurse through the hierarchy
-        dataClasses?.each { dc ->
+        dataClasses?.each {dc ->
             saveDataClassHierarchy(dc)
         }
 
@@ -221,10 +221,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     DataClass checkFacetsAfterImportingCatalogueItem(DataClass catalogueItem) {
         super.checkFacetsAfterImportingCatalogueItem(catalogueItem)
         if (catalogueItem.summaryMetadata) {
-            catalogueItem.summaryMetadata.each { sm ->
+            catalogueItem.summaryMetadata.each {sm ->
                 sm.multiFacetAwareItemId = catalogueItem.id
                 sm.createdBy = sm.createdBy ?: catalogueItem.createdBy
-                sm.summaryMetadataReports.each { smr ->
+                sm.summaryMetadataReports.each {smr ->
                     smr.createdBy = catalogueItem.createdBy
                 }
             }
@@ -242,14 +242,14 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     Collection<DataElement> saveAllAndGetDataElements(Collection<DataClass> dataClasses) {
 
-        List<Classifier> classifiers = dataClasses.collectMany { it.classifiers ?: [] } as List<Classifier>
+        List<Classifier> classifiers = dataClasses.collectMany {it.classifiers ?: [] } as List<Classifier>
         if (classifiers) {
             log.trace('Saving {} classifiers')
             classifierService.saveAll(classifiers)
         }
 
-        Collection<DataClass> alreadySaved = dataClasses.findAll { it.ident() && it.isDirty() }
-        Collection<DataClass> notSaved = dataClasses.findAll { !it.ident() }
+        Collection<DataClass> alreadySaved = dataClasses.findAll {it.ident() && it.isDirty() }
+        Collection<DataClass> notSaved = dataClasses.findAll {!it.ident() }
 
         Collection<DataElement> dataElements = []
 
@@ -264,10 +264,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
             int count = 0
 
             // Find all DCs which are either top level or have their parent DC already saved
-            Collection<DataClass> parentIsSaved = notSaved.findAll { !it.parentDataClass || it.parentDataClass.id }
+            Collection<DataClass> parentIsSaved = notSaved.findAll {!it.parentDataClass || it.parentDataClass.id }
             log.trace('Ready to save on first run {}', parentIsSaved.size())
             while (parentIsSaved) {
-                parentIsSaved.each { dc ->
+                parentIsSaved.each {dc ->
                     dataElements.addAll dc.dataElements ?: []
 
                     dc.dataClasses?.clear()
@@ -285,7 +285,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
                 batch.clear()
                 // Find all DCs which have a saved parent DC
                 notSaved.removeAll(parentIsSaved)
-                parentIsSaved = notSaved.findAll { it.parentDataClass && it.parentDataClass.id }
+                parentIsSaved = notSaved.findAll {it.parentDataClass && it.parentDataClass.id }
                 log.trace('Ready to save on subsequent run {}', parentIsSaved.size())
             }
         }
@@ -298,29 +298,29 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         dataClass.breadcrumbTree.removeFromParent()
         dataClass.dataModel.removeFromDataClasses(dataClass)
         dataClass.extendedDataClasses
-        dataClass.dataClasses?.each { removeAssociations(it) }
+        dataClass.dataClasses?.each {removeAssociations(it) }
     }
 
     private void removeSemanticLinks(DataClass dataClass) {
         List<SemanticLink> semanticLinks = semanticLinkService.findAllByMultiFacetAwareItemId(dataClass.id)
-        semanticLinks.each { semanticLinkService.delete(it) }
+        semanticLinks.each {semanticLinkService.delete(it) }
     }
 
     private void removeReferenceTypes(DataClass dataClass) {
         List<ReferenceType> referenceTypes = new ArrayList<>(dataClass.referenceTypes.findAll())
-        referenceTypes.each { dataTypeService.delete(it) }
+        referenceTypes.each {dataTypeService.delete(it) }
     }
 
     private void removeAllDataElementsWithNoLabel(DataClass dataClass) {
-        List<DataElement> dataElements = new ArrayList<>(dataClass.dataElements.findAll { !it.label })
-        dataElements.each { dataElementService.delete(it) }
+        List<DataElement> dataElements = new ArrayList<>(dataClass.dataElements.findAll {!it.label })
+        dataElements.each {dataElementService.delete(it) }
     }
 
     private void removeAllDataElementsWithSameLabel(DataClass dataClass) {
 
         if (dataClass.dataElements) {
-            Map<String, List<DataElement>> identicalDataElements = dataClass.dataElements.groupBy { it.label }.findAll { it.value.size() > 1 }
-            identicalDataElements.each { label, dataElements ->
+            Map<String, List<DataElement>> identicalDataElements = dataClass.dataElements.groupBy {it.label }.findAll {it.value.size() > 1 }
+            identicalDataElements.each {label, dataElements ->
                 for (int i = 1; i < dataElements.size(); i++) {
                     dataElementService.delete(dataElements[i])
                 }
@@ -330,8 +330,8 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     private void ensureChildDataClassesHaveUniqueNames(DataClass dataClass) {
         if (dataClass.dataClasses) {
-            dataClass.dataClasses.groupBy { it.label }.findAll { it.value.size() > 1 }.each { label, dataClasses ->
-                dataClasses.eachWithIndex { DataClass child, int i ->
+            dataClass.dataClasses.groupBy {it.label }.findAll {it.value.size() > 1 }.each {label, dataClasses ->
+                dataClasses.eachWithIndex {DataClass child, int i ->
                     child.label = "${child.label}-$i"
                 }
             }
@@ -341,10 +341,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     private void collapseReferenceTypes(DataClass dataClass) {
         if (!dataClass.referenceTypes || dataClass.referenceTypes.size() == 1) return
         DataModel dataModel = dataClass.dataModel
-        Map<String, List<ReferenceType>> labelGroupedReferenceTypes = dataClass.referenceTypes.groupBy { it.label }
+        Map<String, List<ReferenceType>> labelGroupedReferenceTypes = dataClass.referenceTypes.groupBy {it.label }
 
-        labelGroupedReferenceTypes.findAll { it.value.size() > 1 }.each { label, labelReferenceTypes ->
-            Map<String, List<ReferenceType>> dmGrouped = labelReferenceTypes.groupBy { it.dataModel ? 'dataModel' : 'noDataModel' }
+        labelGroupedReferenceTypes.findAll {it.value.size() > 1 }.each {label, labelReferenceTypes ->
+            Map<String, List<ReferenceType>> dmGrouped = labelReferenceTypes.groupBy {it.dataModel ? 'dataModel' : 'noDataModel' }
 
             // There will be only 1 datamodel owned type as we've already merged datamodel owned datatypes
             if (dmGrouped.dataModel) {
@@ -362,11 +362,11 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     private void setCreatedBy(User creator, DataClass dataClass) {
         dataClass.createdBy = creator.emailAddress
-        dataClass.dataClasses?.each { dc ->
+        dataClass.dataClasses?.each {dc ->
             setCreatedBy(creator, dc)
         }
 
-        dataClass.dataElements?.each { de ->
+        dataClass.dataElements?.each {de ->
             de.createdBy = creator.emailAddress
         }
     }
@@ -378,13 +378,13 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         checkFacetsAfterImportingCatalogueItem(dataClass)
         if (dataClass.dataClasses) {
             dataClass.fullSortOfChildren(dataClass.dataClasses)
-            dataClass.dataClasses.each { dc ->
+            dataClass.dataClasses.each {dc ->
                 checkImportedDataClassAssociations(importingUser, dataModel, dc, matchDataTypes)
             }
         }
         if (dataClass.dataElements) {
             dataClass.fullSortOfChildren(dataClass.dataElements)
-            dataClass.dataElements.each { de ->
+            dataClass.dataElements.each {de ->
                 de.createdBy = importingUser.emailAddress
                 de.buildPath()
                 dataElementService.checkFacetsAfterImportingCatalogueItem(de)
@@ -394,7 +394,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     }
 
     DataClass findSameLabelTree(DataModel dataModel, DataClass searchFor) {
-        dataModel.dataClasses.find { hasSameLabelTree(it, searchFor) }
+        dataModel.dataClasses.find {hasSameLabelTree(it, searchFor) }
     }
 
     private boolean hasSameLabelTree(DataClass left, DataClass right) {
@@ -548,11 +548,11 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     }
 
     DataClass findDataClass(DataModel dataModel, String label) {
-        dataModel.dataClasses.find { !it.parentDataClass && it.label == label.trim() }
+        dataModel.dataClasses.find {!it.parentDataClass && it.label == label.trim() }
     }
 
     DataClass findDataClass(DataClass parentDataClass, String label) {
-        parentDataClass.dataClasses.find { it.label == label.trim() }
+        parentDataClass.dataClasses.find {it.label == label.trim() }
     }
 
     DataClass findDataClassByPath(DataModel dataModel, List<String> pathLabels) {
@@ -621,8 +621,8 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         if (!copy.validate()) //save(validate: false, copy) else
             throw new ApiInvalidModelException('DCS01', 'Copied DataClass is invalid', copy.errors, messageSource)
 
-        original.referenceTypes.each { refType ->
-            ReferenceType referenceType = copiedDataModel.referenceTypes.find { it.label == refType.label }
+        original.referenceTypes.each {refType ->
+            ReferenceType referenceType = copiedDataModel.referenceTypes.find {it.label == refType.label }
             if (!referenceType) {
                 referenceType = new ReferenceType(createdBy: copier.emailAddress, label: refType.label)
                 copiedDataModel.addToDataTypes(referenceType)
@@ -631,11 +631,11 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         }
 
         copy.dataClasses = []
-        original.dataClasses.each { child ->
+        original.dataClasses.each {child ->
             copy.addToDataClasses(copyDataClass(copiedDataModel, child, copier, userSecurityPolicyManager))
         }
         copy.dataElements = []
-        original.dataElements.each { element ->
+        original.dataElements.each {element ->
             copy.addToDataElements(dataElementService.copyDataElement(copiedDataModel, element, copier, userSecurityPolicyManager))
         }
 
@@ -673,7 +673,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         if (!emptyReferenceTypes) return
         log.debug('Found {} empty reference types', emptyReferenceTypes.size())
         // Copy all the missing reference classes
-        emptyReferenceTypes.each { rt ->
+        emptyReferenceTypes.each {rt ->
             ReferenceType ort = originalDataModel.findDataTypeByLabel(rt.label) as ReferenceType
             String originalDataClassPath = buildPath(ort.referenceClass)
             DataClass copiedDataClass = findDataClassByPath(copiedDataModel, originalDataClassPath.split(/\|/).toList())
@@ -692,7 +692,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     private Set<ReferenceType> getAllNestedReferenceTypes(DataClass dataClass) {
         Set<ReferenceType> referenceTypes = []
         referenceTypes.addAll(dataClass.referenceTypes ?: [])
-        referenceTypes.addAll(dataClass.dataElements.dataType.findAll { it.instanceOf(ReferenceType) })
+        referenceTypes.addAll(dataClass.dataElements.dataType.findAll {it.instanceOf(ReferenceType) })
         dataClass.dataClasses.each {
             referenceTypes.addAll(getAllNestedReferenceTypes(it))
         }
@@ -701,7 +701,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
 
     private Set<ReferenceType> findAllEmptyReferenceTypes(DataModel dataModel) {
-        dataModel.referenceTypes.findAll { !(it as ReferenceType).referenceClass } as Set<ReferenceType>
+        dataModel.referenceTypes.findAll {!(it as ReferenceType).referenceClass } as Set<ReferenceType>
     }
 
 
@@ -740,7 +740,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     @Override
     List<DataClass> findAllReadableByClassifier(UserSecurityPolicyManager userSecurityPolicyManager, Classifier classifier) {
-        DataClass.byClassifierId(classifier.id).list().findAll { userSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, it.model.id) }
+        DataClass.byClassifierId(classifier.id).list().findAll {userSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, it.model.id) }
     }
 
     @Override
@@ -778,10 +778,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         List<SemanticLink> alreadyExistingLinks =
             semanticLinkService.findAllBySourceMultiFacetAwareItemIdInListAndTargetMultiFacetAwareItemIdInListAndLinkType(
                 dataClasses*.id, fromDataClasses*.id, SemanticLinkType.IS_FROM)
-        dataClasses.each { de ->
-            fromDataClasses.each { fde ->
+        dataClasses.each {de ->
+            fromDataClasses.each {fde ->
                 // If no link already exists then add a new one
-                if (!alreadyExistingLinks.any { it.multiFacetAwareItemId == de.id && it.targetMultiFacetAwareItemId == fde.id }) {
+                if (!alreadyExistingLinks.any {it.multiFacetAwareItemId == de.id && it.targetMultiFacetAwareItemId == fde.id }) {
                     setDataClassIsFromDataClass(de, fde, user)
                 }
             }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -583,7 +583,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     DataClass copyDataClassMatchingAllReferenceTypes(DataModel copiedDataModel, DataClass original, User copier,
                                                      UserSecurityPolicyManager userSecurityPolicyManager, Serializable parentDataClassId,
                                                      CopyInformation copyInformation = new CopyInformation()) {
-        DataClass copiedDataClass = copyDataClass(copiedDataModel, original, copier, userSecurityPolicyManager, parentDataClassId,
+        DataClass copiedDataClass = copyDataClass(copiedDataModel, original, copier, userSecurityPolicyManager, parentDataClassId, false,
                                                   copyInformation)
         log.debug('Copied required DataClass, now checking for reference classes which haven\'t been matched or added')
         matchUpAndAddMissingReferenceTypeClasses(copiedDataModel, original.dataModel, copier, userSecurityPolicyManager)
@@ -594,14 +594,15 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     @Override
     DataClass copy(Model copiedDataModel, DataClass original, UserSecurityPolicyManager userSecurityPolicyManager,
-                   UUID parentDataClassId = null, CopyInformation copyInformation = null) {
+                   UUID parentDataClassId = null, CopyInformation copyInformation = new CopyInformation()) {
         copyDataClass(copiedDataModel as DataModel, original, userSecurityPolicyManager.user, userSecurityPolicyManager,
-                      parentDataClassId, copyInformation)
+                      parentDataClassId, false, copyInformation)
     }
 
     DataClass copyDataClass(DataModel copiedDataModel, DataClass original, User copier,
                             UserSecurityPolicyManager userSecurityPolicyManager,
-                            Serializable parentDataClassId = null, boolean copySummaryMetadata = false, CopyInformation copyInformation) {
+                            Serializable parentDataClassId = null, boolean copySummaryMetadata = false,
+                            CopyInformation copyInformation = new CopyInformation()) {
         if (!original) throw new ApiInternalException('DCSXX', 'Cannot copy non-existent DataClass')
 
         DataClass copy = new DataClass(
@@ -692,7 +693,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
     private Set<ReferenceType> getAllNestedReferenceTypes(DataClass dataClass) {
         Set<ReferenceType> referenceTypes = []
         referenceTypes.addAll(dataClass.referenceTypes ?: [])
-        referenceTypes.addAll(dataClass.dataElements.dataType.findAll {it.instanceOf(ReferenceType)})
+        referenceTypes.addAll(dataClass.dataElements.dataType.findAll {it.instanceOf(ReferenceType) })
         dataClass.dataClasses.each {
             referenceTypes.addAll(getAllNestedReferenceTypes(it))
         }
@@ -701,7 +702,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
 
     private Set<ReferenceType> findAllEmptyReferenceTypes(DataModel dataModel) {
-        dataModel.referenceTypes.findAll {!(it as ReferenceType).referenceClass} as Set<ReferenceType>
+        dataModel.referenceTypes.findAll {!(it as ReferenceType).referenceClass } as Set<ReferenceType>
     }
 
 
@@ -740,7 +741,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
     @Override
     List<DataClass> findAllReadableByClassifier(UserSecurityPolicyManager userSecurityPolicyManager, Classifier classifier) {
-        DataClass.byClassifierId(classifier.id).list().findAll {userSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, it.model.id)}
+        DataClass.byClassifierId(classifier.id).list().findAll {userSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, it.model.id) }
     }
 
     @Override
@@ -781,7 +782,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         dataClasses.each {de ->
             fromDataClasses.each {fde ->
                 // If no link already exists then add a new one
-                if (!alreadyExistingLinks.any {it.multiFacetAwareItemId == de.id && it.targetMultiFacetAwareItemId == fde.id}) {
+                if (!alreadyExistingLinks.any {it.multiFacetAwareItemId == de.id && it.targetMultiFacetAwareItemId == fde.id }) {
                     setDataClassIsFromDataClass(de, fde, user)
                 }
             }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -24,6 +24,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.facet.SemanticLinkType
 import uk.ac.ox.softeng.maurodatamapper.core.model.CatalogueItem
 import uk.ac.ox.softeng.maurodatamapper.core.model.Model
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelItemService
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.core.similarity.SimilarityResult
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadata
@@ -333,11 +334,11 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
     }
 
     DataElement copyDataElement(DataModel copiedDataModel, DataElement original, User copier,
-                                UserSecurityPolicyManager userSecurityPolicyManager) {
+                                UserSecurityPolicyManager userSecurityPolicyManager, CopyInformation copyInformation = new CopyInformation()) {
         DataElement copy = new DataElement(minMultiplicity: original.minMultiplicity,
                                            maxMultiplicity: original.maxMultiplicity)
 
-        copy = copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager)
+        copy = copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
         setCatalogueItemRefinesCatalogueItem(copy, original, copier)
 
         DataType dataType = copiedDataModel.findDataTypeByLabel(original.dataType.label)
@@ -357,8 +358,8 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
                                              DataElement copy,
                                              User copier,
                                              UserSecurityPolicyManager userSecurityPolicyManager,
-                                             boolean copySummaryMetadata) {
-        copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager)
+                                             boolean copySummaryMetadata,CopyInformation copyInformation) {
+        copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
         if (copySummaryMetadata) {
             summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {
                 copy.addToSummaryMetadata(label: it.label, summaryMetadataType: it.summaryMetadataType, createdBy: copier.emailAddress)
@@ -371,8 +372,8 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
     DataElement copyCatalogueItemInformation(DataElement original,
                                              DataElement copy,
                                              User copier,
-                                             UserSecurityPolicyManager userSecurityPolicyManager) {
-        copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, false)
+                                             UserSecurityPolicyManager userSecurityPolicyManager, CopyInformation copyInformation) {
+        copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, false, copyInformation)
     }
 
     DataElementSimilarityResult findAllSimilarDataElementsInDataModel(DataModel dataModelToSearch, DataElement dataElementToCompare, maxResults = 5) {

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
@@ -24,6 +24,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.model.CatalogueItem
 import uk.ac.ox.softeng.maurodatamapper.core.model.Model
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelItem
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelItemService
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadata
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadataService
@@ -352,7 +353,7 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
     }
 
     DataType copyDataType(DataModel copiedDataModel, DataType original, User copier, UserSecurityPolicyManager userSecurityPolicyManager,
-                          boolean copySummaryMetadata = false) {
+                          boolean copySummaryMetadata = false, CopyInformation copyInformation = new CopyInformation()) {
 
         DataType copy
 
@@ -378,7 +379,7 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
                 throw new ApiInternalException('DTSXX', 'DataType domain type is unknown and therefore cannot be copied')
         }
 
-        copy = copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copySummaryMetadata)
+        copy = copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copySummaryMetadata, copyInformation)
         setCatalogueItemRefinesCatalogueItem(copy, original, copier)
 
         copiedDataModel.addToDataTypes(copy)
@@ -390,8 +391,9 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
                                           DataType copy,
                                           User copier,
                                           UserSecurityPolicyManager userSecurityPolicyManager,
-                                          boolean copySummaryMetadata) {
-        copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager)
+                                          boolean copySummaryMetadata,
+                                         copyInformation = new CopyInformation()) {
+        copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
         if (copySummaryMetadata) {
             summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {
                 copy.addToSummaryMetadata(label: it.label, summaryMetadataType: it.summaryMetadataType, createdBy: copier.emailAddress)

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
@@ -154,6 +154,12 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         ]
     }
 
+    Map getCopyLabel() {
+        [
+            copyLabel: 'Renamed Copy Label'
+        ]
+    }
+
     @Override
     Map getInvalidJson() {
         [
@@ -402,6 +408,32 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         responseBody().count == 2
         responseBody().items.any {it.label == 'wibble'}
         responseBody().items.any {it.label == 'string'}
+    }
+
+    @Rollback
+    void 'CC04 : Test copying a dataClass with a user assigned label, aka: a save as function' () {
+
+        //copyLable is json object that has new parameter
+        //trigger copy
+        //add copy label as additional object
+        //verify result against copy with label changed
+        given:
+        POST('', validJson)
+        verifyResponse CREATED, response
+        String id = responseBody().id
+
+        POST("$id/dataElements", [
+            label   : 'Functional Test DataElement',
+            copyLabel : 'Renamed label',
+            dataType: dataTypeId
+        ])
+
+        print 'response bd'
+        print responseBody()
+
+        verifyResponse CREATED, response
+
+
     }
 
     @Rollback

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
@@ -129,7 +129,7 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
             sleep(20)
             GET(getResourcePath(otherDataModelId), MAP_ARG, true)
             def items = responseBody().items
-            items.each { i ->
+            items.each {i ->
                 DELETE("${getResourcePath(otherDataModelId)}/$i.id", MAP_ARG, true)
                 assert response.status() == HttpStatus.NO_CONTENT
                 sleep(20)
@@ -364,6 +364,7 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         responseBody().breadcrumbs[1].id == otherId
     }
 
+    @Rollback
     void 'CC03 : test copying to a datamodel with a data element and datatype'() {
         // There is an error around hibernate search in this scenario
         // The metadata and classifiers of the datatype arent initialised and cause a "could not initialize proxy - no Session" exception
@@ -458,13 +459,13 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         String id = responseBody().id
         //create element
         POST("$id/dataElements", [
-            label   : 'Functional Test DataElement',
+            label   : 'Functional Test DataElement 3',
             dataType: dataTypeId
         ])
         verifyResponse CREATED, response
         //create element 2
         POST("$id/dataElements", [
-            label   : 'Functional Test DataElement 2',
+            label   : 'Functional Test DataElement 4',
             dataType: [label: 'wobble', domainType: 'PrimitiveType']
         ])
         verifyResponse CREATED, response
@@ -487,18 +488,16 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
 
         then:
         verifyResponse(OK, response)
-        responseBody().count == 2
-        responseBody().items.any { it.label == 'Functional Test DataElement' }
-        responseBody().items.any { it.label == 'Functional Test DataElement 2' }
+        responseBody().items.any {it.label == 'Functional Test DataElement 3' }
+        responseBody().items.any {it.label == 'Functional Test DataElement 4' }
 
         when:
         GET("dataModels/$otherDataModelId/dataTypes", MAP_ARG, true)
 
         then:
         verifyResponse(OK, response)
-        responseBody().count == 2
-        responseBody().items.any { it.label == 'wobble' }
-        responseBody().items.any { it.label == 'string' }
+        responseBody().items.any {it.label == 'wobble' }
+        responseBody().items.any {it.label == 'string' }
     }
 
     @Rollback
@@ -735,8 +734,8 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         then:
         verifyResponse OK, response
         responseBody().extendsDataClasses.size() == 2
-        responseBody().extendsDataClasses.any { it.id == externalExtendableId && it.model == finalisedDataModelId.toString() }
-        responseBody().extendsDataClasses.any { it.id == internalExtendableId && it.model == dataModelId.toString() }
+        responseBody().extendsDataClasses.any {it.id == externalExtendableId && it.model == finalisedDataModelId.toString() }
+        responseBody().extendsDataClasses.any {it.id == internalExtendableId && it.model == dataModelId.toString() }
 
         cleanup:
         cleanUpData(id)
@@ -910,7 +909,7 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         then:
         verifyResponse OK, response
         responseBody().items.size() == 1
-        responseBody().items.any { it.id == internalId }
+        responseBody().items.any {it.id == internalId }
 
         cleanup:
         cleanUpData(id)

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
@@ -399,7 +399,6 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         responseBody().items.any {it.label == 'Functional Test DataElement'}
         responseBody().items.any {it.label == 'Functional Test DataElement 2'}
 
-
         when:
         GET("dataModels/$otherDataModelId/dataTypes", MAP_ARG, true)
 
@@ -411,30 +410,24 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
     }
 
     @Rollback
-    void 'CC04 : Test copying a dataClass with a user assigned label, aka: a save as function' () {
+    void 'CC04 : Test copying a dataClass with a user assigned label, aka: a save as function'() {
 
-        //copyLable is json object that has new parameter
-        //trigger copy
-        //add copy label as additional object
-        //verify result against copy with label changed
         given:
         POST('', validJson)
         verifyResponse CREATED, response
         String id = responseBody().id
-
-        POST("$id/dataElements", [
-            label   : 'Functional Test DataElement',
-            copyLabel : 'Renamed label',
-            dataType: dataTypeId
-        ])
-
-        print 'response bd'
-        print responseBody()
-
         verifyResponse CREATED, response
 
+        when: 'trying to copy and rename valid'
+        POST("${getResourcePath(otherDataModelId)}/$dataModelId/$id", getCopyLabel(), MAP_ARG, true)
+
+        then:
+        response.status() == CREATED
+        responseBody().id != id
+        responseBody().label == 'Renamed Copy Label'
 
     }
+
 
     @Rollback
     void 'test searching for metadata "mdk1" in content dataclass'() {
@@ -1003,4 +996,5 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         DELETE("dataModels/$finalisedDataModelId/dataClasses/$importableId", MAP_ARG, true)
         assert response.status() == HttpStatus.NO_CONTENT
     }
+
 }

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
@@ -451,7 +451,7 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
     }
 
     @Rollback
-    void 'CC05 : Test copying a datamodel with a data element and datatype renaming the dataClass'() {
+    void 'CC05 : Test copying a dataModel with a data element and datatype renaming the dataClass'() {
 
         given:
         POST('', validJson)

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassFunctionalSpec.groovy
@@ -734,8 +734,8 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         then:
         verifyResponse OK, response
         responseBody().extendsDataClasses.size() == 2
-        responseBody().extendsDataClasses.any {it.id == externalExtendableId && it.model == finalisedDataModelId.toString() }
-        responseBody().extendsDataClasses.any {it.id == internalExtendableId && it.model == dataModelId.toString() }
+        responseBody().extendsDataClasses.any {it.id == externalExtendableId && it.model == finalisedDataModelId.toString()}
+        responseBody().extendsDataClasses.any {it.id == internalExtendableId && it.model == dataModelId.toString()}
 
         cleanup:
         cleanUpData(id)
@@ -909,7 +909,7 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         then:
         verifyResponse OK, response
         responseBody().items.size() == 1
-        responseBody().items.any {it.id == internalId }
+        responseBody().items.any {it.id == internalId}
 
         cleanup:
         cleanUpData(id)
@@ -1067,5 +1067,4 @@ class DataClassFunctionalSpec extends OrderedResourceFunctionalSpec<DataClass> {
         DELETE("dataModels/$finalisedDataModelId/dataClasses/$importableId", MAP_ARG, true)
         assert response.status() == HttpStatus.NO_CONTENT
     }
-
 }


### PR DESCRIPTION
Made use of the command object to store the new label as we can later expand upon it
The object uses the valadatable interface to enforce not null and not empty checking because, again we can extend it.
The label rename takes place in the catalogueitemservice so it can be used for other catalogue item.
The json for editing a lable is sending [copyLabel :  ] with the post