### PR TITLE
Feature/mc 9510

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ hibernateSearchVersion=2.3.0
 luceneVersion=5.5.5
 ## Core
 commonsTextVersion=1.9
+commonsCsvVersion=1.8
 springBootVersion=2.1.17.RELEASE
 jaxbApiVersion=2.3.1
 assetPipelineVersion=3.3.2

--- a/mdm-core/dependencies.gradle
+++ b/mdm-core/dependencies.gradle
@@ -3,6 +3,7 @@ dependencies {
     compile project(':mdm-common')
 
     compile group: 'org.apache.commons', name: 'commons-text', version: commonsTextVersion
+    compile group: 'org.apache.commons', name: 'commons-csv', version: commonsCsvVersion
     compile group: 'org.simplejavamail', name: 'simple-java-mail', version: javaMailVersion
     compile group: 'com.google.guava', name: 'guava', version: guavaVersion
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: commonsBeanutilsVersion

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
@@ -43,6 +43,7 @@ class UrlMappings {
                 '/emails'(resources: 'email', includes: INCLUDES_INDEX_ONLY)
 
                 '/properties'(resources: 'apiProperty', excludes: DEFAULT_EXCLUDES)
+                post '/properties/apply'(controller: 'apiProperty', action: 'apply')
 
                 group "/tree/$containerDomainType/$modelDomainType", {
                     get '/documentationSuperseded'(controller: 'treeItem', action: 'documentationSupersededModels') // New URL

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
@@ -28,7 +28,7 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
 
     ApiPropertyService apiPropertyService
 
-    static responseFormats = ['json', 'xml']
+    static responseFormats = ['json', 'xml', 'csv']
 
     ApiPropertyController() {
         super(ApiProperty)

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
@@ -47,6 +47,26 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
         respond res, [model: [userSecurityPolicyManager: currentUserSecurityPolicyManager], view: 'index']
     }
 
+    /**
+     * Override so that we can specify includesExcludes when creating the resource
+     * @return
+     */
+    @Transactional
+    @Override
+    def save() {
+        if (handleReadOnly()) return
+
+        def instance = createResource(includesExcludes)
+
+        if (response.isCommitted()) return
+
+        if (!validateResource(instance, 'create')) return
+
+        saveResource instance
+
+        saveResponse instance
+    }
+
     @Override
     protected ApiProperty saveResource(ApiProperty resource) {
         ApiProperty apiProperty = super.saveResource(resource)

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
@@ -115,17 +115,22 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
     protected Collection<ApiProperty> createResources() {
 
         // First, bind what was exported to an ApiPropertyCollection (which has properties count and items)
+        // There isn't a way here to specify an includesExcludes list
         ApiPropertyCollection apiPropertyCollection = new ApiPropertyCollection()
         bindData apiPropertyCollection, getObjectToBind()
 
-        // Second, iterate the items we just created, and use each instance as the binding source
-        // to create another instance. This time, we specify includesExcludes.
+        // Second, iterate the items we just created, and use each instance
+        // to create another cleaned instance. This time, we specify includesExcludes.
         // At the same time, set the createdBy property of the cleaned instance.
         Collection<ApiProperty> cleanedInstances = []
         User creator = getCurrentUser()
         apiPropertyCollection.items.each {instance ->
             ApiProperty cleanedInstance = new ApiProperty()
-            bindData cleanedInstance, instance, includesExcludes
+
+            // Copy the included properties to a cleaned instance
+            includesExcludes["include"].each {
+                cleanedInstance[it] = instance[it]
+            }
 
             cleanedInstance.createdBy = creator.emailAddress
             cleanedInstances.add(cleanedInstance)

--- a/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyCollection.groovy
+++ b/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyCollection.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.core.admin
+
+/**
+ * This is a helper class for binding to a collection of ApiProperty
+ */
+class ApiPropertyCollection  {
+
+    // id is not used, but required to prevent a Hibernate exception
+    UUID id
+
+    int count
+    Collection<ApiProperty> items
+}

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/databinding/CsvDataBindingSourceCreator.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/databinding/CsvDataBindingSourceCreator.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.core.databinding
+
+import org.grails.web.databinding.bindingsource.AbstractRequestBodyDataBindingSourceCreator
+import org.grails.web.databinding.bindingsource.InvalidRequestBodyException
+import grails.databinding.CollectionDataBindingSource
+import grails.databinding.DataBindingSource
+import grails.databinding.SimpleMapDataBindingSource
+import grails.web.mime.MimeType
+
+import groovy.transform.CompileStatic
+
+import javax.servlet.http.HttpServletRequest
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVParser
+import org.apache.commons.csv.CSVRecord
+import org.springframework.http.HttpMethod
+
+/**
+ * Read CSV from the body of a request and convert to a Map, so that this Map can
+ * be bound to an instance of a domain. Only the header and next line of the CSV are used.
+ */
+@CompileStatic
+class CsvDataBindingSourceCreator extends AbstractRequestBodyDataBindingSourceCreator {
+
+    @Override
+    MimeType[] getMimeTypes() {
+        [new MimeType('text/csv', 'csv'), new MimeType('application/csv', 'csv')] as MimeType[]
+    }
+
+    @Override
+    DataBindingSource createDataBindingSource(MimeType mimeType, Class bindingTargetType, Object bindingSource) {
+        if(bindingSource instanceof HttpServletRequest) {
+            def req = (HttpServletRequest)bindingSource
+            HttpMethod method = HttpMethod.resolve(req.method)
+            if (req.contentLength != 0 && !ignoredRequestBodyMethods.contains(method)) {
+                return new SimpleMapDataBindingSource(createCsvMap(req.getInputStream(), req.getCharacterEncoding()))
+            }
+        }
+
+        return super.createDataBindingSource(mimeType, bindingTargetType, bindingSource)
+    }
+
+    @Override
+    protected DataBindingSource createBindingSource(Reader reader) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    protected CollectionDataBindingSource createCollectionBindingSource(Reader reader) {
+        throw new UnsupportedOperationException()
+    }
+
+    /**
+     * Parse an InputStream and for a CSV like
+     * header1,header2
+     * value1,value2
+     * return a map like [header1: value1, header2: value2]
+     * @param inputStream
+     * @param characterEncoding
+     * @return A map like [header1: value1, header2: value2]
+     */
+    protected static Map createCsvMap(InputStream inputStream, String characterEncoding) {
+        Map result = [:]
+        CSVFormat csvFormat = CSVFormat.newFormat((char) ',')
+                .withQuote((char) '"')
+                .withHeader()
+
+        CSVParser parser = csvFormat.parse(new InputStreamReader(inputStream, characterEncoding))
+
+        List headers = parser.getHeaderNames()
+
+        // If there is a first record then get it and make a map.
+        // Any subsequent records are ignored.
+        try {
+            if (parser.iterator().hasNext()) {
+                CSVRecord record = parser.iterator().next()
+
+                headers.each {
+                    result[it] = record.get(it)
+                }
+            }
+        } catch (Exception e) {
+            throw new InvalidRequestBodyException(e)
+        }
+
+        parser.close()
+        result
+    }
+}

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/databinding/MdmDataBindingCollection.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/databinding/MdmDataBindingCollection.groovy
@@ -15,15 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package uk.ac.ox.softeng.maurodatamapper.core.admin
-
-import uk.ac.ox.softeng.maurodatamapper.core.databinding.MdmDataBindingCollection
+package uk.ac.ox.softeng.maurodatamapper.core.databinding
 
 /**
  * A helper class used as the data binding target when the source is a collection
- * of ApiProperty represented in JSON, XML or CSV
+ * of domain objects, useful when importing from JSON, XML or CSV a collection that
+ * was exported with data like:
+ * - count
+ * - items[]
  */
-class ApiPropertyCollection extends MdmDataBindingCollection {
-
-    Collection<ApiProperty> items
+class MdmDataBindingCollection  {
+    int count
 }

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/render/MdmCsvApiPropertyCollectionRenderer.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/render/MdmCsvApiPropertyCollectionRenderer.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.core.rest.render
+
+import grails.rest.render.ContainerRenderer
+
+class MdmCsvApiPropertyCollectionRenderer extends MdmCsvApiPropertyRenderer implements ContainerRenderer {
+
+    final Class componentType
+
+    MdmCsvApiPropertyCollectionRenderer(Class componentType) {
+        super(Collection)
+        this.componentType = componentType
+    }
+
+}

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/render/MdmCsvApiPropertyRenderer.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/render/MdmCsvApiPropertyRenderer.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.core.rest.render
+
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
+
+import grails.rest.render.AbstractIncludeExcludeRenderer
+import grails.rest.render.RenderContext
+import grails.web.mime.MimeType
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+import org.grails.datastore.mapping.model.MappingContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+
+class MdmCsvApiPropertyRenderer<T> extends AbstractIncludeExcludeRenderer<T> {
+
+    @Autowired
+    @Qualifier('grailsDomainClassMappingContext')
+    MappingContext mappingContext
+
+    MdmCsvApiPropertyRenderer(Class<T> targetType) {
+        super(targetType, new MimeType("text/csv", "csv"))
+    }
+
+    @Override
+    void render(T object, RenderContext context) {
+        context.contentType = "text/csv"
+        final entity = mappingContext.getPersistentEntity(object.class.name)
+        boolean isDomain = entity != null
+
+        CSVPrinter printer = new CSVPrinter(context.writer, CSVFormat.DEFAULT)
+
+        printHeader(printer)
+
+        if (isDomain) {
+            printApiProperty(printer, object)
+        } else if (object instanceof Collection) {
+            for (ApiProperty o in ((Collection) object)) {
+                printApiProperty(printer, o)
+            }
+        }
+
+        printer.flush()
+        printer.close()
+        context.writer.flush()
+    }
+
+    private void printHeader(CSVPrinter printer) {
+        printer.printRecord(["ID", "Key", "Value", "Category", "Publicly Visible", "Last Updated By", "Created By", "Last Updated"])
+    }
+
+    private void printApiProperty(CSVPrinter printer, ApiProperty o) {
+        printer.printRecord([o.id, o.key, o.value, o.category, o.publiclyVisible, o.lastUpdatedBy, o.createdBy, o.lastUpdated])
+    }
+}

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/render/MdmCsvApiPropertyRenderer.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/render/MdmCsvApiPropertyRenderer.groovy
@@ -62,7 +62,7 @@ class MdmCsvApiPropertyRenderer<T> extends AbstractIncludeExcludeRenderer<T> {
     }
 
     private void printHeader(CSVPrinter printer) {
-        printer.printRecord(["ID", "Key", "Value", "Category", "Publicly Visible", "Last Updated By", "Created By", "Last Updated"])
+        printer.printRecord(["id", "key", "value", "category", "publiclyVisible", "lastUpdatedBy", "createdBy", "lastUpdated"])
     }
 
     private void printApiProperty(CSVPrinter printer, ApiProperty o) {

--- a/mdm-core/grails-app/views/apiProperty/_apiProperty.gml
+++ b/mdm-core/grails-app/views/apiProperty/_apiProperty.gml
@@ -1,0 +1,14 @@
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
+
+ApiProperty ap = apiProperty as ApiProperty
+
+apiProperty {
+    id ap.id
+    key ap.key
+    value ap.value
+    if (ap.category) category ap.category
+    publiclyVisible ap.publiclyVisible
+    lastUpdatedBy ap.lastUpdatedBy
+    createdBy ap.createdBy
+    lastUpdated ap.lastUpdated
+}

--- a/mdm-core/grails-app/views/apiProperty/index.gml
+++ b/mdm-core/grails-app/views/apiProperty/index.gml
@@ -1,0 +1,15 @@
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
+
+import grails.gorm.PagedResultList
+
+Iterable<ApiProperty> apl = apiPropertyList as Iterable<ApiProperty>
+
+xmlDeclaration()
+index{
+    count (apl instanceof PagedResultList ? ((PagedResultList) apl).getTotalCount() : apl?.size() ?: 0)
+    apiProperties {
+        apl.each {ap ->
+            layout '_apiProperty.gml', apiProperty: ap
+        }
+    }
+}

--- a/mdm-core/grails-app/views/apiProperty/index.gml
+++ b/mdm-core/grails-app/views/apiProperty/index.gml
@@ -5,11 +5,10 @@ import grails.gorm.PagedResultList
 Iterable<ApiProperty> apl = apiPropertyList as Iterable<ApiProperty>
 
 xmlDeclaration()
-index{
+
+apiProperties {
     count (apl instanceof PagedResultList ? ((PagedResultList) apl).getTotalCount() : apl?.size() ?: 0)
-    apiProperties {
-        apl.each {ap ->
-            layout '_apiProperty.gml', apiProperty: ap
-        }
+    apl.each {ap ->
+        layout 'apiProperty/_apiProperty.gml', apiProperty: ap
     }
 }

--- a/mdm-core/grails-app/views/apiProperty/index.gml
+++ b/mdm-core/grails-app/views/apiProperty/index.gml
@@ -8,7 +8,9 @@ xmlDeclaration()
 
 apiProperties {
     count (apl instanceof PagedResultList ? ((PagedResultList) apl).getTotalCount() : apl?.size() ?: 0)
-    apl.each {ap ->
-        layout 'apiProperty/_apiProperty.gml', apiProperty: ap
+    items {
+        apl.each {ap ->
+            layout 'apiProperty/_apiProperty.gml', apiProperty: ap
+        }
     }
 }

--- a/mdm-core/grails-app/views/apiProperty/show.gml
+++ b/mdm-core/grails-app/views/apiProperty/show.gml
@@ -1,0 +1,6 @@
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
+
+ApiProperty ap = apiProperty as ApiProperty
+
+xmlDeclaration()
+layout 'apiProperty/_apiProperty.gml', apiProperty: ap

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -64,6 +64,10 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> {
          category: 'Functional Test']
     }
 
+    String getValidCsv() {
+        "key,value,publiclyVisible,category\r\na.csv.key,a.csv.value,false,csvs"
+    }
+
     void verifyR1EmptyIndexResponse() {
         verifyResponse(HttpStatus.OK, response)
         assert responseBody().count == 15
@@ -130,6 +134,19 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> {
         DELETE(getDeleteEndpoint(id))
         assert response.status() == HttpStatus.NO_CONTENT
 
+    }
+
+    void 'Test the save action correctly persists an instance from CSV'() {
+        when: 'The save action is executed with valid CSV data'
+        log.debug('Valid content save')
+        POST(getSavePath(), getValidCsv(), MAP_ARG, true, 'text/csv')
+
+        then: 'The response is correct'
+        verifyResponse(HttpStatus.CREATED, response)
+
+        cleanup:
+        DELETE(getDeleteEndpoint(response.body().id))
+        assert response.status() == HttpStatus.NO_CONTENT
     }
 
     def 'check index and show endpoints for CSV'(){

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -252,7 +252,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         verifyResponse(HttpStatus.OK, jsonCapableResponse)
         String csv = jsonCapableResponse.body().toString()
         String[] lines = csv.split("\r\n")
-        assert lines.size() == 17 //header + 16 rows
+        assert lines.size() == 16 //header + 15 rows
         assert lines[0] == "id,key,value,category,publiclyVisible,lastUpdatedBy,createdBy,lastUpdated"
         String id = lines[1].split(",")[0]
 
@@ -297,7 +297,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         GET('')
 
         then:
-        responseBody().count == 16
+        responseBody().count == 15
         responseBody().items[0].key == "email.invite_edit.body"
         String id = responseBody().items[0].id
 

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -68,11 +68,23 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
     }
 
     String getValidCsv() {
-        "key,value,publiclyVisible,category\r\na.csv.key,a.csv.value,false,csvs"
+        "id,key,value,category,publiclyVisible,lastUpdatedBy,createdBy,lastUpdated\r\n" +
+        "e2b3398f-f3e5-4d70-8793-25526bbe0dbe,a.csv.key,a.csv.value,csvs,false,updater@example.com,creator@example.com,2021-10-27T11:02:32.682Z"
     }
 
     String getValidXml() {
-        "<?xml version='1.0'?><apiProperty><key>an.xml.key</key><value>An XML value</value><category>XML</category><publiclyVisible>false</publiclyVisible></apiProperty>"
+        """\
+        <?xml version='1.0'?>
+        <apiProperty>
+            <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
+            <key>an.xml.key</key>
+            <value>An XML value</value>
+            <category>XML</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>example@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
+        </apiProperty>""".stripIndent()
     }
 
     String getSaveCollectionPath() {
@@ -82,13 +94,15 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
     Map getValidJsonCollection() {
         [count: 2,
          items: [
-                 [key     : 'functional.test.key1',
+                 [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbe',
+                  key     : 'functional.test.key1',
                   value   : 'Some random thing1',
                   category: 'Functional Test',
                   publiclyVisible: false,
                   lastUpdatedBy: 'hello@example.com',
                   lastUpdated: '2021-10-27T11:02:32.682Z'],
-                 [key     : 'functional.test.key2',
+                 [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbf',
+                  key     : 'functional.test.key2',
                   value   : 'Some random thing2',
                   category: 'Functional Test',
                   publiclyVisible: false,
@@ -105,6 +119,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
             <count>2</count>
             <items>
                 <apiProperty>
+                    <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
                     <key>functional.test.xml.key.1</key>
                     <value>XML value 1</value>
                     <category>XMLTests</category>
@@ -114,6 +129,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
                     <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
                 </apiProperty>
                 <apiProperty>
+                    <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbf</id>
                     <key>functional.test.xml.key.2</key>
                     <value>XML value 2</value>
                     <category>XMLTests</category>
@@ -233,7 +249,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         String csv = jsonCapableResponse.body().toString()
         String[] lines = csv.split("\r\n")
         assert lines.size() == 17 //header + 16 rows
-        assert lines[0] == "ID,Key,Value,Category,Publicly Visible,Last Updated By,Created By,Last Updated"
+        assert lines[0] == "id,key,value,category,publiclyVisible,lastUpdatedBy,createdBy,lastUpdated"
         String id = lines[1].split(",")[0]
 
         when:
@@ -244,7 +260,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         String csv2 = jsonCapableResponse.body().toString()
         String[] lines2 = csv2.split("\r\n")
         assert lines2.size() == 2 //header + 1 rows
-        assert lines2[0] == "ID,Key,Value,Category,Publicly Visible,Last Updated By,Created By,Last Updated"
+        assert lines2[0] == "id,key,value,category,publiclyVisible,lastUpdatedBy,createdBy,lastUpdated"
     }
 
     void 'check index endpoint for XML'(){

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -71,6 +71,10 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         "key,value,publiclyVisible,category\r\na.csv.key,a.csv.value,false,csvs"
     }
 
+    String getValidXml() {
+        "<?xml version='1.0'?><apiProperty><key>an.xml.key</key><value>An XML value</value><category>XML</category><publiclyVisible>false</publiclyVisible></apiProperty>"
+    }
+
     void verifyR1EmptyIndexResponse() {
         verifyResponse(HttpStatus.OK, response)
         assert responseBody().count == 15
@@ -143,6 +147,19 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         when: 'The save action is executed with valid CSV data'
         log.debug('Valid content save')
         POST(getSavePath(), getValidCsv(), MAP_ARG, true, 'text/csv')
+
+        then: 'The response is correct'
+        verifyResponse(HttpStatus.CREATED, response)
+
+        cleanup:
+        DELETE(getDeleteEndpoint(response.body().id))
+        assert response.status() == HttpStatus.NO_CONTENT
+    }
+
+    void 'Test the save action correctly persists an instance from XML'() {
+        when: 'The save action is executed with valid XML data'
+        log.debug('Valid content save')
+        POST(getSavePath(), getValidXml(), MAP_ARG, true, 'application/xml')
 
         then: 'The response is correct'
         verifyResponse(HttpStatus.CREATED, response)

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -84,10 +84,16 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
          items: [
                  [key     : 'functional.test.key1',
                   value   : 'Some random thing1',
-                  category: 'Functional Test'],
+                  category: 'Functional Test',
+                  publiclyVisible: false,
+                  lastUpdatedBy: 'hello@example.com',
+                  lastUpdated: '2021-10-27T11:02:32.682Z'],
                  [key     : 'functional.test.key2',
                   value   : 'Some random thing2',
-                  category: 'Functional Test']
+                  category: 'Functional Test',
+                  publiclyVisible: false,
+                  lastUpdatedBy: 'hello@example.com',
+                  lastUpdated: '2021-10-27T11:02:32.682Z']
                 ]
         ]
     }
@@ -261,6 +267,10 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         verifyResponse(HttpStatus.OK, response)
         response.body().items.any{it.key == "functional.test.key1"}
         response.body().items.any{it.key == "functional.test.key2"}
+
+        and: 'The lastUpdatedBy property was ignored from the posted data'
+        response.body().items.find{it.key == "functional.test.key1"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+        response.body().items.find{it.key == "functional.test.key2"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
 
         cleanup:
         String id1 = response.body().items.find{it.key == "functional.test.key1"}.id

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -131,4 +131,27 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> {
         assert response.status() == HttpStatus.NO_CONTENT
 
     }
+
+    def 'check index and show endpoints for CSV'(){
+        when:
+        GET('?format=csv', STRING_ARG)
+
+        then:
+        verifyResponse(HttpStatus.OK, jsonCapableResponse)
+        String csv = jsonCapableResponse.body().toString()
+        String[] lines = csv.split("\r\n")
+        assert lines.size() == 17 //header + 16 rows
+        assert lines[0] == "ID,Key,Value,Category,Publicly Visible,Last Updated By,Created By,Last Updated"
+        String id = lines[1].split(",")[0]
+
+        when:
+        GET("${id}?format=csv", STRING_ARG)
+
+        then:
+        verifyResponse(HttpStatus.OK, jsonCapableResponse)
+        String csv2 = jsonCapableResponse.body().toString()
+        String[] lines2 = csv2.split("\r\n")
+        assert lines2.size() == 2 //header + 1 rows
+        assert lines2[0] == "ID,Key,Value,Category,Publicly Visible,Last Updated By,Created By,Last Updated"
+    }
 }

--- a/mdm-core/src/integration-test/resources/xml/apiProperties.xml
+++ b/mdm-core/src/integration-test/resources/xml/apiProperties.xml
@@ -1,219 +1,221 @@
 <?xml version='1.0'?>
 <apiProperties>
     <count>16</count>
-    <apiProperty>
-        <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
-        <key>email.invite_edit.body</key>
-        <value>Dear ${firstName},
-            You have been invited to edit the model '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
+    <items>
+        <apiProperty>
+            <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
+            <key>email.invite_edit.body</key>
+            <value>Dear ${firstName},
+                You have been invited to edit the model '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
 
-            Your username / email address is: ${emailAddress}
-            Your password is: ${tempPassword}
-            and you will be asked to update this when you first log on.
-            Kind regards, the Mauro Data Mapper folks.
+                Your username / email address is: ${emailAddress}
+                Your password is: ${tempPassword}
+                and you will be asked to update this when you first log on.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>d2e72ad7-c5b9-4500-93b5-51fcbe5b08f3</id>
-        <key>email.admin_register.body</key>
-        <value>Dear ${firstName},
-            You have been given access to the Mauro Data Mapper at ${catalogueUrl}
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>d2e72ad7-c5b9-4500-93b5-51fcbe5b08f3</id>
+            <key>email.admin_register.body</key>
+            <value>Dear ${firstName},
+                You have been given access to the Mauro Data Mapper at ${catalogueUrl}
 
-            Your username / email address is: ${emailAddress}
-            Your password is: ${tempPassword}
-            and you will be asked to update this when you first log on.
+                Your username / email address is: ${emailAddress}
+                Your password is: ${tempPassword}
+                and you will be asked to update this when you first log on.
 
-            Kind regards, the Mauro Data Mapper folks.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.350677+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>79050fbb-5f15-44d5-84a2-6dd5593979ee</id>
-        <key>email.admin_register.subject</key>
-        <value>Mauro Data Mapper Registration</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.351740+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>cf8dc112-7462-4b3e-b89d-770854e44ab6</id>
-        <key>email.self_register.subject</key>
-        <value>Mauro Data Mapper Registration</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.352107+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>449ddf99-d79d-4c60-87d7-ab10c4121fe2</id>
-        <key>email.forgotten_password.subject</key>
-        <value>Mauro Data Mapper Forgotten Password</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.352675+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>0348f2ea-2067-41ba-8b14-6c913b8e5ed7</id>
-        <key>email.invite_edit.subject</key>
-        <value>Mauro Data Mapper Invitation</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.353246+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>393b37d6-d5d0-49fb-88f5-9fe34e5a3518</id>
-        <key>email.invite_view.subject</key>
-        <value>Mauro Data Mapper Invitation</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.354490+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>efb00d48-1fe4-4b2e-adbe-f36ebc63a2d0</id>
-        <key>email.admin_confirm_registration.body</key>
-        <value>Dear ${firstName},
-            Your registration for the Mauro Data Mapper at ${catalogueUrl} has been confirmed.
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.350677+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>79050fbb-5f15-44d5-84a2-6dd5593979ee</id>
+            <key>email.admin_register.subject</key>
+            <value>Mauro Data Mapper Registration</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.351740+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>cf8dc112-7462-4b3e-b89d-770854e44ab6</id>
+            <key>email.self_register.subject</key>
+            <value>Mauro Data Mapper Registration</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.352107+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>449ddf99-d79d-4c60-87d7-ab10c4121fe2</id>
+            <key>email.forgotten_password.subject</key>
+            <value>Mauro Data Mapper Forgotten Password</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.352675+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>0348f2ea-2067-41ba-8b14-6c913b8e5ed7</id>
+            <key>email.invite_edit.subject</key>
+            <value>Mauro Data Mapper Invitation</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.353246+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>393b37d6-d5d0-49fb-88f5-9fe34e5a3518</id>
+            <key>email.invite_view.subject</key>
+            <value>Mauro Data Mapper Invitation</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.354490+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>efb00d48-1fe4-4b2e-adbe-f36ebc63a2d0</id>
+            <key>email.admin_confirm_registration.body</key>
+            <value>Dear ${firstName},
+                Your registration for the Mauro Data Mapper at ${catalogueUrl} has been confirmed.
 
-            Your username / email address is: ${emailAddress}
-            You chose a password on registration, but can reset it from the login page.
+                Your username / email address is: ${emailAddress}
+                You chose a password on registration, but can reset it from the login page.
 
-            Kind regards, the Mauro Data Mapper folks.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.355320+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>ffd5ccd6-eef4-4089-a2ce-30f1fea8f21c</id>
-        <key>email.self_register.body</key>
-        <value>Dear ${firstName},
-            You have self-registered for the Mauro Data Mapper at ${catalogueUrl}
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.355320+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>ffd5ccd6-eef4-4089-a2ce-30f1fea8f21c</id>
+            <key>email.self_register.body</key>
+            <value>Dear ${firstName},
+                You have self-registered for the Mauro Data Mapper at ${catalogueUrl}
 
-            Your username / email address is: ${emailAddress}
-            Your registration is marked as pending: you'll be sent another email when your request has been confirmed by an administrator.
-            Kind regards, the Mauro Data Mapper folks.
+                Your username / email address is: ${emailAddress}
+                Your registration is marked as pending: you'll be sent another email when your request has been confirmed by an administrator.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.356045+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>c1d6c69c-3e1d-49c5-bcc1-f3738d64fa95</id>
-        <key>email.password_reset.body</key>
-        <value>Dear ${firstName},
-            Your password has been reset for the Mauro Data Mapper at ${catalogueUrl}.
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.356045+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>c1d6c69c-3e1d-49c5-bcc1-f3738d64fa95</id>
+            <key>email.password_reset.body</key>
+            <value>Dear ${firstName},
+                Your password has been reset for the Mauro Data Mapper at ${catalogueUrl}.
 
-            Your new temporary password is: ${tempPassword}
-            and you will be asked to update this when you next log on.
+                Your new temporary password is: ${tempPassword}
+                and you will be asked to update this when you next log on.
 
-            Kind regards, the Mauro Data Mapper folks.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.357945+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>9efa506e-fdcf-4c2c-9ded-0db1d3e14ce3</id>
-        <key>email.from.name</key>
-        <value>Mauro Data Mapper</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.358632+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>9a39b639-2955-4154-b488-d27390639d0f</id>
-        <key>email.admin_confirm_registration.subject</key>
-        <value>Mauro Data Mapper Registration - Confirmation</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.358953+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>cbb2b36b-1394-49b5-a2f7-ea92135cfb85</id>
-        <key>email.forgotten_password.body</key>
-        <value>Dear ${firstName},
-            A request has been made to reset the password for the Mauro Data Mapper at ${catalogueUrl}.
-            If you did not make this request please ignore this email.
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.357945+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>9efa506e-fdcf-4c2c-9ded-0db1d3e14ce3</id>
+            <key>email.from.name</key>
+            <value>Mauro Data Mapper</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.358632+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>9a39b639-2955-4154-b488-d27390639d0f</id>
+            <key>email.admin_confirm_registration.subject</key>
+            <value>Mauro Data Mapper Registration - Confirmation</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.358953+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>cbb2b36b-1394-49b5-a2f7-ea92135cfb85</id>
+            <key>email.forgotten_password.body</key>
+            <value>Dear ${firstName},
+                A request has been made to reset the password for the Mauro Data Mapper at ${catalogueUrl}.
+                If you did not make this request please ignore this email.
 
-            Please use the following link to reset your password ${passwordResetLink}.
-            Kind regards, the Mauro Data Mapper folks.
+                Please use the following link to reset your password ${passwordResetLink}.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.359260+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>8963c45d-ca59-4936-8c7a-7e3b6856c5ae</id>
-        <key>email.password_reset.subject</key>
-        <value>Mauro Data Mapper Password Reset</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.360715+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>8e881056-06b9-4647-8812-0288b312d061</id>
-        <key>email.invite_view.body</key>
-        <value>Dear ${firstName},
-            You have been invited to view the item '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.359260+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>8963c45d-ca59-4936-8c7a-7e3b6856c5ae</id>
+            <key>email.password_reset.subject</key>
+            <value>Mauro Data Mapper Password Reset</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.360715+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>8e881056-06b9-4647-8812-0288b312d061</id>
+            <key>email.invite_view.body</key>
+            <value>Dear ${firstName},
+                You have been invited to view the item '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
 
-            Your username / email address is: ${emailAddress}
-            Your password is: ${tempPassword}
-            and you will be asked to update this when you first log on.
-            Kind regards, the Mauro Data Mapper folks.
+                Your username / email address is: ${emailAddress}
+                Your password is: ${tempPassword}
+                and you will be asked to update this when you first log on.
+                Kind regards, the Mauro Data Mapper folks.
 
-            (This is an automated mail).</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.361160+01:00</lastUpdated>
-    </apiProperty>
-    <apiProperty>
-        <id>fa1686cd-4c08-4127-aa59-f806f25cc71f</id>
-        <key>email.from.address</key>
-        <value>username@gmail.com</value>
-        <category>Email</category>
-        <publiclyVisible>false</publiclyVisible>
-        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-        <lastUpdated>2021-10-26T13:57:57.388869+01:00</lastUpdated>
-    </apiProperty>
+                (This is an automated mail).</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.361160+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>fa1686cd-4c08-4127-aa59-f806f25cc71f</id>
+            <key>email.from.address</key>
+            <value>username@gmail.com</value>
+            <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-26T13:57:57.388869+01:00</lastUpdated>
+        </apiProperty>
+    </items>
 </apiProperties>

--- a/mdm-core/src/integration-test/resources/xml/apiProperties.xml
+++ b/mdm-core/src/integration-test/resources/xml/apiProperties.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0'?>
 <apiProperties>
-    <count>16</count>
+    <count>15</count>
     <items>
         <apiProperty>
-            <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
+            <id>cd07f97f-5315-45f4-894f-ed814b835653</id>
             <key>email.invite_edit.body</key>
             <value>Dear ${firstName},
                 You have been invited to edit the model '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
@@ -18,10 +18,10 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.720622+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>d2e72ad7-c5b9-4500-93b5-51fcbe5b08f3</id>
+            <id>ea8e5610-5aca-4c26-8003-e97e1cd9b651</id>
             <key>email.admin_register.body</key>
             <value>Dear ${firstName},
                 You have been given access to the Mauro Data Mapper at ${catalogueUrl}
@@ -37,60 +37,60 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.350677+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.793294+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>79050fbb-5f15-44d5-84a2-6dd5593979ee</id>
+            <id>2ebb00f4-2647-448b-95e8-b0feca932d53</id>
             <key>email.admin_register.subject</key>
             <value>Mauro Data Mapper Registration</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.351740+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.795507+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>cf8dc112-7462-4b3e-b89d-770854e44ab6</id>
+            <id>2e549f31-f802-443e-96c0-ba827fa99e19</id>
             <key>email.self_register.subject</key>
             <value>Mauro Data Mapper Registration</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.352107+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.796164+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>449ddf99-d79d-4c60-87d7-ab10c4121fe2</id>
+            <id>eb1e80a3-929b-4fd4-b78e-c9b0f5c531b1</id>
             <key>email.forgotten_password.subject</key>
             <value>Mauro Data Mapper Forgotten Password</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.352675+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.797530+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>0348f2ea-2067-41ba-8b14-6c913b8e5ed7</id>
+            <id>4b6e11ac-2a39-47bc-98fe-b8f371204acd</id>
             <key>email.invite_edit.subject</key>
             <value>Mauro Data Mapper Invitation</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.353246+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.798075+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>393b37d6-d5d0-49fb-88f5-9fe34e5a3518</id>
+            <id>b9568310-c5c8-4315-9725-2f02ec270da3</id>
             <key>email.invite_view.subject</key>
             <value>Mauro Data Mapper Invitation</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.354490+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.798667+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>efb00d48-1fe4-4b2e-adbe-f36ebc63a2d0</id>
+            <id>7e9dfd6e-dc59-4dc2-8e2d-52e58c313d57</id>
             <key>email.admin_confirm_registration.body</key>
             <value>Dear ${firstName},
                 Your registration for the Mauro Data Mapper at ${catalogueUrl} has been confirmed.
@@ -105,10 +105,10 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.355320+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.799203+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>ffd5ccd6-eef4-4089-a2ce-30f1fea8f21c</id>
+            <id>a33db8f5-3bbc-4d8f-aa3a-18e0e9fe4ff8</id>
             <key>email.self_register.body</key>
             <value>Dear ${firstName},
                 You have self-registered for the Mauro Data Mapper at ${catalogueUrl}
@@ -122,10 +122,10 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.356045+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.799802+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>c1d6c69c-3e1d-49c5-bcc1-f3738d64fa95</id>
+            <id>5988c0b3-6fc8-4875-ba68-2c389262ae90</id>
             <key>email.password_reset.body</key>
             <value>Dear ${firstName},
                 Your password has been reset for the Mauro Data Mapper at ${catalogueUrl}.
@@ -140,30 +140,30 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.357945+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.800305+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>9efa506e-fdcf-4c2c-9ded-0db1d3e14ce3</id>
+            <id>17b7891d-a169-4c5c-909a-ac52091803df</id>
             <key>email.from.name</key>
             <value>Mauro Data Mapper</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.358632+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.802335+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>9a39b639-2955-4154-b488-d27390639d0f</id>
+            <id>e137cf55-1fa3-428a-a845-78bc4f65d40b</id>
             <key>email.admin_confirm_registration.subject</key>
             <value>Mauro Data Mapper Registration - Confirmation</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.358953+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.803009+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>cbb2b36b-1394-49b5-a2f7-ea92135cfb85</id>
+            <id>d632ed42-88cf-4eda-a994-6456a8f5d4aa</id>
             <key>email.forgotten_password.body</key>
             <value>Dear ${firstName},
                 A request has been made to reset the password for the Mauro Data Mapper at ${catalogueUrl}.
@@ -177,20 +177,20 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.359260+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.803475+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>8963c45d-ca59-4936-8c7a-7e3b6856c5ae</id>
+            <id>14e74603-83da-45b6-b7d2-5f89a513ccb5</id>
             <key>email.password_reset.subject</key>
             <value>Mauro Data Mapper Password Reset</value>
             <category>Email</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.360715+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.804030+01:00</lastUpdated>
         </apiProperty>
         <apiProperty>
-            <id>8e881056-06b9-4647-8812-0288b312d061</id>
+            <id>4880df63-0a85-4462-8129-3959f4772f05</id>
             <key>email.invite_view.body</key>
             <value>Dear ${firstName},
                 You have been invited to view the item '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
@@ -205,17 +205,7 @@
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.361160+01:00</lastUpdated>
-        </apiProperty>
-        <apiProperty>
-            <id>fa1686cd-4c08-4127-aa59-f806f25cc71f</id>
-            <key>email.from.address</key>
-            <value>username@gmail.com</value>
-            <category>Email</category>
-            <publiclyVisible>false</publiclyVisible>
-            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
-            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
-            <lastUpdated>2021-10-26T13:57:57.388869+01:00</lastUpdated>
+            <lastUpdated>2021-10-28T13:49:24.804440+01:00</lastUpdated>
         </apiProperty>
     </items>
 </apiProperties>

--- a/mdm-core/src/integration-test/resources/xml/apiProperties.xml
+++ b/mdm-core/src/integration-test/resources/xml/apiProperties.xml
@@ -1,0 +1,219 @@
+<?xml version='1.0'?>
+<apiProperties>
+    <count>16</count>
+    <apiProperty>
+        <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
+        <key>email.invite_edit.body</key>
+        <value>Dear ${firstName},
+            You have been invited to edit the model '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
+
+            Your username / email address is: ${emailAddress}
+            Your password is: ${tempPassword}
+            and you will be asked to update this when you first log on.
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>d2e72ad7-c5b9-4500-93b5-51fcbe5b08f3</id>
+        <key>email.admin_register.body</key>
+        <value>Dear ${firstName},
+            You have been given access to the Mauro Data Mapper at ${catalogueUrl}
+
+            Your username / email address is: ${emailAddress}
+            Your password is: ${tempPassword}
+            and you will be asked to update this when you first log on.
+
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.350677+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>79050fbb-5f15-44d5-84a2-6dd5593979ee</id>
+        <key>email.admin_register.subject</key>
+        <value>Mauro Data Mapper Registration</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.351740+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>cf8dc112-7462-4b3e-b89d-770854e44ab6</id>
+        <key>email.self_register.subject</key>
+        <value>Mauro Data Mapper Registration</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.352107+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>449ddf99-d79d-4c60-87d7-ab10c4121fe2</id>
+        <key>email.forgotten_password.subject</key>
+        <value>Mauro Data Mapper Forgotten Password</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.352675+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>0348f2ea-2067-41ba-8b14-6c913b8e5ed7</id>
+        <key>email.invite_edit.subject</key>
+        <value>Mauro Data Mapper Invitation</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.353246+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>393b37d6-d5d0-49fb-88f5-9fe34e5a3518</id>
+        <key>email.invite_view.subject</key>
+        <value>Mauro Data Mapper Invitation</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.354490+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>efb00d48-1fe4-4b2e-adbe-f36ebc63a2d0</id>
+        <key>email.admin_confirm_registration.body</key>
+        <value>Dear ${firstName},
+            Your registration for the Mauro Data Mapper at ${catalogueUrl} has been confirmed.
+
+            Your username / email address is: ${emailAddress}
+            You chose a password on registration, but can reset it from the login page.
+
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.355320+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>ffd5ccd6-eef4-4089-a2ce-30f1fea8f21c</id>
+        <key>email.self_register.body</key>
+        <value>Dear ${firstName},
+            You have self-registered for the Mauro Data Mapper at ${catalogueUrl}
+
+            Your username / email address is: ${emailAddress}
+            Your registration is marked as pending: you'll be sent another email when your request has been confirmed by an administrator.
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.356045+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>c1d6c69c-3e1d-49c5-bcc1-f3738d64fa95</id>
+        <key>email.password_reset.body</key>
+        <value>Dear ${firstName},
+            Your password has been reset for the Mauro Data Mapper at ${catalogueUrl}.
+
+            Your new temporary password is: ${tempPassword}
+            and you will be asked to update this when you next log on.
+
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.357945+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>9efa506e-fdcf-4c2c-9ded-0db1d3e14ce3</id>
+        <key>email.from.name</key>
+        <value>Mauro Data Mapper</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.358632+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>9a39b639-2955-4154-b488-d27390639d0f</id>
+        <key>email.admin_confirm_registration.subject</key>
+        <value>Mauro Data Mapper Registration - Confirmation</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.358953+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>cbb2b36b-1394-49b5-a2f7-ea92135cfb85</id>
+        <key>email.forgotten_password.body</key>
+        <value>Dear ${firstName},
+            A request has been made to reset the password for the Mauro Data Mapper at ${catalogueUrl}.
+            If you did not make this request please ignore this email.
+
+            Please use the following link to reset your password ${passwordResetLink}.
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.359260+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>8963c45d-ca59-4936-8c7a-7e3b6856c5ae</id>
+        <key>email.password_reset.subject</key>
+        <value>Mauro Data Mapper Password Reset</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.360715+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>8e881056-06b9-4647-8812-0288b312d061</id>
+        <key>email.invite_view.body</key>
+        <value>Dear ${firstName},
+            You have been invited to view the item '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
+
+            Your username / email address is: ${emailAddress}
+            Your password is: ${tempPassword}
+            and you will be asked to update this when you first log on.
+            Kind regards, the Mauro Data Mapper folks.
+
+            (This is an automated mail).</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.361160+01:00</lastUpdated>
+    </apiProperty>
+    <apiProperty>
+        <id>fa1686cd-4c08-4127-aa59-f806f25cc71f</id>
+        <key>email.from.address</key>
+        <value>username@gmail.com</value>
+        <category>Email</category>
+        <publiclyVisible>false</publiclyVisible>
+        <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+        <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+        <lastUpdated>2021-10-26T13:57:57.388869+01:00</lastUpdated>
+    </apiProperty>
+</apiProperties>

--- a/mdm-core/src/integration-test/resources/xml/apiProperty.xml
+++ b/mdm-core/src/integration-test/resources/xml/apiProperty.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0'?>
+<apiProperty>
+    <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
+    <key>email.invite_edit.body</key>
+    <value>Dear ${firstName},
+        You have been invited to edit the model '${itemLabel}' in the Mauro Data Mapper at ${catalogueUrl}
+
+        Your username / email address is: ${emailAddress}
+        Your password is: ${tempPassword}
+        and you will be asked to update this when you first log on.
+        Kind regards, the Mauro Data Mapper folks.
+
+        (This is an automated mail).</value>
+    <category>Email</category>
+    <publiclyVisible>false</publiclyVisible>
+    <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+    <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+    <lastUpdated>2021-10-26T13:57:57.342140+01:00</lastUpdated>
+</apiProperty>

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
@@ -17,6 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core
 
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
 import uk.ac.ox.softeng.maurodatamapper.core.flyway.MdmFlywayMigationStrategy
 import uk.ac.ox.softeng.maurodatamapper.core.gorm.mapping.CoreSchemaMappingContext
 import uk.ac.ox.softeng.maurodatamapper.core.gorm.mapping.domain.AnnotationAwareMappingContext
@@ -35,6 +36,8 @@ import uk.ac.ox.softeng.maurodatamapper.core.gorm.mapping.domain.VersionLinkAwar
 import uk.ac.ox.softeng.maurodatamapper.core.json.view.JsonViewTemplateEngine
 import uk.ac.ox.softeng.maurodatamapper.core.markup.view.MarkupViewTemplateEngine
 import uk.ac.ox.softeng.maurodatamapper.core.provider.MauroDataMapperProviderService
+import uk.ac.ox.softeng.maurodatamapper.core.rest.render.MdmCsvApiPropertyRenderer
+import uk.ac.ox.softeng.maurodatamapper.core.rest.render.MdmCsvApiPropertyCollectionRenderer
 import uk.ac.ox.softeng.maurodatamapper.provider.plugin.MauroDataMapperPlugin
 import uk.ac.ox.softeng.maurodatamapper.search.filter.IdPathFilterFactory
 import uk.ac.ox.softeng.maurodatamapper.search.filter.IdPathSecureFilterFactory
@@ -200,6 +203,12 @@ This is basically the backend API.
             // we can actually add the global exclusion fields to the generator
             if (grailsApplication.config.getProperty('grails.views.excludeFields')) {
                 jsonTemplateEngine(JsonViewTemplateEngine, grailsApplication, ref('jsonViewConfiguration'), applicationContext.classLoader)
+            }
+
+            halCsvApiPropertyRenderer(MdmCsvApiPropertyRenderer, ApiProperty) {
+            }
+
+            halCsvApiPropertyCollectionRenderer(MdmCsvApiPropertyCollectionRenderer, ApiProperty) {
             }
         }
 

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
@@ -214,10 +214,10 @@ This is basically the backend API.
                 jsonTemplateEngine(JsonViewTemplateEngine, grailsApplication, ref('jsonViewConfiguration'), applicationContext.classLoader)
             }
 
-            halCsvApiPropertyRenderer(MdmCsvApiPropertyRenderer, ApiProperty) {
+            csvApiPropertyRenderer(MdmCsvApiPropertyRenderer, ApiProperty) {
             }
 
-            halCsvApiPropertyCollectionRenderer(MdmCsvApiPropertyCollectionRenderer, ApiProperty) {
+            csvApiPropertyCollectionRenderer(MdmCsvApiPropertyCollectionRenderer, ApiProperty) {
             }
 
             //Ensure that MarkupViews (rather than the default XML renderer) is used when XML is requested

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
@@ -18,6 +18,7 @@
 package uk.ac.ox.softeng.maurodatamapper.core
 
 import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
+import uk.ac.ox.softeng.maurodatamapper.core.databinding.CsvDataBindingSourceCreator
 import uk.ac.ox.softeng.maurodatamapper.core.flyway.MdmFlywayMigationStrategy
 import uk.ac.ox.softeng.maurodatamapper.core.gorm.mapping.CoreSchemaMappingContext
 import uk.ac.ox.softeng.maurodatamapper.core.gorm.mapping.domain.AnnotationAwareMappingContext
@@ -51,6 +52,7 @@ import org.apache.lucene.analysis.core.LowerCaseFilterFactory
 import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory
 import org.apache.lucene.analysis.miscellaneous.WordDelimiterFilterFactory
+import org.grails.web.databinding.bindingsource.DataBindingSourceRegistry
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean
 
 import java.lang.management.ManagementFactory
@@ -182,6 +184,11 @@ This is basically the backend API.
             catalogueItemMappingContext CatalogueItemMappingContext
 
             /*
+             * Define custom data binding beans
+             */
+            csvDataBindingSourceCreator(CsvDataBindingSourceCreator)
+
+            /*
              * Get all MDM Plugins to execute their doWithSpring
              */
             MauroDataMapperProviderService.getServices(MauroDataMapperPlugin).each { MauroDataMapperPlugin plugin ->
@@ -219,6 +226,12 @@ This is basically the backend API.
 
     void doWithApplicationContext() {
         if (config.env == 'live') outputRuntimeArgs()
+
+        /*
+         * Add custom data binding bean to the data binding registry
+         */
+        DataBindingSourceRegistry registry = applicationContext.getBean(DataBindingSourceRegistry.BEAN_NAME)
+        registry.addDataBindingSourceCreator(applicationContext.getBean(CsvDataBindingSourceCreator))
     }
 
     void outputRuntimeArgs() {

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/MdmCoreGrailsPlugin.groovy
@@ -47,6 +47,8 @@ import uk.ac.ox.softeng.maurodatamapper.security.basic.NoAccessSecurityPolicyMan
 import uk.ac.ox.softeng.maurodatamapper.security.basic.PublicAccessSecurityPolicyManager
 
 import grails.plugins.Plugin
+import grails.web.mime.MimeType
+import grails.plugin.markup.view.MarkupViewConfiguration
 import groovy.util.logging.Slf4j
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory
 import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory
@@ -216,6 +218,11 @@ This is basically the backend API.
             }
 
             halCsvApiPropertyCollectionRenderer(MdmCsvApiPropertyCollectionRenderer, ApiProperty) {
+            }
+
+            //Ensure that MarkupViews (rather than the default XML renderer) is used when XML is requested
+            markupViewConfiguration(MarkupViewConfiguration) {
+                mimeTypes = [MimeType.XML.name, MimeType.HAL_XML.name, MimeType.TEXT_XML.name]
             }
         }
 

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyCollection.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyCollection.groovy
@@ -18,13 +18,10 @@
 package uk.ac.ox.softeng.maurodatamapper.core.admin
 
 /**
- * This is a helper class for binding to a collection of ApiProperty
+ * A helper class used as the data binding target when the source is a collection
+ * of ApiProperty represented in JSON or XML.
  */
 class ApiPropertyCollection  {
-
-    // id is not used, but required to prevent a Hibernate exception
-    UUID id
-
     int count
     Collection<ApiProperty> items
 }

--- a/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/csv/CsvComparer.groovy
+++ b/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/csv/CsvComparer.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.test.csv
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVParser
+import org.apache.commons.csv.CSVRecord
+
+import groovy.util.logging.Slf4j
+
+/**
+ * Compare two CSV strings, ignoring IDs and date fields, and assuming row orders are expected to be identical
+ */
+@Slf4j
+trait CsvComparer {
+
+    List ignoreFields = ['id', 'lastUpdated', 'exportedOn', 'dateFinalised']
+
+    /**
+     * Test that two strings representing a CSV are the same, other than for expected differences in id
+     * and date fields. The following comparisons are made:
+     * - Number of headers columns are the same
+     * - Header names are identical and in the same order
+     * - All row values are identical, other than ignored fields.
+     * @param expected
+     * @param actual
+     * @return boolean expected and actual CSV strings are the same, other than for allowed differences
+     */
+    boolean compareCsv(String expected, String actual) {
+
+        CSVFormat csvFormat = CSVFormat.newFormat((char) ',')
+                .withQuote((char) '"')
+                .withHeader()
+
+        CSVParser expectedParser = csvFormat.parse(new StringReader(expected))
+        CSVParser actualParser = csvFormat.parse(new StringReader(actual))
+
+        List expectedHeaders = expectedParser.getHeaderNames()
+        List actualHeaders = actualParser.getHeaderNames()
+
+        compareHeaderSizes(expectedHeaders, actualHeaders) &&
+        compareHeaders(expectedHeaders, actualHeaders) &&
+        compareRows(expectedHeaders, expectedParser, actualParser)
+    }
+
+    private boolean compareHeaderSizes(List expectedHeaders, List actualHeaders) {
+        if (expectedHeaders.size() == actualHeaders.size()) {
+            return true
+        } else {
+            log.error("\nExpected number of headers to be ${expectedHeaders.size()} but actual was ${actualHeaders.size()}")
+            return false
+        }
+    }
+
+    private boolean compareHeaders(List expectedHeaders, List actualHeaders) {
+        boolean result = true
+
+        expectedHeaders.eachWithIndex {item, index ->
+            if (item != actualHeaders[index]) {
+                log.error("\nExpected header ${item} at position ${index} but actual was ${actualHeaders[index]}")
+                result = false
+            }
+        }
+
+        return result
+    }
+
+    private boolean compareRows(List expectedHeaders, CSVParser expectedParser, CSVParser actualParser) {
+        boolean result = true
+
+        while (expectedParser.iterator().hasNext()) {
+            CSVRecord expectedRecord = expectedParser.iterator().next()
+
+            if (!actualParser.iterator().hasNext()) {
+                // Number of records in expected exceeds that in actual
+                log.error("\nCould not find next actual record")
+                result = false
+            }
+
+            if (result) {
+                CSVRecord actualRecord = actualParser.iterator().next()
+
+                expectedHeaders.each {header ->
+                    String expectedValue = expectedRecord[header]
+                    String actualValue = actualRecord[header]
+
+                    if (!ignoreFields.contains(header)) {
+                        if (expectedValue != actualValue) {
+                            log.error("\nExpected ${expectedValue} but actual was ${actualValue}")
+                            result = false
+                        }
+                    }
+                }
+            }
+        }
+
+        if (result && actualParser.iterator().hasNext()) {
+            // Number of records in actual exceeds that in expected
+            log.error("\nAdditional actual record found")
+            result = false
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
- Add beans to render ApiProperty or collection of ApiProperty as CSV
- Add .gml files for index and show of ApiProperty, and add MarkupViewConfiguration to MdmCoreGrailsPlugin so that the .gml files are used rather than the default XML renderer
- Add csv to response formats, so when appending ?format=csv or ?format=xml to GET /api/admin/properties or GET /api/admin/properties/{id} the response is rendered as CSV or XML
- Add a data binding bean for CsvDataBindingSourceCreator which enables binding of CSV to either a single target instance or a collection of target instances
- The endpoint POST /api/admin/properties with a body expressed as XML or CSV thus creates a resource in the same way as happens for JSON. The Content-Type header in the POST must be set to application/xml or text/csv
- Add an endpoint POST /api/admin/properties/apply so that a body containing a collection of ApiProperties as JSON, XML or CSV will be "applied" i.e. imported. For XML the Content-Type header on the POST must be set to application/xml. For CSV the Content-Type header on the POST must be set to text/csv. All items in the collection are saved in a single transaction, so a failure in one item (which will happen if the key or value already exists) means that none will be imported.
- Add a CsvComparer trait to make testing easier
- Add tests in mdm-core and mdm-testing-functional