### PR TITLE
Feature/gh 187

### DIFF
--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -417,6 +417,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         DataClass.byDataModelId(dataModelId).eq('label', label).find()
     }
 
+    DataClass findByDataModelIdAndNullParentDataClassAndLabel(UUID dataModelId, String label) {
+        DataClass.byDataModelId(dataModelId).isNull('parentDataClass').eq('label', label).find()
+    }
+
     DataClass findWhereRootDataClassOfDataModelIdAndId(UUID dataModelId, Serializable id) {
         DataClass.byRootDataClassOfDataModelId(dataModelId).idEq(id).find()
     }
@@ -821,7 +825,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
      */
     @Override
     DataClass findByParentIdAndLabel(UUID parentId, String label) {
-        DataClass dataClass = findByDataModelIdAndLabel(parentId, label)
+        DataClass dataClass = findByDataModelIdAndNullParentDataClassAndLabel(parentId, label)
         if (!dataClass) {
             dataClass = DataClass.byParentDataClassId(parentId).eq('label', label).get()
         }

--- a/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/merge/DataModelPluginMergeBuilder.groovy
+++ b/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/merge/DataModelPluginMergeBuilder.groovy
@@ -192,7 +192,8 @@ class DataModelPluginMergeBuilder extends BaseTestMergeBuilder {
             modifyAndModifyReturningDifference  : getIdFromPath(target, "${pathing}dm:Functional Test DataModel ${suffix}\$main|dc:modifyAndModifyReturningDifference"),
             deleteLeftOnly                      : getIdFromPath(target, "${pathing}dm:Functional Test DataModel ${suffix}\$main|dc:deleteLeftOnly"),
             modifyLeftOnly                      : getIdFromPath(target, "${pathing}dm:Functional Test DataModel ${suffix}\$main|dc:modifyLeftOnly"),
-            deleteLeftOnlyFromExistingClass     : getIdFromPath(target, "${pathing}dm:Functional Test DataModel ${suffix}\$main|dc:deleteLeftOnlyFromExistingClass"),
+            deleteLeftOnlyFromExistingClass     :
+                    getIdFromPath(target, "${pathing}dm:Functional Test DataModel ${suffix}\$main|dc:existingClass|dc:deleteLeftOnlyFromExistingClass"),
             metadataModifyAndDelete             : getIdFromPath(target, "${pathing}dm:Functional Test DataModel ${suffix}\$main|md:functional.test.modifyAndDelete"),
         ]
 


### PR DESCRIPTION
Closes #187 

- Add a failing test to reproduce the bug
- Fix by testing that parentDataClass is null when looking for a data class by data model ID and label
- Make a change to DataModelPluginMergeBuilder which looks like a bug only revealed by the above fix