### PR TITLE
Feature/gh 192

### DIFF
--- a/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/container/Folder.groovy
+++ b/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/container/Folder.groovy
@@ -190,7 +190,11 @@ class Folder implements Container, Diffable<Folder> {
     }
 
     static DetachedCriteria<Folder> byParentFolderIdAndLabel(UUID id, String label) {
-        byParentFolderId(id).eq('label', label)
+        if (id) {
+            byParentFolderId(id).eq('label', label)
+        } else {
+            byNoParentFolder().eq('label', label)
+        }
     }
 
     static Folder getMiscellaneousFolder() {

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/FolderFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/FolderFunctionalSpec.groovy
@@ -276,6 +276,22 @@ class FolderFunctionalSpec extends ResourceFunctionalSpec<Folder> {
         cleanUpData(id)
     }
 
+    void 'test can retrieve by valid path'() {
+        given:
+        def id = createNewItem(validJson)
+        def path = 'Functional%20Test%20Folder'
+
+        when:
+        GET("path/fo:${path}")
+
+        then:
+        verifyResponse HttpStatus.OK, response
+        responseBody().label == 'Functional Test Folder'
+
+        cleanup:
+        cleanUpData(id)
+    }
+
     void 'test searching for label "test" in empty folder using POST'() {
         given:
         def id = createNewItem(validJson)

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/NestedFolderFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/NestedFolderFunctionalSpec.groovy
@@ -221,4 +221,47 @@ class NestedFolderFunctionalSpec extends ResourceFunctionalSpec<Folder> {
         then: 'The response is correct'
         response.status == HttpStatus.NO_CONTENT
     }
+
+    void 'test can retrieve by valid path'() {
+        given:
+        def pathParent = 'Parent%20Functional%20Test%20Folder'
+        def pathNested = 'Functional%20Test%20Folder'
+
+        when: 'The save action is executed with valid data'
+        POST('', validJson)
+
+        then: 'The response is correct'
+        response.status == HttpStatus.CREATED
+        String id = response.body().id
+
+        when: 'Retrieve by path of parent folder'
+        GET("folders/path/fo:${pathParent}", MAP_ARG, true)
+
+        then: 'The parent folder is found'
+        verifyResponse HttpStatus.OK, response
+        responseBody().label == 'Parent Functional Test Folder'
+
+        when: 'Retrieve nested folder by path of nested folder only'
+        GET("folders/path/fo:${pathNested}", MAP_ARG, true)
+
+        then: 'The nested folder is not found'
+        verifyResponse HttpStatus.NOT_FOUND, response
+
+        when: 'Retrieve nested folder by path of nested folder and parent folder'
+        GET("folders/path/fo:${pathParent}%7cfo:${pathNested}", MAP_ARG, true)
+
+        then: 'The nested folder is found'
+        verifyResponse HttpStatus.OK, response
+        responseBody().label == 'Functional Test Folder'
+
+        when: 'Retrieve nested folder by path of nested folder and ID of parent folder'
+        GET("folders/${parentFolderId}/path/fo:${pathNested}", MAP_ARG, true)
+
+        then: 'The nested folder is found'
+        verifyResponse HttpStatus.OK, response
+        responseBody().label == 'Functional Test Folder'
+
+        cleanup:
+        DELETE(getDeleteEndpoint(id))
+    }
 }


### PR DESCRIPTION
Closes #192

- When retrieving a folder by path, handle a null parent id
- Add tests for path retrieval of folder and nested folder