### PR TITLE
Added TreeItem Endpoint addition to show under the /ancestors option

### DIFF
--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
@@ -247,6 +247,7 @@ class UrlMappings {
                     get '/'(controller: 'treeItem', action: 'index')
                     get "/${containerId}"(controller: 'treeItem', action: 'show')
                     get "/${catalogueItemDomainType}/$catalogueItemId"(controller: 'treeItem', action: 'show')
+                    get "/${catalogueItemDomainType}/$catalogueItemId/ancestors"(controller: 'treeItem', action: 'ancestors')
                     get "/search/$searchTerm"(controller: 'treeItem', action: 'search')
                 }
                 "/full/$modelDomainType/$modelId"(controller: 'treeItem', action: 'fullModelTree')

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemController.groovy
@@ -132,6 +132,16 @@ class TreeItemController extends RestfulController<TreeItem> implements MdmContr
         respond(treeItemService.buildFullModelTree(model))
     }
 
+    def ancestors() {
+        log.debug('Call to tree for containing ancestors of a catalogue item')
+        CatalogueItem catalogueItem = treeItemService.findTreeCapableCatalogueItem(params.catalogueItemClass, params.catalogueItemId)
+        if (!catalogueItem) return notFound(CatalogueItem, params.catalogueItemId)
+
+        respond(containerTreeItem:
+                    treeItemService.buildCatalogueItemTreeWithAncestors(params.containerClass, catalogueItem, currentUserSecurityPolicyManager))
+
+    }
+
     private boolean shouldIncludeDeletedItems() {
         // Not admin, no see deleted items
         if (!currentUserSecurityPolicyManager.applicationAdministrator) return false

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemInterceptor.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemInterceptor.groovy
@@ -74,6 +74,12 @@ class TreeItemInterceptor implements MdmInterceptor {
                 Model model = proxyHandler.unwrapIfProxy(getOwningModel())
                 return checkActionAuthorisationOnUnsecuredResource(params.catalogueItemClass, params.catalogueItemId, model.getClass(), model.getId())
             }
+            if (actionName == 'ancestors') {
+                mapDomainTypeToClass('catalogueItem', true)
+                boolean canRead = currentUserSecurityPolicyManager.userCanReadResourceId(params.catalogueItemClass, params.catalogueItemId, params.catalogueItemClass,
+                                                                                         params.catalogueItemId)
+                return canRead ?: notFound(params.catalogueItemClass, params.catalogueItemId)
+            }
             // Otherwise top level action so should be allowed through
             return true
         } else if (params.modelDomainType) {

--- a/mdm-core/grails-app/views/treeItem/ancestors.gson
+++ b/mdm-core/grails-app/views/treeItem/ancestors.gson
@@ -1,0 +1,8 @@
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.tree.ContainerTreeItem
+import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.tree.TreeItem
+
+model {
+    ContainerTreeItem containerTreeItem
+}
+json tmpl.treeItem(containerTreeItem)
+

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/tree/TreeItemFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/tree/TreeItemFunctionalSpec.groovy
@@ -783,15 +783,45 @@ class TreeItemFunctionalSpec extends BaseFunctionalSpec {
         responseBody()
         responseBody().hasChildren
         responseBody().children.size() == 2
-        responseBody().children.any {it.label == 'string' && !it.hasChildren}
-        responseBody().children.any {it.label == 'Functional Test DataClass' && it.hasChildren}
+        responseBody().children.any { it.label == 'string' && !it.hasChildren }
+        responseBody().children.any { it.label == 'Functional Test DataClass' && it.hasChildren }
 
         when:
-        Map dataClassTree = responseBody().children.find {it.label == 'Functional Test DataClass'}
+        Map dataClassTree = responseBody().children.find { it.label == 'Functional Test DataClass' }
 
         then:
         dataClassTree.children.size() == 1
-        dataClassTree.children.any {it.label == 'Functional Test DataElement'}
+        dataClassTree.children.any { it.label == 'Functional Test DataElement' }
+    }
+
+    void 'AN01 : test getting ancestors of class item'() {
+
+        when:
+        GET("folders/dataClasses/${importingParentDataClassId}/ancestors")
+        then:
+        verifyResponse(OK, response)
+        responseBody().id == importTestFolder.id.toString()
+        responseBody().hasChildren
+        responseBody().children.size() == 1
+
+        responseBody().children.any({ it.id == importingDataModelId.toString() })
+        responseBody().children.any({ it.hasChildren == true })
+
+        responseBody().children.find { it.id == importingDataModelId.toString() }.children.any { it.id = importingParentDataClassId.toString() }
+        responseBody().children.find { it.id == importingDataModelId.toString() }.children.any { it.hasChildren == false }
+
+    }
+
+    void 'AN02 : test getting ancestors of DataModel item'() {
+        when:
+        GET("folders/dataModels/${importingDataModelId}/ancestors")
+        then:
+        verifyResponse(OK, response)
+        responseBody().id == importTestFolder.id.toString()
+        responseBody().hasChildren
+        responseBody().children.size() == 1
+        responseBody().children.any({ it.id == importingDataModelId.toString() })
+        responseBody().children.any({ it.hasChildren == true })
     }
 
     @Override


### PR DESCRIPTION
The endpoint works its way up from the provided catalogue item till it reaches the top of the tree then wraps
all the proceding objects in the top level container.
changes were made to the tree item controller, service, gson view and functional spec.
Some JDOC explanation has been provided for the recursive implementation because it could be unclear
