### PR TITLE
gh-180 add filtering by namespace (ns), key and value

### DIFF
--- a/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/facet/Metadata.groovy
+++ b/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/facet/Metadata.groovy
@@ -158,8 +158,13 @@ class Metadata implements MultiFacetItemAware, Diffable<Metadata> {
         new DetachedCriteria<Metadata>(Metadata)
     }
 
-    static DetachedCriteria<Metadata> byMultiFacetAwareItemId(Serializable multiFacetAwareItemId) {
-        new DetachedCriteria<Metadata>(Metadata).eq('multiFacetAwareItemId', Utils.toUuid(multiFacetAwareItemId))
+    static DetachedCriteria<Metadata> byMultiFacetAwareItemId(Serializable multiFacetAwareItemId, Map filters = [:]) {
+        DetachedCriteria criteria = new DetachedCriteria<Metadata>(Metadata).eq('multiFacetAwareItemId', Utils.toUuid(multiFacetAwareItemId))
+        if (filters) {
+            criteria = withFilter(criteria, filters)
+        }
+
+        criteria
     }
 
     static DetachedCriteria<Metadata> byMultiFacetAwareItemIdInList(List<UUID> multiFacetAwareItemIds) {
@@ -186,8 +191,13 @@ class Metadata implements MultiFacetItemAware, Diffable<Metadata> {
         byMultiFacetAwareItemId(multiFacetAwareItemId).eq('namespace', namespace)
     }
 
-    static DetachedCriteria<Metadata> byMultiFacetAwareItemIdAndNotNamespaces(Serializable multiFacetAwareItemId, List<String> namespaces) {
-        byMultiFacetAwareItemId(multiFacetAwareItemId).not {inList('namespace', namespaces)}
+    static DetachedCriteria<Metadata> byMultiFacetAwareItemIdAndNotNamespaces(Serializable multiFacetAwareItemId, List<String> namespaces, Map filters = [:]) {
+        DetachedCriteria criteria = byMultiFacetAwareItemId(multiFacetAwareItemId).not {inList('namespace', namespaces)}
+        if (filters) {
+            criteria = withFilter(criteria, filters)
+        }
+
+        criteria
     }
 
 

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/MetadataService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/MetadataService.groovy
@@ -191,9 +191,9 @@ class MetadataService implements MultiFacetItemAwareService<Metadata> {
 
     List<Metadata> findAllByMultiFacetAwareItemIdAndNotNamespaces(UUID multiFacetAwareItemId, List<String> namespaces, Map pagination = [:]) {
         if (!namespaces || namespaces.size() == 0) {
-            return Metadata.byMultiFacetAwareItemId(multiFacetAwareItemId).list(pagination)
+            return Metadata.byMultiFacetAwareItemId(multiFacetAwareItemId, pagination).list(pagination)
         }
-        Metadata.byMultiFacetAwareItemIdAndNotNamespaces(multiFacetAwareItemId, namespaces).list(pagination)
+        Metadata.byMultiFacetAwareItemIdAndNotNamespaces(multiFacetAwareItemId, namespaces, pagination).list(pagination)
     }
 
     List<NamespaceKeys> findNamespaceKeysIlikeNamespace(String namespacePrefix) {

--- a/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/ProfileFunctionalSpec.groovy
@@ -321,6 +321,108 @@ class ProfileFunctionalSpec extends BaseFunctionalSpec {
 '''
     }
 
+    void 'test getting with filters other properties on a datamodel'() {
+        given:
+        String id = getComplexDataModelId()
+
+        when: 'filter with a namespace that matches all three properties'
+        GET("dataModels/${id}/profiles/otherMetadata?ns=test.com", STRING_ARG)
+
+        then: 'all three properties are returned'
+        verifyJsonResponse OK, '''
+{
+    "count": 3,
+    "items": [{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com",
+        "key":"mdk1",
+        "value":"mdv1",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    },{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com",
+        "key":"mdk2",
+        "value":"mdv2",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    },{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com/test",
+        "key":"mdk1",
+        "value":"mdv2",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    }
+]}
+'''
+
+        when: 'filter with a namespace that matches just one property'
+        GET("dataModels/${id}/profiles/otherMetadata?ns=test.com/test", STRING_ARG)
+
+        then: 'the one matching property is returned'
+        verifyJsonResponse OK, '''
+{
+    "count": 1,
+    "items": [{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com/test",
+        "key":"mdk1",
+        "value":"mdv2",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    }
+]}
+'''
+
+        when: 'filter by namespace and key'
+        GET("dataModels/${id}/profiles/otherMetadata?ns=test.com&key=mdk1", STRING_ARG)
+
+        then: 'two matching properties are returned'
+        verifyJsonResponse OK, '''
+{
+    "count": 2,
+    "items": [{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com",
+        "key":"mdk1",
+        "value":"mdv1",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    },{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com/test",
+        "key":"mdk1",
+        "value":"mdv2",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    }
+]}
+'''
+
+        when: 'filter by namespace and key and value'
+        GET("dataModels/${id}/profiles/otherMetadata?ns=test.com&key=mdk1&value=mdv2", STRING_ARG)
+
+        then: 'the one matching property is returned'
+        verifyJsonResponse OK, '''
+{
+    "count": 1,
+    "items": [{
+        "id":"${json-unit.matches:id}",
+        "namespace":"test.com/test",
+        "key":"mdk1",
+        "value":"mdv2",
+        "lastUpdated":"${json-unit.matches:offsetDateTime}"
+    }
+]}
+'''
+
+        when: 'filter by namespace and key and value that do not match'
+        GET("dataModels/${id}/profiles/otherMetadata?ns=test.com&key=mdk1&value=mdv3", STRING_ARG)
+
+        then: 'no properties are returned'
+        verifyJsonResponse OK, '''
+{
+    "count": 0,
+    "items": [
+]}
+'''
+    }
+
     void 'test getting other properties on a folder'() {
         given:
         String id = folder.id.toString()


### PR DESCRIPTION
Closes #180 

Add optional filtering by namespace, key and value to queries used when retrieving metadata.

This enables the endpoint ```/dataModels/${id}/profiles/otherMetadata``` to be used, for example, as follows:

```/dataModels/${id}/profiles/otherMetadata?ns=mynamespace&key=mykey&value=myvalue```

