### PR TITLE
Add columnNumber to ReferenceDataElement

### DIFF
--- a/mdm-plugin-referencedata/grails-app/assets/xsd/export_4.0.xsd
+++ b/mdm-plugin-referencedata/grails-app/assets/xsd/export_4.0.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:exp="http://maurodatamapper.com/export/4.0"
+           xmlns:mdm="http://maurodatamapper.com/referenceDataModel/4.0" elementFormDefault="qualified"
+           targetNamespace="http://maurodatamapper.com/export/4.0">
+  <xs:import namespace="http://maurodatamapper.com/referenceDataModel/4.0" schemaLocation="referenceDataModel_4.0.xsd" />
+  <xs:element name="exportModel" type="exp:exportType" />
+  <xs:complexType name="exportType">
+    <xs:sequence>
+      <xs:element ref="mdm:referenceDataModel" />
+      <xs:element name="exportMetadata" type="exp:exportMetadata" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="exporterType">
+    <xs:all>
+      <xs:element name="namespace" type="xs:string" />
+      <xs:element name="name" type="xs:string" />
+      <xs:element name="version" type="xs:decimal" />
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="exportMetadata">
+    <xs:all>
+      <xs:element name="exportedBy" type="xs:string" />
+      <xs:element name="exportedOn" type="xs:dateTime" />
+      <xs:element name="exporter" type="exp:exporterType" />
+    </xs:all>
+  </xs:complexType>
+</xs:schema>

--- a/mdm-plugin-referencedata/grails-app/assets/xsd/referenceDataModel_4.0.xsd
+++ b/mdm-plugin-referencedata/grails-app/assets/xsd/referenceDataModel_4.0.xsd
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mdm="http://maurodatamapper.com/referenceDataModel/4.0" elementFormDefault="qualified"
+           targetNamespace="http://maurodatamapper.com/referenceDataModel/4.0">
+  <xs:element name="referenceDataModel" type="mdm:referenceDataModelType" />
+  <xs:complexType name="catalogueItem">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="label" type="mdm:mandatoryString" />
+      <xs:element maxOccurs="1" minOccurs="0" name="description" type="xs:string" />
+      <xs:element minOccurs="0" name="aliases" type="mdm:aliasesType" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+      <xs:element minOccurs="0" name="classifiers" type="mdm:classifiersType" />
+      <xs:element name="metadata" type="mdm:metadataCollectionType" minOccurs="0" />
+      <xs:element minOccurs="0" name="annotations" type="mdm:annotationsType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceDataModelType">
+    <xs:complexContent>
+      <xs:extension base="mdm:catalogueItem">
+        <xs:sequence>
+          <xs:element name="type" type="mdm:referenceDataModelTypeEnum" />
+          <xs:element name="author" type="xs:string" minOccurs="0" />
+          <xs:element name="organisation" type="xs:string" minOccurs="0" />
+          <xs:element name="documentationVersion" type="mdm:mandatoryString">
+            <xs:annotation>
+              <xs:documentation>If adding a ReferenceDataModel which already exists in the Mauro Data Mapper then this must be provided and be a later version to the one in the Catalogue.
+Otherwise you will get an import error due to non-unique labels</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="finalised" type="xs:boolean" />
+          <xs:element minOccurs="0" name="dateFinalised" type="xs:dateTime">
+            <xs:annotation>
+              <xs:documentation>If finalised is true then this element is NOT optional</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element minOccurs="0" name="modelVersion" type="xs:string">
+            <xs:annotation>
+            <xs:documentation>ModelVersion must only be set if the ReferenceDataModel is finalised.</xs:documentation>
+          </xs:annotation>
+          </xs:element>
+          <xs:element name="authority" type="mdm:authorityType" />
+          <xs:element name="referenceDataTypes" type="mdm:referenceDataTypesType" maxOccurs="1" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Whilst it is preferable to provide the list of DataTypes here and then use the label and domainType to link from the DataElement, you can provide the DataType information at the DataElement level.
+
+However be aware that any DataTypes which use the same label will use the first set of information found for all DataElements which use this DataType, therefore any differences in, say enumerations, will be lost. This is why it is better to provide the list of DataTypes upfront.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="referenceDataElements" type="mdm:referenceDataElementsType" maxOccurs="1" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Provide a list of Reference Data Elements</xs:documentation>
+            </xs:annotation>
+          </xs:element>    
+          <xs:element name="referenceDataValues" type="mdm:referenceDataValuesType" maxOccurs="1" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Provide a list of Reference Data Values</xs:documentation>
+            </xs:annotation>
+          </xs:element>                 
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="aliasesType">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="alias" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="classifiersType">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="classifier" type="mdm:classifierType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="classifierType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="label" type="mdm:mandatoryString" />
+      <xs:element maxOccurs="1" minOccurs="0" name="description" type="xs:string" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="annotationsType">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="annotation" type="mdm:annotationType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="annotationType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="createdBy" type="mdm:mandatoryString" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+      <xs:element name="label" type="mdm:mandatoryString">
+        <xs:annotation>
+          <xs:documentation />
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="description" type="xs:string" />
+      <xs:element minOccurs="0" name="childAnnotations" type="mdm:childAnnotationsType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="childAnnotationsType">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="annotation" type="mdm:childAnnotationType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="childAnnotationType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="label" type="mdm:mandatoryString" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation />
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="createdBy" type="mdm:mandatoryString" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+      <xs:element maxOccurs="1" minOccurs="0" name="description" type="xs:string" />
+      <xs:element minOccurs="0" name="childAnnotations" type="mdm:annotationsType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceDataTypesType">
+    <xs:sequence>
+      <xs:element name="referenceDataType" maxOccurs="unbounded" type="mdm:referenceDataTypeType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceDataTypeType">
+    <xs:complexContent>
+      <xs:extension base="mdm:catalogueItem">
+        <xs:sequence>
+          <xs:element name="domainType" type="mdm:referenceDataTypeDomainTypeEnum" />
+          <xs:element name="referenceEnumerationValues" minOccurs="0" type="mdm:referenceEnumerationValuesType">
+            <xs:annotation>
+              <xs:documentation>Mandatory if domainType is "ReferenceEnumerationType".
+Ignored otherwise</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="units" type="mdm:mandatoryString">
+            <xs:annotation>
+              <xs:documentation>Optional if domainType is "PrimitiveType". Ignored otherwise</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="referenceDataElementsType">
+    <xs:sequence>
+      <xs:element name="referenceDataElement" maxOccurs="unbounded" type="mdm:referenceDataElementType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceDataElementType">
+    <xs:complexContent>
+      <xs:extension base="mdm:catalogueItem">
+        <xs:sequence>
+          <xs:element name="columnNumber" type="xs:integer" />
+          <xs:element name="referenceDataType" type="mdm:referenceDataTypeType">
+            <xs:annotation>
+              <xs:documentation>If you've already provided the full DataType information in the DataModel list of DataTypes, then you need only provide the label and domainType here to link to the DataType.
+
+If you have not provided all the information at the DataModel level then a DataType will be created using the information provided.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="maxMultiplicity" type="mdm:multiplicity" maxOccurs="1" minOccurs="0" default="1">
+            <xs:annotation>
+              <xs:documentation />
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="minMultiplicity" type="mdm:multiplicity" maxOccurs="1" minOccurs="0" default="1">
+            <xs:annotation>
+              <xs:documentation />
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="referenceDataValuesType">
+    <xs:sequence>
+      <xs:element name="referenceDataValue" maxOccurs="unbounded" type="mdm:referenceDataValueType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceDataValueType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="rowNumber" type="xs:integer" />
+      <xs:element name="value" type="xs:string" />
+      <xs:element name="referenceDataElement" type="mdm:referenceDataElementType">
+        <xs:annotation>
+          <xs:documentation>If you've already provided the full DataType information in the DataModel list of DataTypes, then you need only provide the label and domainType here to link to the DataType.
+If you have not provided all the information at the DataModel level then a DataType will be created using the information provided.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>  
+  <xs:complexType name="referenceEnumerationValuesType">
+    <xs:sequence>
+      <xs:element name="referenceEnumerationValue" maxOccurs="unbounded" type="mdm:referenceEnumerationValueType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceEnumerationValueType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="index" type="xs:integer" />
+      <xs:element name="key" type="xs:string" />
+      <xs:element name="value" type="xs:string" />
+      <xs:element name="category" type="xs:string" minOccurs="0" />
+      <xs:element minOccurs="0" name="aliases" type="mdm:aliasesType" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+      <xs:element minOccurs="0" name="classifiers" type="mdm:classifiersType" />
+      <xs:element name="metadata" type="mdm:metadataCollectionType" minOccurs="0" />
+      <xs:element minOccurs="0" name="annotations" type="mdm:annotationsType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadataCollectionType">
+    <xs:sequence>
+      <xs:element name="metadata" maxOccurs="unbounded" type="mdm:metadataType" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadataType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="namespace" type="xs:string" />
+      <xs:element name="key" type="xs:string" />
+      <xs:element name="value" type="xs:string" minOccurs="1" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="exporterType">
+    <xs:all>
+      <xs:element name="namespace" type="xs:string" />
+      <xs:element name="name" type="xs:string" />
+      <xs:element name="version" type="xs:decimal" />
+    </xs:all>
+  </xs:complexType>
+  <xs:simpleType name="mandatoryString">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="multiplicity">
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="-1" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="referenceDataModelTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ReferenceDataModel" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="referenceDataTypeDomainTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ReferencePrimitiveType" />
+      <xs:enumeration value="ReferenceEnumerationType" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="uuid">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-fF0-9]{4}-[a-f0-9]{12}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="authorityType">
+    <xs:sequence>
+      <xs:element name="id" type="mdm:uuid" minOccurs="0" />
+      <xs:element name="label" type="mdm:mandatoryString" />
+      <xs:element name="url" type="mdm:mandatoryString" />
+      <xs:element maxOccurs="1" minOccurs="0" name="description" type="xs:string" />
+      <xs:element name="lastUpdated" type="xs:dateTime" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/mdm-plugin-referencedata/grails-app/conf/db/migration/referencedata/V2_3_0__add_column_number_to_element.sql
+++ b/mdm-plugin-referencedata/grails-app/conf/db/migration/referencedata/V2_3_0__add_column_number_to_element.sql
@@ -1,0 +1,9 @@
+ALTER TABLE referencedata.reference_data_element
+    ADD COLUMN column_number INT8;
+
+UPDATE referencedata.reference_data_element
+SET column_number = 0;
+
+ALTER TABLE referencedata.reference_data_element
+    ALTER COLUMN column_number SET NOT NULL;
+

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementController.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementController.groovy
@@ -98,7 +98,8 @@ class ReferenceDataElementController extends CatalogueItemController<ReferenceDa
         }
         if (params.all) removePaginationParameters()
 
-        return referenceDataElementService.findAllByReferenceDataModelId(params.referenceDataModelId, params)
+        // Always sort the list of elements in a model by columnNumber
+        return referenceDataElementService.findAllByReferenceDataModelId(params.referenceDataModelId, params).sort{ it.columnNumber }
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueController.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueController.groovy
@@ -170,8 +170,10 @@ class ReferenceDataValueController extends EditLoggingController<ReferenceDataVa
      * Turn a list of ReferenceDataValue into a list of rows
      */
     private List rowify(List<ReferenceDataValue> referenceDataValues) {
-        //Sort the list by rowNumber ascending
-        referenceDataValues.sort {it.getProperty(params.sortBy)}
+        //Sort the list by rowNumber ascending and then columnNumber ascending
+        referenceDataValues.sort {it1, it2 ->
+            it1.rowNumber <=> it2.rowNumber ?: it1.referenceDataElement.columnNumber <=> it2.referenceDataElement.columnNumber
+        }
 
         //Make a list of row numbers
         List rowNumbers = []

--- a/mdm-plugin-referencedata/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElement.groovy
+++ b/mdm-plugin-referencedata/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElement.groovy
@@ -62,6 +62,7 @@ class ReferenceDataElement implements ModelItem<ReferenceDataElement, ReferenceD
     ReferenceDataType referenceDataType
 
     UUID id
+    int columnNumber
 
     static belongsTo = [ReferenceDataModel, ReferenceDataType]
 

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/exporter/ReferenceDataJsonExporterService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/exporter/ReferenceDataJsonExporterService.groovy
@@ -50,7 +50,7 @@ class ReferenceDataJsonExporterService extends ReferenceDataModelExporterProvide
 
     @Override
     String getVersion() {
-        '3.0'
+        '4.0'
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/exporter/ReferenceDataXmlExporterService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/exporter/ReferenceDataXmlExporterService.groovy
@@ -50,7 +50,7 @@ class ReferenceDataXmlExporterService extends ReferenceDataModelExporterProvider
 
     @Override
     String getVersion() {
-        '3.1'
+        '4.0'
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/importer/ReferenceDataCsvImporterService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/importer/ReferenceDataCsvImporterService.groovy
@@ -47,7 +47,7 @@ class ReferenceDataCsvImporterService
 
     @Override
     String getVersion() {
-        '3.0'
+        '4.0'
     }
 
     @Override
@@ -77,8 +77,8 @@ class ReferenceDataCsvImporterService
         log.debug('Input parsed in {}', Utils.timeTaken(start))            
 
         List headers = parser.getHeaderNames()
-        headers.each {
-            ReferenceDataElement referenceDataElement = new ReferenceDataElement(referenceDataType: stringDataType, label: it, createdBy: currentUser.emailAddress)
+        headers.eachWithIndex {it, index ->
+            ReferenceDataElement referenceDataElement = new ReferenceDataElement(referenceDataType: stringDataType, columnNumber: index, label: it, createdBy: currentUser.emailAddress)
             referenceDataModel.addToReferenceDataElements(referenceDataElement)
             referenceDataElements[it] = referenceDataElement
         }

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/importer/ReferenceDataJsonImporterService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/importer/ReferenceDataJsonImporterService.groovy
@@ -40,7 +40,7 @@ class ReferenceDataJsonImporterService
 
     @Override
     String getVersion() {
-        '3.0'
+        '4.0'
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/importer/ReferenceDataXmlImporterService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/importer/ReferenceDataXmlImporterService.groovy
@@ -40,7 +40,7 @@ class ReferenceDataXmlImporterService
 
     @Override
     String getVersion() {
-        '3.0'
+        '4.0'
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/referencedata/bootstrap/BootstrapModels.groovy
+++ b/mdm-plugin-referencedata/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/referencedata/bootstrap/BootstrapModels.groovy
@@ -61,8 +61,8 @@ class BootstrapModels {
 
             checkAndSave(messageSource, referenceDataModel)
 
-            ReferenceDataElement organisationName = new ReferenceDataElement(referenceDataType: stringDataType, label: "Organisation name", createdBy: DEVELOPMENT)
-            ReferenceDataElement organisationCode = new ReferenceDataElement(referenceDataType: stringDataType, label: "Organisation code", createdBy: DEVELOPMENT)
+            ReferenceDataElement organisationName = new ReferenceDataElement(referenceDataType: stringDataType, label: "Organisation name", createdBy: DEVELOPMENT, columnNumber: 1)
+            ReferenceDataElement organisationCode = new ReferenceDataElement(referenceDataType: stringDataType, label: "Organisation code", createdBy: DEVELOPMENT, columnNumber: 0)
             referenceDataModel.addToReferenceDataElements(organisationName)
             referenceDataModel.addToReferenceDataElements(organisationCode)
 
@@ -115,9 +115,9 @@ class BootstrapModels {
 
             checkAndSave(messageSource, referenceDataModel)
 
-            ReferenceDataElement a = new ReferenceDataElement(referenceDataType: stringDataType, label: "Column A", createdBy: DEVELOPMENT)
-            ReferenceDataElement b = new ReferenceDataElement(referenceDataType: stringDataType, label: "Column B", createdBy: DEVELOPMENT)
-            ReferenceDataElement c = new ReferenceDataElement(referenceDataType: stringDataType, label: "Column C", createdBy: DEVELOPMENT)
+            ReferenceDataElement a = new ReferenceDataElement(referenceDataType: stringDataType, label: "Column A", createdBy: DEVELOPMENT, columnNumber: 0)
+            ReferenceDataElement b = new ReferenceDataElement(referenceDataType: stringDataType, label: "Column B", createdBy: DEVELOPMENT, columnNumber: 1)
+            ReferenceDataElement c = new ReferenceDataElement(referenceDataType: stringDataType, label: "Column C", createdBy: DEVELOPMENT, columnNumber: 2)
             referenceDataModel.addToReferenceDataElements(a)
             referenceDataModel.addToReferenceDataElements(b)
             referenceDataModel.addToReferenceDataElements(c)

--- a/mdm-plugin-referencedata/grails-app/views/referenceDataElement/_export.gson
+++ b/mdm-plugin-referencedata/grails-app/views/referenceDataElement/_export.gson
@@ -5,6 +5,7 @@ model {
     ReferenceDataElement referenceDataElement
 }
 json {
+    columnNumber referenceDataElement.columnNumber
     referenceDataType tmpl.'/referenceDataType/export'(referenceDataElement.referenceDataType)
     if (referenceDataElement.maxMultiplicity != null) maxMultiplicity referenceDataElement.maxMultiplicity
     if (referenceDataElement.minMultiplicity != null) minMultiplicity referenceDataElement.minMultiplicity

--- a/mdm-plugin-referencedata/grails-app/views/referenceDataElement/_referenceDataElement.gson
+++ b/mdm-plugin-referencedata/grails-app/views/referenceDataElement/_referenceDataElement.gson
@@ -6,6 +6,7 @@ model {
 }
 
 json {
+    columnNumber referenceDataElement.columnNumber
     referenceDataType tmpl.'/referenceDataType/referenceDataType'(referenceDataElement.referenceDataType)
     if (referenceDataElement.maxMultiplicity != null) maxMultiplicity referenceDataElement.maxMultiplicity
     if (referenceDataElement.minMultiplicity != null) minMultiplicity referenceDataElement.minMultiplicity

--- a/mdm-plugin-referencedata/grails-app/views/referenceDataElement/_referenceDataElement_full.gson
+++ b/mdm-plugin-referencedata/grails-app/views/referenceDataElement/_referenceDataElement_full.gson
@@ -12,6 +12,7 @@ model {
 }
 
 json {
+    columnNumber referenceDataElement.columnNumber
     referenceDataType tmpl.'/referenceDataType/referenceDataType'(referenceDataElement.referenceDataType)
     if (referenceDataElement.maxMultiplicity != null) maxMultiplicity referenceDataElement.maxMultiplicity
     if (referenceDataElement.minMultiplicity != null) minMultiplicity referenceDataElement.minMultiplicity

--- a/mdm-plugin-referencedata/grails-app/views/referenceDataElement/export.gml
+++ b/mdm-plugin-referencedata/grails-app/views/referenceDataElement/export.gml
@@ -4,6 +4,7 @@ ReferenceDataElement rde = referenceDataElement as ReferenceDataElement
 
 'mdm:referenceDataElement' {
     layout '/catalogueItem/_export.gml', catalogueItem: rde
+    'mdm:columnNumber'(rde.columnNumber)
     layout '/referenceDataType/export.gml', referenceDataType: rde.referenceDataType
     if (rde.maxMultiplicity != null) 'mdm:maxMultiplicity'(rde.maxMultiplicity)
     if (rde.minMultiplicity != null) 'mdm:minMultiplicity'(rde.minMultiplicity)

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelFunctionalSpec.groovy
@@ -177,7 +177,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         verifyJsonResponse OK, '''[
   {
     "name": "ReferenceDataJsonExporterService",
-    "version": "3.0",
+    "version": "4.0",
     "displayName": "JSON Reference Data Exporter",
     "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
     "allowsExtraMetadataKeys": true,
@@ -191,7 +191,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
   },
   {
     "name": "ReferenceDataXmlExporterService",
-    "version": "3.1",
+    "version": "4.0",
     "displayName": "XML Reference Data Exporter",
     "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
     "allowsExtraMetadataKeys": true,
@@ -214,7 +214,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         verifyJsonResponse OK, '''[
   {
     "name": "ReferenceDataJsonImporterService",
-    "version": "3.0",
+    "version": "4.0",
     "displayName": "JSON Reference Data Importer",
     "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer",
     "allowsExtraMetadataKeys": true,
@@ -228,7 +228,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
   },
   {
     "name": "ReferenceDataXmlImporterService",
-    "version": "3.0",
+    "version": "4.0",
     "displayName": "XML Reference Data Importer",
     "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer",
     "allowsExtraMetadataKeys": true,
@@ -242,7 +242,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
   },
   {
     "name": "ReferenceDataCsvImporterService",
-    "version": "3.0",
+    "version": "4.0",
     "displayName": "CSV Reference Data Importer",
     "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer",
     "allowsExtraMetadataKeys": false,
@@ -1096,7 +1096,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         String id = createNewItem(validJson)
 
         when:
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
 
         then:
         verifyJsonResponse OK, '''{
@@ -1119,7 +1119,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
     "exporter": {
       "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
       "name": "ReferenceDataJsonExporterService",
-      "version": "3.0"
+      "version": "4.0"
     }
   }
 }'''
@@ -1134,7 +1134,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         String id2 = createNewItem([label: 'Functional Test Model 2'])
 
         when:
-        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0',
+        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0',
              [referenceDataModelIds: [id, id2]], STRING_ARG
         )
 
@@ -1159,7 +1159,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
     "exporter": {
       "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
       "name": "ReferenceDataJsonExporterService",
-      "version": "3.0"
+      "version": "4.0"
     }
   }
 }'''
@@ -1173,7 +1173,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         given:
         String id = createNewItem(validJson)
 
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
 
@@ -1181,7 +1181,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         exportedJsonString
 
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             modelName                      : 'Functional Test Import',
             folderId                       : folderId.toString(),
@@ -1220,7 +1220,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
             modelVersion: Version.from('1.0.0')
         ])
 
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
 
@@ -1228,7 +1228,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         exportedJsonString
 
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : true,
             modelName                      : 'Functional Test Model',
             folderId                       : folderId.toString(),
@@ -1334,7 +1334,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         log.debug("${loadCsvFile('simpleCSV').toList().toString()}")
 
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataCsvImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataCsvImporterService/4.0', [
             finalised                      : true,
             folderId                       : folderId.toString(),
             modelName                      : 'FT Test Reference Data Model',
@@ -1357,7 +1357,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
 
     void 'test importing ReferenceData with classifiers'() {
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : true,
             folderId                       : folderId.toString(),
             importAsNewDocumentationVersion: false,
@@ -1379,7 +1379,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
 
     void 'test export ReferenceData'() {
         given:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             folderId                       : folderId.toString(),
             importAsNewDocumentationVersion: false,
@@ -1399,7 +1399,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         id
 
         when:
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
 
         then:
         verifyJsonResponse OK, expected
@@ -2716,7 +2716,7 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         log.debug("${loadCsvFile('simpleCSV').toList().toString()}")
 
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataCsvImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataCsvImporterService/4.0', [
             finalised                      : true,
             folderId                       : folderId.toString(),
             modelName                      : 'FT Test Reference Data Model',

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementFunctionalSpec.groovy
@@ -128,7 +128,8 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
             label          : 'Functional Test DataElement',
             maxMultiplicity: 2,
             minMultiplicity: 0,
-            referenceDataType       : referenceDataTypeId.toString()
+            referenceDataType       : referenceDataTypeId.toString(),
+            columnNumber: 83
         ]
     }
 
@@ -155,6 +156,7 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
   "lastUpdated": "${json-unit.matches:offsetDateTime}",
   "domainType": "ReferenceDataElement",
   "availableActions": ["delete","show","update"],
+  "columnNumber": 83,
   "referenceDataType": {
     "domainType": "ReferencePrimitiveType",
     "model": "${json-unit.matches:id}",
@@ -222,6 +224,7 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
                  label            : 'Functional Test DataElement',
                  maxMultiplicity  : 2,
                  minMultiplicity  : 1,
+                 columnNumber: 12,
                  referenceDataType: [
                      label     : 'Functional Test DataType',
                      domainType: ReferenceDataType.PRIMITIVE_DOMAIN_TYPE
@@ -233,6 +236,7 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
   "lastUpdated": "${json-unit.matches:offsetDateTime}",
   "domainType": "ReferenceDataElement",
   "availableActions": ["delete","show","update"],
+  "columnNumber": 12,
   "referenceDataType": {
     "domainType": "ReferencePrimitiveType",
     "model": "${json-unit.matches:id}",
@@ -285,6 +289,7 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
   "lastUpdated": "${json-unit.matches:offsetDateTime}",
   "domainType": "ReferenceDataElement",
   "availableActions": ["delete","show","update"],
+  "columnNumber": 83,
   "referenceDataType": {
     "domainType": "ReferencePrimitiveType",
     "model": "${json-unit.matches:id}",
@@ -326,6 +331,7 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
                  label          : 'Functional Test DataElement',
                  maxMultiplicity: 2,
                  minMultiplicity: 1,
+                 columnNumber: 3,
                  referenceDataType       : [
                      label         : 'Functional Test DataType 3',
                      domainType    : ReferenceDataType.PRIMITIVE_DOMAIN_TYPE,
@@ -338,6 +344,7 @@ class ReferenceDataElementFunctionalSpec extends ResourceFunctionalSpec<Referenc
   "lastUpdated": "${json-unit.matches:offsetDateTime}",
   "domainType": "ReferenceDataElement",
   "availableActions": ["delete","show","update"],
+  "columnNumber": 3,
   "referenceDataType": {
     "domainType": "ReferencePrimitiveType",
     "model": "${json-unit.matches:id}",

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
@@ -126,6 +126,7 @@ class ReferenceDataValueFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
                 "finalised": false
             }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
             "id": "${json-unit.matches:id}",
             "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/JsonReferenceDataImporterExporterServiceSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/JsonReferenceDataImporterExporterServiceSpec.groovy
@@ -199,7 +199,7 @@ class JsonReferenceDataImporterExporterServiceSpec extends BaseReferenceDataMode
         diff.diffs.find {it.fieldName == 'rule'}.deleted.size() == 1
     }
 
-void 'RDM03: test empty data import'() {
+    void 'RDM03: test empty data import'() {
         given:
         setupData()
 

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/MauroDataMapperServiceProviderFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/provider/MauroDataMapperServiceProviderFunctionalSpec.groovy
@@ -124,7 +124,7 @@ class MauroDataMapperServiceProviderFunctionalSpec extends BaseFunctionalSpec {
   },
   {
     "name": "ReferenceDataCsvImporterService",
-    "version": "3.0",
+    "version": "${json-unit.matches:version}",
     "displayName": "CSV Reference Data Importer",
     "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer",
     "allowsExtraMetadataKeys": false,

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/bootstrapExample.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/bootstrapExample.json
@@ -60,6 +60,7 @@
                 "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                 "label": "Organisation code",
                 "lastUpdated": "2021-02-27T20:50:01.699Z",
+                "columnNumber": 0,
                 "referenceDataType": {
                     "id": "6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3",
                     "label": "string",
@@ -71,6 +72,7 @@
                 "id": "103130c2-661b-439a-996b-0360dc246fd3",
                 "label": "Organisation name",
                 "lastUpdated": "2021-02-27T20:50:02.436Z",
+                "columnNumber": 1,
                 "referenceDataType": {
                     "id": "6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3",
                     "label": "string",
@@ -89,6 +91,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -123,6 +126,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -157,6 +161,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -191,6 +196,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -225,6 +231,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -259,6 +266,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -293,6 +301,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -327,6 +336,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -361,6 +371,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -395,6 +406,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -429,6 +441,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -463,6 +476,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -497,6 +511,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -531,6 +546,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -565,6 +581,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -599,6 +616,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -633,6 +651,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -667,6 +686,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -701,6 +721,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -735,6 +756,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -769,6 +791,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -803,6 +826,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -837,6 +861,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -871,6 +896,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -905,6 +931,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -939,6 +966,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -973,6 +1001,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1007,6 +1036,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1041,6 +1071,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1075,6 +1106,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1109,6 +1141,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1143,6 +1176,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1177,6 +1211,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1211,6 +1246,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1245,6 +1281,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1279,6 +1316,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1313,6 +1351,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1347,6 +1386,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1381,6 +1421,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1415,6 +1456,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1449,6 +1491,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1483,6 +1526,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1517,6 +1561,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1551,6 +1596,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1585,6 +1631,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1619,6 +1666,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1653,6 +1701,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1687,6 +1736,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1721,6 +1771,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1755,6 +1806,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1789,6 +1841,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1823,6 +1876,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1857,6 +1911,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1891,6 +1946,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1925,6 +1981,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1959,6 +2016,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1993,6 +2051,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2027,6 +2086,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2061,6 +2121,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2095,6 +2156,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2129,6 +2191,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2163,6 +2226,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2197,6 +2261,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2231,6 +2296,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2265,6 +2331,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2299,6 +2366,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2333,6 +2401,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2367,6 +2436,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2401,6 +2471,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2435,6 +2506,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2469,6 +2541,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2503,6 +2576,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2537,6 +2611,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2571,6 +2646,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2605,6 +2681,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2639,6 +2716,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2673,6 +2751,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2707,6 +2786,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2741,6 +2821,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2775,6 +2856,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2809,6 +2891,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2843,6 +2926,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2877,6 +2961,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2911,6 +2996,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2945,6 +3031,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2979,6 +3066,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3013,6 +3101,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3047,6 +3136,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3081,6 +3171,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3115,6 +3206,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3149,6 +3241,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3183,6 +3276,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3217,6 +3311,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3251,6 +3346,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3285,6 +3381,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3319,6 +3416,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3353,6 +3451,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3387,6 +3486,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3421,6 +3521,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3455,6 +3556,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3489,6 +3591,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3523,6 +3626,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3557,6 +3661,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3591,6 +3696,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3625,6 +3731,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3659,6 +3766,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3693,6 +3801,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3727,6 +3836,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3761,6 +3871,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3795,6 +3906,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3829,6 +3941,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3863,6 +3976,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3897,6 +4011,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3931,6 +4046,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3965,6 +4081,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3999,6 +4116,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4033,6 +4151,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4067,6 +4186,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4101,6 +4221,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4135,6 +4256,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4169,6 +4291,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4203,6 +4326,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4237,6 +4361,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4271,6 +4396,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4305,6 +4431,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4339,6 +4466,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4373,6 +4501,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4407,6 +4536,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4441,6 +4571,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4475,6 +4606,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4509,6 +4641,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4543,6 +4676,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4577,6 +4711,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4611,6 +4746,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4645,6 +4781,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4679,6 +4816,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4713,6 +4851,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4747,6 +4886,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4781,6 +4921,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4815,6 +4956,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4849,6 +4991,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4883,6 +5026,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4917,6 +5061,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4951,6 +5096,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4985,6 +5131,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5019,6 +5166,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5053,6 +5201,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5087,6 +5236,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5121,6 +5271,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5155,6 +5306,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5189,6 +5341,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5223,6 +5376,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5257,6 +5411,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5291,6 +5446,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5325,6 +5481,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5359,6 +5516,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5393,6 +5551,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5427,6 +5586,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5461,6 +5621,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5495,6 +5656,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5529,6 +5691,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5563,6 +5726,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5597,6 +5761,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5631,6 +5796,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5665,6 +5831,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5699,6 +5866,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5733,6 +5901,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5767,6 +5936,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5801,6 +5971,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5835,6 +6006,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5869,6 +6041,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5903,6 +6076,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5937,6 +6111,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5971,6 +6146,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6005,6 +6181,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6039,6 +6216,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6073,6 +6251,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6107,6 +6286,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6141,6 +6321,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6175,6 +6356,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6209,6 +6391,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6243,6 +6426,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6277,6 +6461,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6311,6 +6496,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6345,6 +6531,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6379,6 +6566,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6413,6 +6601,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6447,6 +6636,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6481,6 +6671,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6515,6 +6706,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6549,6 +6741,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6583,6 +6776,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6617,6 +6811,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6651,6 +6846,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6685,6 +6881,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6719,6 +6916,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6753,6 +6951,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6787,6 +6986,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6821,6 +7021,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6855,6 +7056,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6888,7 +7090,7 @@
         "exporter": {
             "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
             "name": "ReferenceDataJsonExporterService",
-            "version": "3.0"
+            "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValues.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValues.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -51,6 +52,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -84,6 +86,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 2,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -117,6 +120,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -150,6 +154,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -183,6 +188,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 2,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -216,6 +222,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -249,6 +256,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -282,6 +290,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 2,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -315,6 +324,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValuesAsRows.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValuesAsRows.json
@@ -20,6 +20,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -53,6 +54,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -86,6 +88,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -123,6 +126,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -156,6 +160,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -189,6 +194,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -226,6 +232,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -259,6 +266,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -292,6 +300,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -329,6 +338,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -362,6 +372,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -395,6 +406,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -432,6 +444,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -465,6 +478,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -498,6 +512,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -535,6 +550,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -568,6 +584,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -601,6 +618,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -638,6 +656,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -671,6 +690,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -704,6 +724,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -741,6 +762,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -774,6 +796,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -807,6 +830,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -844,6 +868,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -877,6 +902,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -910,6 +936,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -947,6 +974,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -980,6 +1008,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -1013,6 +1042,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValuesAsRowsMax.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValuesAsRowsMax.json
@@ -20,6 +20,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -53,6 +54,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -86,6 +88,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -123,6 +126,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -156,6 +160,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -189,6 +194,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValuesMax.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/expectedGetValuesMax.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -51,6 +52,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/expectedSearchValuesRow6.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/expectedSearchValuesRow6.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/expectedSearchValuesRow6AsRows.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/expectedSearchValuesRow6AsRows.json
@@ -20,6 +20,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -53,6 +54,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -86,6 +88,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importReferenceDataModel.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importReferenceDataModel.json
@@ -62,6 +62,7 @@
                 "id": "8fa399ae-d118-4d66-8090-3a1ea4f5be2f",
                 "label": "Organisation code",
                 "lastUpdated": "2020-10-27T15:00:33.882Z",
+                "columnNumber": 0,
                 "referenceDataType": {
                     "id": "b26b82e4-8667-4024-a430-17bdefd79ca1",
                     "label": "string",
@@ -73,6 +74,7 @@
                 "id": "1a6e5ec3-0554-4d88-89cb-dc74c9950a0f",
                 "label": "Organisation name",
                 "lastUpdated": "2020-10-27T15:00:33.871Z",
+                "columnNumber": 1,
                 "referenceDataType": {
                     "id": "b26b82e4-8667-4024-a430-17bdefd79ca1",
                     "label": "string",
@@ -91,6 +93,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -125,6 +128,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -159,6 +163,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -193,6 +198,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -227,6 +233,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -261,6 +268,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -295,6 +303,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -329,6 +338,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -363,6 +373,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -397,6 +408,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -431,6 +443,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -465,6 +478,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -499,6 +513,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -533,6 +548,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -567,6 +583,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -601,6 +618,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -635,6 +653,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -669,6 +688,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -703,6 +723,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -737,6 +758,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -771,6 +793,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -805,6 +828,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -839,6 +863,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -873,6 +898,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -907,6 +933,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -941,6 +968,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -975,6 +1003,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1009,6 +1038,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1043,6 +1073,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1077,6 +1108,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1111,6 +1143,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1145,6 +1178,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1179,6 +1213,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1213,6 +1248,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1247,6 +1283,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1281,6 +1318,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1315,6 +1353,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1349,6 +1388,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1383,6 +1423,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1417,6 +1458,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1451,6 +1493,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1485,6 +1528,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1519,6 +1563,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1553,6 +1598,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1587,6 +1633,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1621,6 +1668,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1655,6 +1703,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1689,6 +1738,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1723,6 +1773,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1757,6 +1808,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1791,6 +1843,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1825,6 +1878,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1859,6 +1913,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1893,6 +1948,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1927,6 +1983,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1961,6 +2018,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -1995,6 +2053,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2029,6 +2088,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2063,6 +2123,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2097,6 +2158,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2131,6 +2193,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2165,6 +2228,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2199,6 +2263,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2233,6 +2298,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2267,6 +2333,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2301,6 +2368,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2335,6 +2403,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2369,6 +2438,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2403,6 +2473,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2437,6 +2508,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2471,6 +2543,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2505,6 +2578,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2539,6 +2613,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2573,6 +2648,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2607,6 +2683,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2641,6 +2718,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2675,6 +2753,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2709,6 +2788,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2743,6 +2823,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2777,6 +2858,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2811,6 +2893,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2845,6 +2928,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2879,6 +2963,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2913,6 +2998,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2947,6 +3033,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -2981,6 +3068,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3015,6 +3103,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3049,6 +3138,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3083,6 +3173,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3117,6 +3208,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3151,6 +3243,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3185,6 +3278,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3219,6 +3313,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3253,6 +3348,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3287,6 +3383,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3321,6 +3418,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3355,6 +3453,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3389,6 +3488,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3423,6 +3523,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3457,6 +3558,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3491,6 +3593,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3525,6 +3628,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3559,6 +3663,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3593,6 +3698,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3627,6 +3733,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3661,6 +3768,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3695,6 +3803,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3729,6 +3838,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3763,6 +3873,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3797,6 +3908,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3831,6 +3943,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3865,6 +3978,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3899,6 +4013,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3933,6 +4048,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -3967,6 +4083,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4001,6 +4118,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4035,6 +4153,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4069,6 +4188,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4103,6 +4223,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4137,6 +4258,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4171,6 +4293,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4205,6 +4328,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4239,6 +4363,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4273,6 +4398,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4307,6 +4433,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4341,6 +4468,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4375,6 +4503,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4409,6 +4538,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4443,6 +4573,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4477,6 +4608,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4511,6 +4643,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4545,6 +4678,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4579,6 +4713,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4613,6 +4748,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4647,6 +4783,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4681,6 +4818,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4715,6 +4853,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4749,6 +4888,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4783,6 +4923,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4817,6 +4958,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4851,6 +4993,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4885,6 +5028,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4919,6 +5063,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4953,6 +5098,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -4987,6 +5133,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5021,6 +5168,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5055,6 +5203,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5089,6 +5238,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5123,6 +5273,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5157,6 +5308,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5191,6 +5343,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5225,6 +5378,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5259,6 +5413,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5293,6 +5448,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5327,6 +5483,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5361,6 +5518,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5395,6 +5553,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5429,6 +5588,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5463,6 +5623,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5497,6 +5658,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5531,6 +5693,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5565,6 +5728,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5599,6 +5763,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5633,6 +5798,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5667,6 +5833,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5701,6 +5868,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5735,6 +5903,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5769,6 +5938,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5803,6 +5973,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5837,6 +6008,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5871,6 +6043,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5905,6 +6078,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5939,6 +6113,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -5973,6 +6148,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6007,6 +6183,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6041,6 +6218,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6075,6 +6253,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6109,6 +6288,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6143,6 +6323,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6177,6 +6358,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6211,6 +6393,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6245,6 +6428,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6279,6 +6463,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6313,6 +6498,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6347,6 +6533,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6381,6 +6568,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6415,6 +6603,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6449,6 +6638,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6483,6 +6673,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6517,6 +6708,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6551,6 +6743,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6585,6 +6778,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6619,6 +6813,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6653,6 +6848,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6687,6 +6883,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6721,6 +6918,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6755,6 +6953,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6789,6 +6988,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6823,6 +7023,7 @@
                     "id": "d482506c-8387-4d80-ba5c-24332ee76fc8",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation code",
+                    "columnNumber": 0,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6857,6 +7058,7 @@
                     "id": "103130c2-661b-439a-996b-0360dc246fd3",
                     "domainType": "ReferenceDataElement",
                     "label": "Organisation name",
+                    "columnNumber": 1,
                     "model": "cdea5e30-5937-4a02-b8e6-0b803038f90f",
                     "breadcrumbs": [
                         {
@@ -6890,7 +7092,7 @@
         "exporter": {
             "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
             "name": "ReferenceDataJsonExporterService",
-            "version": "3.0"
+            "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importSimple.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importSimple.json
@@ -20,7 +20,7 @@
         "exporter": {
           "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
           "name": "ReferenceDataJsonExporterService",
-          "version": "3.0"
+          "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleValue.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleValue.json
@@ -62,6 +62,7 @@
                 "id": "${json-unit.matches:id}",
                 "label": "Organisation code",
                 "lastUpdated": "${json-unit.matches:offsetDateTime}",
+                "columnNumber": 0,
                 "referenceDataType": {
                     "id": "${json-unit.matches:id}",
                     "label": "string",
@@ -73,6 +74,7 @@
                 "id": "${json-unit.matches:id}",
                 "label": "Organisation name",
                 "lastUpdated": "${json-unit.matches:offsetDateTime}",
+                "columnNumber": 1,
                 "referenceDataType": {
                     "id": "${json-unit.matches:id}",
                     "label": "string",
@@ -100,6 +102,7 @@
                             "finalised": false
                         }
                     ],
+                    "columnNumber": 0,
                     "referenceDataType": {
                         "id": "${json-unit.matches:id}",
                         "domainType": "ReferencePrimitiveType",
@@ -134,6 +137,7 @@
                             "finalised": false
                         }
                     ],
+                    "columnNumber": 1,
                     "referenceDataType": {
                         "id": "${json-unit.matches:id}",
                         "domainType": "ReferencePrimitiveType",
@@ -158,7 +162,7 @@
         "exporter": {
           "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
           "name": "ReferenceDataJsonExporterService",
-          "version": "3.0"
+          "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithAliases.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithAliases.json
@@ -24,7 +24,7 @@
         "exporter": {
           "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
           "name": "ReferenceDataJsonExporterService",
-          "version": "3.0"
+          "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithAnnotations.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithAnnotations.json
@@ -29,7 +29,7 @@
         "exporter": {
           "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
           "name": "ReferenceDataJsonExporterService",
-          "version": "3.0"
+          "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithClassifiers.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithClassifiers.json
@@ -32,7 +32,7 @@
         "exporter": {
           "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
           "name": "ReferenceDataJsonExporterService",
-          "version": "3.0"
+          "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithMetadata.json
+++ b/mdm-plugin-referencedata/src/integration-test/resources/json/importSimpleWithMetadata.json
@@ -43,7 +43,7 @@
         "exporter": {
           "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
           "name": "ReferenceDataJsonExporterService",
-          "version": "3.0"
+          "version": "4.0"
         }
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/bootstrapExample.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/bootstrapExample.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>cdea5e30-5937-4a02-b8e6-0b803038f90f</mdm:id>
         <mdm:label>Simple Reference Data Model</mdm:label>
@@ -59,9 +59,10 @@
         </mdm:referenceDataTypes>
         <mdm:referenceDataElements>
             <mdm:referenceDataElement>
-                <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
-                <mdm:label>Organisation name</mdm:label>
-                <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
+                <mdm:label>Organisation code</mdm:label>
+                <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                <mdm:columnNumber>0</mdm:columnNumber>
                 <mdm:referenceDataType>
                     <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                     <mdm:label>string</mdm:label>
@@ -70,9 +71,10 @@
                 </mdm:referenceDataType>
             </mdm:referenceDataElement>
             <mdm:referenceDataElement>
-                <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
-                <mdm:label>Organisation code</mdm:label>
-                <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
+                <mdm:label>Organisation name</mdm:label>
+                <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                <mdm:columnNumber>1</mdm:columnNumber>
                 <mdm:referenceDataType>
                     <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                     <mdm:label>string</mdm:label>
@@ -90,6 +92,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -106,6 +109,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -122,6 +126,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -138,6 +143,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -154,6 +160,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -170,6 +177,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -186,6 +194,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -202,6 +211,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -218,6 +228,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -234,6 +245,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -250,6 +262,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -266,6 +279,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -282,6 +296,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -298,6 +313,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -314,6 +330,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -330,6 +347,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -346,6 +364,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -362,6 +381,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -378,6 +398,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -394,6 +415,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -410,6 +432,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -426,6 +449,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -442,6 +466,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -458,6 +483,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -474,6 +500,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -490,6 +517,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -506,6 +534,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -522,6 +551,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -538,6 +568,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -554,6 +585,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -570,6 +602,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -586,6 +619,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -602,6 +636,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -618,6 +653,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -634,6 +670,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -650,6 +687,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -666,6 +704,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -682,6 +721,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -698,6 +738,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -714,6 +755,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -730,6 +772,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -746,6 +789,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -762,6 +806,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -778,6 +823,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -794,6 +840,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -810,6 +857,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -826,6 +874,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -842,6 +891,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -858,6 +908,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -874,6 +925,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -890,6 +942,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -906,6 +959,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -922,6 +976,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -938,6 +993,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -954,6 +1010,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -970,6 +1027,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -986,6 +1044,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1002,6 +1061,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1018,6 +1078,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1034,6 +1095,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1050,6 +1112,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1066,6 +1129,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1082,6 +1146,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1098,6 +1163,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1114,6 +1180,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1130,6 +1197,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1146,6 +1214,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1162,6 +1231,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1178,6 +1248,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1194,6 +1265,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1210,6 +1282,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1226,6 +1299,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1242,6 +1316,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1258,6 +1333,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1274,6 +1350,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1290,6 +1367,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1306,6 +1384,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1322,6 +1401,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1338,6 +1418,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1354,6 +1435,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1370,6 +1452,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1386,6 +1469,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1402,6 +1486,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1418,6 +1503,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1434,6 +1520,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1450,6 +1537,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1466,6 +1554,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1482,6 +1571,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1498,6 +1588,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1514,6 +1605,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1530,6 +1622,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1546,6 +1639,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1562,6 +1656,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1578,6 +1673,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1594,6 +1690,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1610,6 +1707,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1626,6 +1724,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1642,6 +1741,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1658,6 +1758,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1674,6 +1775,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1690,6 +1792,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1706,6 +1809,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1722,6 +1826,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1738,6 +1843,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1754,6 +1860,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1770,6 +1877,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1786,6 +1894,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1802,6 +1911,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1818,6 +1928,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1834,6 +1945,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1850,6 +1962,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1866,6 +1979,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1882,6 +1996,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1898,6 +2013,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1914,6 +2030,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1930,6 +2047,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1946,6 +2064,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1962,6 +2081,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1978,6 +2098,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -1994,6 +2115,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2010,6 +2132,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2026,6 +2149,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2042,6 +2166,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2058,6 +2183,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2074,6 +2200,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2090,6 +2217,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2106,6 +2234,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2122,6 +2251,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2138,6 +2268,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2154,6 +2285,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2170,6 +2302,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2186,6 +2319,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2202,6 +2336,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2218,6 +2353,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2234,6 +2370,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2250,6 +2387,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2266,6 +2404,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2282,6 +2421,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2298,6 +2438,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2314,6 +2455,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2330,6 +2472,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2346,6 +2489,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2362,6 +2506,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2378,6 +2523,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2394,6 +2540,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2410,6 +2557,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2426,6 +2574,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2442,6 +2591,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2458,6 +2608,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2474,6 +2625,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2490,6 +2642,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2506,6 +2659,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2522,6 +2676,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2538,6 +2693,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2554,6 +2710,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2570,6 +2727,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2586,6 +2744,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2602,6 +2761,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2618,6 +2778,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2634,6 +2795,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2650,6 +2812,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2666,6 +2829,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2682,6 +2846,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2698,6 +2863,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2714,6 +2880,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2730,6 +2897,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2746,6 +2914,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2762,6 +2931,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2778,6 +2948,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2794,6 +2965,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2810,6 +2982,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2826,6 +2999,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2842,6 +3016,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2858,6 +3033,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2874,6 +3050,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2890,6 +3067,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2906,6 +3084,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2922,6 +3101,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2938,6 +3118,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2954,6 +3135,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2970,6 +3152,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -2986,6 +3169,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3002,6 +3186,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3018,6 +3203,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3034,6 +3220,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3050,6 +3237,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3066,6 +3254,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3082,6 +3271,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3098,6 +3288,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3114,6 +3305,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3130,6 +3322,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3146,6 +3339,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3162,6 +3356,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3178,6 +3373,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3194,6 +3390,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3210,6 +3407,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3226,6 +3424,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3242,6 +3441,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3258,6 +3458,7 @@
                     <mdm:id>d482506c-8387-4d80-ba5c-24332ee76fc8</mdm:id>
                     <mdm:label>Organisation code</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:01.699Z</mdm:lastUpdated>
+                    <mdm:columnNumber>0</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3274,6 +3475,7 @@
                     <mdm:id>103130c2-661b-439a-996b-0360dc246fd3</mdm:id>
                     <mdm:label>Organisation name</mdm:label>
                     <mdm:lastUpdated>2021-02-27T20:50:02.436Z</mdm:lastUpdated>
+                    <mdm:columnNumber>1</mdm:columnNumber>
                     <mdm:referenceDataType>
                         <mdm:id>6a8db6ff-1be0-40bb-9961-7f03ba5b1ee3</mdm:id>
                         <mdm:label>string</mdm:label>
@@ -3290,7 +3492,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/importReferenceDataModel.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/importReferenceDataModel.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>941f6774-9eae-4bfa-890e-e819eb1af281</mdm:id>
         <mdm:label>Imported Reference Data Model</mdm:label>
@@ -64,6 +64,7 @@
                 <mdm:id>1a6e5ec3-0554-4d88-89cb-dc74c9950a0f</mdm:id>
                 <mdm:label>Organisation name</mdm:label>
                 <mdm:lastUpdated>2020-10-27T15:00:33.871Z</mdm:lastUpdated>
+                <mdm:columnNumber>1</mdm:columnNumber>
                 <mdm:referenceDataType>
                     <mdm:id>b26b82e4-8667-4024-a430-17bdefd79ca1</mdm:id>
                     <mdm:label>string</mdm:label>
@@ -75,6 +76,7 @@
                 <mdm:id>8fa399ae-d118-4d66-8090-3a1ea4f5be2f</mdm:id>
                 <mdm:label>Organisation code</mdm:label>
                 <mdm:lastUpdated>2020-10-27T15:00:33.882Z</mdm:lastUpdated>
+                <mdm:columnNumber>0</mdm:columnNumber>
                 <mdm:referenceDataType>
                     <mdm:id>b26b82e4-8667-4024-a430-17bdefd79ca1</mdm:id>
                     <mdm:label>string</mdm:label>
@@ -3892,7 +3894,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimple.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimple.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>941f6774-9eae-4bfa-890e-e819eb1af281</mdm:id>
         <mdm:label>importSimple Reference Data Model</mdm:label>
@@ -22,7 +22,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithAliases.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithAliases.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>941f6774-9eae-4bfa-890e-e819eb1af281</mdm:id>
         <mdm:label>importSimple Reference Data Model</mdm:label>
@@ -26,7 +26,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithAnnotations.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithAnnotations.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>941f6774-9eae-4bfa-890e-e819eb1af281</mdm:id>
         <mdm:label>importSimple Reference Data Model</mdm:label>
@@ -31,7 +31,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithClassifiers.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithClassifiers.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>941f6774-9eae-4bfa-890e-e819eb1af281</mdm:id>
         <mdm:label>importSimple Reference Data Model</mdm:label>
@@ -34,7 +34,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithMetadata.xml
+++ b/mdm-plugin-referencedata/src/integration-test/resources/xml/importSimpleWithMetadata.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/3.1' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/3.1'>
+<exp:exportModel xmlns:exp='http://maurodatamapper.com/export/4.0' xmlns:mdm='http://maurodatamapper.com/referenceDataModel/4.0'>
     <mdm:referenceDataModel>
         <mdm:id>941f6774-9eae-4bfa-890e-e819eb1af281</mdm:id>
         <mdm:label>importSimple Reference Data Model</mdm:label>
@@ -45,7 +45,7 @@
         <exp:exporter>
             <exp:namespace>uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter</exp:namespace>
             <exp:name>ReferenceDataXmlExporterService</exp:name>
-            <exp:version>3.1</exp:version>
+            <exp:version>4.0</exp:version>
         </exp:exporter>
     </exp:exportMetadata>
 </exp:exportModel>

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataModelFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataModelFunctionalSpec.groovy
@@ -405,7 +405,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         String id = getValidId()
 
         when:
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0")
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0")
 
         then:
         verifyNotFound response, id
@@ -420,7 +420,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginAuthenticated()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0")
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0")
 
         then:
         verifyNotFound response, id
@@ -435,7 +435,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginReader()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
 
         then:
         verifyJsonResponse OK, '''{
@@ -472,7 +472,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         String id = getValidId()
 
         when:
-        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0',
+        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0',
              [referenceDataModelIds: [id, getSimpleDataModelId()]]
         )
 
@@ -488,7 +488,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         String id = getValidId()
 
         when:
-        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0',
+        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0',
              [referenceDataModelIds: [id, getSimpleDataModelId()]]
         )
 
@@ -505,7 +505,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginReader()
-        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0',
+        POST('export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0',
              [referenceDataModelIds: [id, getSimpleDataModelId()]], STRING_ARG
         )
 
@@ -543,7 +543,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         given:
         String id = getValidId()
         loginReader()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
         logout()
@@ -552,7 +552,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         exportedJsonString
 
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             modelName                      : 'Functional Test Import',
             folderId                       : testFolderId.toString(),
@@ -575,7 +575,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         given:
         String id = getValidId()
         loginReader()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
         logout()
@@ -585,7 +585,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginAuthenticated()
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             modelName                      : 'Functional Test Import',
             folderId                       : testFolderId.toString(),
@@ -608,7 +608,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         given:
         String id = getValidId()
         loginReader()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
         logout()
@@ -618,7 +618,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginReader()
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             modelName                      : 'Functional Test Import',
             folderId                       : testFolderId.toString(),
@@ -641,7 +641,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         given:
         String id = getValidId()
         loginReader()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
         logout()
@@ -651,7 +651,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginEditor()
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             modelName                      : 'Functional Test Import',
             folderId                       : testFolderId.toString(),
@@ -681,7 +681,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         given:
         String id = getValidId()
         loginReader()
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
         verifyResponse OK, jsonCapableResponse
         String exportedJsonString = jsonCapableResponse.body()
         logout()
@@ -691,7 +691,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
 
         when:
         loginEditor()
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataJsonImporterService/4.0', [
             finalised                      : false,
             folderId                       : testFolderId.toString(),
             importAsNewDocumentationVersion: true,
@@ -734,7 +734,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         loginEditor()
 
         when:
-        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataCsvImporterService/3.0', [
+        POST('import/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.importer/ReferenceDataCsvImporterService/4.0', [
             finalised                      : true,
             folderId                       : testFolderId.toString(),
             modelName                      : 'FT Test Reference Data Model',
@@ -752,7 +752,7 @@ class ReferenceDataModelFunctionalSpec extends ModelUserAccessPermissionChanging
         id
 
         when:
-        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/3.0", STRING_ARG)
+        GET("${id}/export/uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter/ReferenceDataJsonExporterService/4.0", STRING_ARG)
 
         then:
         verifyJsonResponse OK, new String(loadTestFile('expectedExport.json'))

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataValueFunctionalSpec.groovy
@@ -100,7 +100,7 @@ class ReferenceDataValueFunctionalSpec extends UserAccessFunctionalSpec {
             rowNumber           : 1,
             value               : 'Functional Test ReferenceDataValue',
             referenceDataModel  : simpleReferenceDataModelId,
-            referenceDataElement: referenceDataElementId,
+            referenceDataElement: referenceDataElementId
         ]
     }
 

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/item/ReferenceDataElementFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/item/ReferenceDataElementFunctionalSpec.groovy
@@ -68,7 +68,8 @@ class ReferenceDataElementFunctionalSpec extends UserAccessFunctionalSpec {
             label          : 'Functional Test DataElement',
             maxMultiplicity: 2,
             minMultiplicity: 0,
-            referenceDataType       : referenceDataTypeId
+            referenceDataType       : referenceDataTypeId,
+            columnNumber: 0
         ]
     }
 
@@ -158,6 +159,7 @@ class ReferenceDataElementFunctionalSpec extends UserAccessFunctionalSpec {
     "delete"
   ],
   "lastUpdated": "${json-unit.matches:offsetDateTime}",
+  "columnNumber": 0,
   "referenceDataType": {
     "id": "${json-unit.matches:id}",
     "domainType": "ReferencePrimitiveType",
@@ -195,6 +197,7 @@ class ReferenceDataElementFunctionalSpec extends UserAccessFunctionalSpec {
           "finalised": false
         }
       ],
+      "columnNumber": 1,
       "referenceDataType": {
         "id": "${json-unit.matches:id}",
         "domainType": "ReferencePrimitiveType",
@@ -223,6 +226,7 @@ class ReferenceDataElementFunctionalSpec extends UserAccessFunctionalSpec {
           "finalised": false
         }
       ],
+      "columnNumber": 0,
       "referenceDataType": {
         "id": "${json-unit.matches:id}",
         "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedEditorIndex.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedEditorIndex.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -51,6 +52,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -84,6 +86,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -117,6 +120,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -150,6 +154,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -183,6 +188,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -216,6 +222,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -249,6 +256,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -282,6 +290,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -315,6 +324,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedExport.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedExport.json
@@ -26,6 +26,7 @@
           "id": "${json-unit.matches:id}",
           "label": "Column 1",
           "lastUpdated": "${json-unit.matches:offsetDateTime}",
+          "columnNumber": 0,
           "referenceDataType": {
             "id": "${json-unit.matches:id}",
             "label": "string",
@@ -37,6 +38,7 @@
           "id": "${json-unit.matches:id}",
           "label": "Column 2",
           "lastUpdated": "${json-unit.matches:offsetDateTime}",
+          "columnNumber": 1,
           "referenceDataType": {
             "id": "${json-unit.matches:id}",
             "label": "string",
@@ -48,6 +50,7 @@
           "id": "${json-unit.matches:id}",
           "label": "Column 3",
           "lastUpdated": "${json-unit.matches:offsetDateTime}",
+          "columnNumber": 2,
           "referenceDataType": {
             "id": "${json-unit.matches:id}",
             "label": "string",
@@ -75,6 +78,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -109,6 +113,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -143,6 +148,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -177,6 +183,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -211,6 +218,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -245,6 +253,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -279,6 +288,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -313,6 +323,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -347,6 +358,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -381,6 +393,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -415,6 +428,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -449,6 +463,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -483,6 +498,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -517,6 +533,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -551,6 +568,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -585,6 +603,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -619,6 +638,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -653,6 +673,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -687,6 +708,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -721,6 +743,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -755,6 +778,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -789,6 +813,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -823,6 +848,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -857,6 +883,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -891,6 +918,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -925,6 +953,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -959,6 +988,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -993,6 +1023,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 0,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -1027,6 +1058,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 1,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -1061,6 +1093,7 @@
                 "finalised": false
               }
             ],
+            "columnNumber": 2,
             "referenceDataType": {
               "id": "${json-unit.matches:id}",
               "domainType": "ReferencePrimitiveType",
@@ -1085,7 +1118,7 @@
       "exporter": {
         "namespace": "uk.ac.ox.softeng.maurodatamapper.referencedata.provider.exporter",
         "name": "ReferenceDataJsonExporterService",
-        "version": "3.0"
+        "version": "4.0"
       }
     }
   }

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValues.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValues.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -51,6 +52,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -84,6 +86,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 2,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -117,6 +120,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -150,6 +154,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -183,6 +188,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 2,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -216,6 +222,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -249,6 +256,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -282,6 +290,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 2,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -315,6 +324,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValuesAsRows.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValuesAsRows.json
@@ -20,6 +20,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -53,6 +54,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -86,6 +88,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -123,6 +126,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -156,6 +160,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -189,6 +194,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -226,6 +232,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -259,6 +266,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -292,6 +300,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -329,6 +338,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -362,6 +372,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -395,6 +406,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -432,6 +444,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -465,6 +478,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -498,6 +512,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -535,6 +550,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -568,6 +584,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -601,6 +618,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -638,6 +656,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -671,6 +690,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -704,6 +724,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -741,6 +762,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -774,6 +796,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -807,6 +830,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -844,6 +868,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -877,6 +902,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -910,6 +936,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -947,6 +974,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -980,6 +1008,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -1013,6 +1042,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValuesAsRowsMax.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValuesAsRowsMax.json
@@ -20,6 +20,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -53,6 +54,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -86,6 +88,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -123,6 +126,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -156,6 +160,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -189,6 +194,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValuesMax.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedGetValuesMax.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 0,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",
@@ -51,6 +52,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedSearchValuesRow6.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedSearchValuesRow6.json
@@ -18,6 +18,7 @@
             "finalised": false
           }
         ],
+        "columnNumber": 1,
         "referenceDataType": {
           "id": "${json-unit.matches:id}",
           "domainType": "ReferencePrimitiveType",

--- a/mdm-testing-functional/src/integration-test/resources/referencedata/expectedSearchValuesRow6AsRows.json
+++ b/mdm-testing-functional/src/integration-test/resources/referencedata/expectedSearchValuesRow6AsRows.json
@@ -20,6 +20,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 0,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -53,6 +54,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 1,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",
@@ -86,6 +88,7 @@
                   "finalised": false
                 }
               ],
+              "columnNumber": 2,
               "referenceDataType": {
                 "id": "${json-unit.matches:id}",
                 "domainType": "ReferencePrimitiveType",


### PR DESCRIPTION
To ensure that after importing a reference data CSV file the data can be displayed in the same column order as the input file:
- add a zero-based columnNumber property to ReferenceDataElement
- add database migration script which adds this column, sets the value to 0 for all existing values, and then makes the column not null. Ordering is not applied to existing reference data elements
- change CSV importer to set columnNumber as it iterates through the column headers
- update all importers and exporters (CSV, JSON, XML) from assorted versions 3.0, 3.1 to a consistent 4.0 in all cases
- add a version 4.0 xsd for the XML export
- add columnNumber property to various .gson and .gml, including in the exporters
- in cases where it is necessary (API to list ReferenceDataElements and API to list ReferenceDataValues in row format, both of which are consumed by the UI and which I think makes an assumption that results are sorted) ensure that the results are sorted by the new columnNumber attribute. In other places where it seems not necessary, the results are not sorted (but a consumer could choose to sort by the columnNumber property)
- update lots of test data and specs

Also ran some informal tests with the UI to check results are ordered as expected.