### PR TITLE
Feature/gh 208 Set the domainId for a BreadcrumbTree on Enumeration Value

### DIFF
--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
@@ -262,6 +262,17 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
     }
 
     @Override
+    void checkBreadcrumbTreeAfterSavingCatalogueItem(DataType dataType) {
+        super.checkBreadcrumbTreeAfterSavingCatalogueItem(dataType)
+
+        if (dataType.instanceOf(EnumerationType)) {
+            dataType.enumerationValues.each { enumerationValue ->
+                super.checkBreadcrumbTreeAfterSavingCatalogueItem(enumerationValue)
+            }
+        }
+    }
+
+    @Override
     DataType updateFacetsAfterInsertingCatalogueItem(DataType dataType) {
         if (dataType.instanceOf(EnumerationType)) {
             enumerationTypeService.updateFacetsAfterInsertingCatalogueItem(dataType as EnumerationType)

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/test/provider/DataBindDataModelImporterProviderServiceSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/test/provider/DataBindDataModelImporterProviderServiceSpec.groovy
@@ -403,6 +403,8 @@ abstract class DataBindDataModelImporterProviderServiceSpec<K extends DataBindDa
         !val2.metadata
         !val1.annotations
         !val2.annotations
+        val1.breadcrumbTree.domainId
+        val2.breadcrumbTree.domainId
 
     }
 


### PR DESCRIPTION
Closes #208 

When importing a Data Model, the BreadCrumb tree is set for Enumeration Values.