### PR TITLE
Feature/gh 209 - fix profile sort

### DIFF
--- a/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
+++ b/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
@@ -62,7 +62,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUsedProfileServices(multiFacetAware)
+        respond profileProviderServices: profileService.getUsedProfileServices(multiFacetAware, true)
     }
 
     def unusedProfiles() {
@@ -71,7 +71,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware)
+        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true)
     }
 
     def nonProfileMetadata() {

--- a/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/ProfileFunctionalSpec.groovy
@@ -750,6 +750,12 @@ class ProfileFunctionalSpec extends BaseFunctionalSpec {
         verifyResponse(OK, response)
 
         when:
+        PUT("dataModels/$dynamicProfileModelId/finalise", [versionChangeType: 'Major', versionTag: 'Functional Test Version Tag'])
+
+        then:
+        verifyResponse OK, response
+
+        when:
         Map optionalFieldMap = [
             fieldName   : 'Dynamic Profile Elem (Optional)',
             currentValue: 'abc'

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/provider/DynamicJsonProfileProviderService.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/provider/DynamicJsonProfileProviderService.groovy
@@ -43,7 +43,7 @@ class DynamicJsonProfileProviderService extends JsonProfileProviderService {
         this.dataModelId = dataModel.id
         this.dataModelLabel = dataModel.label
         this.dataModelDescription = dataModel.description
-        this.dataModelVersion = dataModel.modelVersionTag ?: dataModel.modelVersion ?: dataModel.branchName
+        this.dataModelVersion = dataModel.modelVersion ?: 'SNAPSHOT'
     }
 
     @Override

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
@@ -195,8 +195,10 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         ]
 
         POST("profiles/${profileSpecificationProfileService.namespace}/${profileSpecificationProfileService.name}/dataModels/${dynamicProfileModelId}", profileMap)
-
         verifyResponse(OK, response)
+
+        PUT("dataModels/$dynamicProfileModelId/finalise", [versionChangeType: 'Major', versionTag: 'Functional Test Version Tag'])
+        verifyResponse OK, response
 
         logout()
 
@@ -278,8 +280,10 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         ]
 
         POST("profiles/${profileSpecificationProfileService.namespace}/${profileSpecificationProfileService.name}/dataModels/${dynamicProfileModelId}", profileMap)
-
         verifyResponse(OK, response)
+
+        PUT("dataModels/$dynamicProfileModelId/finalise", [versionChangeType: 'Major'])
+        verifyResponse OK, response
 
         logout()
 
@@ -1070,6 +1074,12 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, response)
+
+        when: 'the dynamic profile data model is finalised'
+        PUT("dataModels/$dynamicProfileModelId/finalise", [versionChangeType: 'Major'])
+
+        then: 'the response is OK'
+        verifyResponse OK, response
 
         when:
         Map optionalFieldMap = [
@@ -2529,8 +2539,20 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         String simpleModelId = getDataModelId()
         String profileModelId = getDynamicProfileModelId()
         loginEditor()
-        PUT("dataModels/$profileModelId/finalise", [versionChangeType: 'Major', versionTag: 'Functional Test Version Tag'])
-        verifyResponse OK, response
+
+        when: 'count the used profiles on the simple data model'
+        HttpResponse<List<Map>> localResponse = GET("dataModels/${simpleModelId}/profiles/used", Argument.listOf(Map))
+
+        then: 'the result is 0'
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 0
+
+        when: 'get the unused profiles on the simple data model'
+        localResponse = GET("dataModels/${simpleModelId}/profiles/unused", Argument.listOf(Map))
+
+        then: '1 of these is for the Dynamic Profile Model'
+        verifyResponse(OK, localResponse)
+        localResponse.body().findAll{it.displayName == 'Dynamic Profile Model'}.size() == 1
 
         when: 'get the finalised profile against the simple data model'
         GET("dataModels/$simpleModelId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic+Profile+Model", STRING_ARG)
@@ -2545,11 +2567,25 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         verifyResponse CREATED, response
         String profileModelVersion2Id = response.body().id
 
+        when: 'get the unused profiles on the simple data model'
+        localResponse = GET("dataModels/${simpleModelId}/profiles/unused", Argument.listOf(Map))
+
+        then: 'still 1 of these is for the Dynamic Profile Model'
+        verifyResponse(OK, localResponse)
+        localResponse.body().findAll{it.displayName == 'Dynamic Profile Model'}.size() == 1
+
         when: 'finalise the new branch model version'
         PUT("dataModels/$profileModelVersion2Id/finalise", [versionChangeType: 'Major', versionTag: 'Functional Test Second Version Tag'])
 
         then: 'the response is OK'
         verifyResponse OK, response
+
+        when: 'get the unused profiles on the simple data model'
+        localResponse = GET("dataModels/${simpleModelId}/profiles/unused", Argument.listOf(Map))
+
+        then: 'now 2 of these are for the Dynamic Profile Model, because we get the finalised profile branch'
+        verifyResponse(OK, localResponse)
+        localResponse.body().findAll{it.displayName == 'Dynamic Profile Model'}.size() == 2
 
         when: 'get the finalised profile against the simple data model now that there are two versions of the profile'
         GET("dataModels/$simpleModelId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic+Profile+Model", MAP_ARG)


### PR DESCRIPTION
- Fix the way profiles are sorted, so that when a profile having two versions, each with version tags, is retrieved by namespace and name only, the most recent semantic version is retrieved.
- Exclude non-finalised dynamic profiles from the profiles listed at the ```/{multiFacetAwareItemDomainType}/{multiFacetAwareItemId}/profiles/used``` and ```/{multiFacetAwareItemDomainType}/{multiFacetAwareItemId}/profiles/unused``` endpoints