### PR TITLE
Don't generate an empty asset manifest file for mdm-plugin-profile (Solves #185)

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyService.groovy
@@ -17,6 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core.admin
 
+// import asset.pipeline.AssetPipelineConfigHolder
 import uk.ac.ox.softeng.maurodatamapper.security.User
 
 import asset.pipeline.grails.AssetResourceLocator
@@ -177,6 +178,27 @@ class ApiPropertyService {
 
     void loadDefaultPropertiesIntoDatabase(User createdBy) {
         log.info('Loading default API properties')
+
+
+        // TODO: Once we're happy that this issue has been solved, the extra logging can be removed
+/*        log.info("Class Search Directories: ")
+        assetResourceLocator.classSearchDirectories.each {
+            log.info(it)
+        }
+        log.info("Resource Search Directories: ")
+        assetResourceLocator.resourceSearchDirectories.each {
+            log.info(it)
+        }
+        log.info("Plugin List: ")
+        assetResourceLocator.pluginManager.pluginList.each {
+            log.info(it.toString())
+        }
+        log.info("Manifest properties found: ")
+        log.info(AssetPipelineConfigHolder.manifest.toString())
+
+        log.info("Is war: " + assetResourceLocator.warDeployed)
+        log.info(assetResourceLocator.defaultResourceLoader.toString())
+*/
         Resource resource = assetResourceLocator.findAssetForURI('defaults.properties')
         try {
             if (resource?.exists()) {
@@ -199,6 +221,8 @@ class ApiPropertyService {
                 } catch (FileNotFoundException ignored) {
                     log.warn('URL loading of API defaults file failed as asset not found')
                 }
+            } else {
+                log.error("Cannot find the defaults.properties file")
             }
         } catch (IOException e) {
             log.error('Something went wrong trying to load default API Properties', e)

--- a/mdm-plugin-profile/build.gradle
+++ b/mdm-plugin-profile/build.gradle
@@ -26,7 +26,7 @@ apply plugin: "org.grails.grails-plugin"
 apply plugin: "org.grails.grails-plugin-publish"
 apply plugin: "org.grails.plugins.views-json"
 apply plugin: "org.grails.plugins.views-markup"
-apply plugin: "com.bertramlabs.asset-pipeline"
+//apply plugin: "com.bertramlabs.asset-pipeline"
 
 apply plugin: 'ox.softeng.grails'
 


### PR DESCRIPTION
Don't use the gradle asset pipeline plugin, so don't generate an empty assets `manifest.properties` file, which causes asset loading to barf in some circumstances