### PR TITLE
Added TreeItem Endpoint addition to show under the /ancestors option

### DIFF
--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
@@ -249,6 +249,7 @@ class UrlMappings {
                     get '/'(controller: 'treeItem', action: 'index')
                     get "/${containerId}"(controller: 'treeItem', action: 'show')
                     get "/${catalogueItemDomainType}/$catalogueItemId"(controller: 'treeItem', action: 'show')
+                    get "/${catalogueItemDomainType}/$catalogueItemId/$ancestors"(controller: 'treeItem', action: 'show')
                     get "/search/$searchTerm"(controller: 'treeItem', action: 'search')
                 }
                 "/full/$modelDomainType/$modelId"(controller: 'treeItem', action: 'fullModelTree')

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemController.groovy
@@ -73,6 +73,10 @@ class TreeItemController extends RestfulController<TreeItem> implements MdmContr
         CatalogueItem catalogueItem = treeItemService.findTreeCapableCatalogueItem(params.catalogueItemClass, params.catalogueItemId)
         if (!catalogueItem) return notFound(CatalogueItem, params.catalogueItemId)
 
+        if (params.ancestors) {
+            return respond(containerTreeItem: treeItemService.buildCatalogueItemTreeWithAncestors(params.containerClass, catalogueItem, currentUserSecurityPolicyManager))
+        }
+
         respond treeItemList: treeItemService.buildCatalogueItemTree(catalogueItem, false, currentUserSecurityPolicyManager)
     }
 

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemService.groovy
@@ -250,6 +250,50 @@ class TreeItemService {
         tree.sort()
     }
 
+    def <K extends Container> ContainerTreeItem buildCatalogueItemTreeWithAncestors(Class<K> containerClass, CatalogueItem catalogueItem,
+                                                                                    UserSecurityPolicyManager userSecurityPolicyManager) {
+        TreeItem treeItem = recursiveAncestorModelItemTreeItemBuilder(catalogueItem, userSecurityPolicyManager)
+
+        List ModelItemList = new ArrayList()
+        ModelItemList.add(treeItem as ModelTreeItem)
+
+        List<ContainerTreeItem> cti = buildContainerTreeForModelTreeItems(containerClass, userSecurityPolicyManager, ModelItemList, true)
+        cti.first()
+    }
+
+
+    /**
+     * Given a catalogue Item the method works its way up the tree to a non ModelItem (which should be a DataModel)
+     * and builds a tree from the items along the way
+     * It returns a generic TreeItem for recursion purposes but it is always a ModelTreeItem at the top end when it breaks out
+     * @param catalogueItem
+     * @return TreeItem
+     */
+    TreeItem recursiveAncestorModelItemTreeItemBuilder(CatalogueItem catalogueItem,
+                                                       UserSecurityPolicyManager userSecurityPolicyManager) {
+
+        if (catalogueItem instanceof ModelItem) {
+            ModelItem mi = catalogueItem as ModelItem
+            List<String> actions = userSecurityPolicyManager ?
+                                   userSecurityPolicyManager.userAvailableTreeActions(mi.domainType, mi.id, mi.model.domainType, mi.model.id) :
+                                   []
+            List<ModelItemTreeItem> current = new ArrayList<>()
+            current.add(new ModelItemTreeItem(mi, mi.hasChildren(), actions))
+            if (catalogueItem.getPathParent()) {
+                TreeItem parent = recursiveAncestorModelItemTreeItemBuilder(catalogueItem.getPathParent() as CatalogueItem,
+                                                                            userSecurityPolicyManager)
+                parent.addAllToChildren(current)
+                parent.renderChildren = true
+                return parent
+            }
+        }
+        Model model = catalogueItem as Model
+        List<String> actions = userSecurityPolicyManager ?
+                               userSecurityPolicyManager.userAvailableTreeActions(model.domainType, model.id, model.domainType, model.id) :
+                               []
+        new ModelTreeItem(model, model.folder.id, true, false, actions)
+    }
+
     ModelTreeItem buildFullModelTree(Model model) {
         log.info("Building full model tree for ${model.class.simpleName}")
         long start = System.currentTimeMillis()

--- a/mdm-core/grails-app/views/treeItem/show.gson
+++ b/mdm-core/grails-app/views/treeItem/show.gson
@@ -1,7 +1,12 @@
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.tree.ContainerTreeItem
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.tree.TreeItem
 
 model {
     Iterable<TreeItem> treeItemList
+    ContainerTreeItem containerTreeItem
 }
-json tmpl.treeItem(treeItemList ?: [])
-
+if(containerTreeItem){
+    json tmpl.treeItem(containerTreeItem)
+}else {
+    json tmpl.treeItem(treeItemList ?: [])
+}

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/tree/TreeItemFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/tree/TreeItemFunctionalSpec.groovy
@@ -791,6 +791,37 @@ class TreeItemFunctionalSpec extends BaseFunctionalSpec {
         dataClassTree.children.any {it.label == 'Functional Test DataElement'}
     }
 
+    void 'AN01 : test getting ancestors of class item'() {
+
+        when:
+        GET("folders/dataClasses/${importingParentDataClassId}/ancestors")
+        then:
+        verifyResponse(OK, response)
+        responseBody().id == importTestFolder.id.toString()
+        responseBody().hasChildren
+        responseBody().children.size() == 1
+
+        responseBody().children.any({ it.id == importingDataModelId.toString() })
+        responseBody().children.any({ it.hasChildren == true })
+
+        responseBody().children.find { it.id == importingDataModelId.toString()}.children.any { it.id = importingParentDataClassId.toString() }
+        responseBody().children.find { it.id == importingDataModelId.toString()}.children.any { it.hasChildren == false}
+
+    }
+
+    void 'AN02 : test getting ancestors of DataModel item'() {
+        when:
+        GET("folders/dataModels/${importingDataModelId}/ancestors")
+        then:
+        verifyResponse(OK, response)
+        responseBody().id == importTestFolder.id.toString()
+        responseBody().hasChildren
+        responseBody().children.size() == 1
+        responseBody().children.any({ it.id == importingDataModelId.toString() })
+        responseBody().children.any({ it.hasChildren == true })
+
+    }
+
     @Override
     void cleanUpData(String id) {
         cleanUpData(id, 'dataModels')


### PR DESCRIPTION
The endpoint works its way up from the provided catalogue item till it reaches the top of the tree then wraps
all the proceding objects in the top level container.
changes were made to the tree item controller, service, gson view and functional spec.
Some JDOC explanation has been provided for the recursive implementation because it could be unclear