### PR TITLE
Feature/gh 70 - Copy Summary Metadata to new model version

### DIFF
--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementController.groovy
@@ -69,7 +69,7 @@ class DataElementController extends CatalogueItemController<DataElement> {
         if (!originalDataElement) return notFound(params.dataElementId)
         DataElement copy
         try {
-            copy = dataElementService.copyDataElement(destinationDataModel, originalDataElement, currentUser, currentUserSecurityPolicyManager, copyInformation)
+            copy = dataElementService.copyDataElement(destinationDataModel, originalDataElement, currentUser, currentUserSecurityPolicyManager, false, copyInformation)
             destinationDataClass.addToDataElements(copy)
             dataClassService.matchUpAndAddMissingReferenceTypeClasses(destinationDataModel, sourceDataModel, currentUser,
                                                                       currentUserSecurityPolicyManager)

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -618,14 +618,14 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
         if (original.dataTypes) {
             // Copy all the datatypes
             original.dataTypes.each { dt ->
-                dataTypeService.copyDataType(copy, dt, copier, userSecurityPolicyManager)
+                dataTypeService.copyDataType(copy, dt, copier, userSecurityPolicyManager, copySummaryMetadata)
             }
         }
 
         if (original.childDataClasses) {
             // Copy all the dataclasses (this will also match up the reference types)
             original.childDataClasses.each { dc ->
-                dataClassService.copyDataClass(copy, dc, copier, userSecurityPolicyManager)
+                dataClassService.copyDataClass(copy, dc, copier, userSecurityPolicyManager, null, copySummaryMetadata, null)
             }
         }
 
@@ -647,9 +647,7 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
                                            boolean copySummaryMetadata) {
         copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager) as DataModel
         if (copySummaryMetadata) {
-            summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {
-                copy.addToSummaryMetadata(label: it.label, summaryMetadataType: it.summaryMetadataType, createdBy: copier.emailAddress)
-            }
+            copy = copySummaryMetadataFromOriginal(original, copy, copier)
         }
         copy
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -640,11 +640,11 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
         copy.dataClasses = []
         original.dataClasses.each {child ->
-            copy.addToDataClasses(copyDataClass(copiedDataModel, child, copier, userSecurityPolicyManager))
+            copy.addToDataClasses(copyDataClass(copiedDataModel, child, copier, userSecurityPolicyManager, null, copySummaryMetadata, null))
         }
         copy.dataElements = []
         original.dataElements.each {element ->
-            copy.addToDataElements(dataElementService.copyDataElement(copiedDataModel, element, copier, userSecurityPolicyManager))
+            copy.addToDataElements(dataElementService.copyDataElement(copiedDataModel, element, copier, userSecurityPolicyManager, copySummaryMetadata))
         }
 
         copy
@@ -658,9 +658,7 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
 
         copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
         if (copySummaryMetadata) {
-            summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {
-                copy.addToSummaryMetadata(label: it.label, summaryMetadataType: it.summaryMetadataType, createdBy: copier.emailAddress)
-            }
+            copy = copySummaryMetadataFromOriginal(original, copy, copier)
         }
         copy
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -356,11 +356,12 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
     }
 
     DataElement copyDataElement(DataModel copiedDataModel, DataElement original, User copier,
-                                UserSecurityPolicyManager userSecurityPolicyManager, CopyInformation copyInformation = new CopyInformation()) {
+                                UserSecurityPolicyManager userSecurityPolicyManager, boolean copySummaryMetadata = false,
+                                CopyInformation copyInformation = new CopyInformation()) {
         DataElement copy = new DataElement(minMultiplicity: original.minMultiplicity,
                                            maxMultiplicity: original.maxMultiplicity)
 
-        copy = copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
+        copy = copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copySummaryMetadata, copyInformation)
         setCatalogueItemRefinesCatalogueItem(copy, original, copier)
 
         DataType dataType = copiedDataModel.findDataTypeByLabel(original.dataType.label)
@@ -380,12 +381,11 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
                                              DataElement copy,
                                              User copier,
                                              UserSecurityPolicyManager userSecurityPolicyManager,
-                                             boolean copySummaryMetadata, CopyInformation copyInformation) {
+                                             boolean copySummaryMetadata,
+                                             CopyInformation copyInformation) {
         copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
         if (copySummaryMetadata) {
-            summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {
-                copy.addToSummaryMetadata(label: it.label, summaryMetadataType: it.summaryMetadataType, createdBy: copier.emailAddress)
-            }
+            copySummaryMetadataFromOriginal(original, copy, copier)
         }
         copy
     }
@@ -394,7 +394,8 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
     DataElement copyCatalogueItemInformation(DataElement original,
                                              DataElement copy,
                                              User copier,
-                                             UserSecurityPolicyManager userSecurityPolicyManager, CopyInformation copyInformation) {
+                                             UserSecurityPolicyManager userSecurityPolicyManager,
+                                             CopyInformation copyInformation) {
         copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, false, copyInformation)
     }
 

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
@@ -425,9 +425,7 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
                                           copyInformation = new CopyInformation()) {
         copy = super.copyCatalogueItemInformation(original, copy, copier, userSecurityPolicyManager, copyInformation)
         if (copySummaryMetadata) {
-            summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {
-                copy.addToSummaryMetadata(label: it.label, summaryMetadataType: it.summaryMetadataType, createdBy: copier.emailAddress)
-            }
+            copy = copySummaryMetadataFromOriginal(original, copy, copier)
         }
         copy
     }

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelServiceIntegrationSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelServiceIntegrationSpec.groovy
@@ -32,6 +32,9 @@ import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.ObjectPatchDat
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.legacy.ItemPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.legacy.LegacyFieldPatchData
 import uk.ac.ox.softeng.maurodatamapper.datamodel.bootstrap.BootstrapModels
+import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadata
+import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadataType
+import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.summarymetadata.SummaryMetadataReport
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClass
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClassService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataElement
@@ -46,10 +49,12 @@ import uk.ac.ox.softeng.maurodatamapper.version.Version
 
 import grails.gorm.transactions.Rollback
 import grails.testing.mixin.integration.Integration
+import groovy.json.JsonBuilder
 import groovy.util.logging.Slf4j
 import org.spockframework.util.Assert
 import spock.lang.PendingFeature
 
+import java.time.OffsetDateTime
 import java.util.function.Predicate
 
 @Slf4j
@@ -76,7 +81,6 @@ class DataModelServiceIntegrationSpec extends BaseDataModelIntegrationSpec {
                                              authority: testAuthority)
         DataModel dataModel3 = new DataModel(createdByUser: editor, label: 'test standard', type: DataModelType.DATA_STANDARD, folder: testFolder,
                                              authority: testAuthority)
-
         checkAndSave(dataModel1)
         checkAndSave(dataModel2)
         checkAndSave(dataModel3)
@@ -89,6 +93,71 @@ class DataModelServiceIntegrationSpec extends BaseDataModelIntegrationSpec {
         checkAndSave(dataModel1)
 
         id = dataModel1.id
+    }
+
+    void setupDataModelWithSummaryMetadata() {
+        DataModel dataModel = new DataModel(createdByUser: editor, label: 'Data Model having Summary Metadata', type: DataModelType.DATA_ASSET, folder: testFolder,
+            authority: testAuthority)
+
+        checkAndSave(dataModel)
+
+        // Add summary metadata with report to data model
+        SummaryMetadata dataModelSummaryMetadata = new SummaryMetadata(label: 'Data Model Summary Metadata', createdBy: editor.emailAddress,
+            summaryMetadataType: SummaryMetadataType.MAP)
+        SummaryMetadataReport dataModelSummaryMetadataReport = new SummaryMetadataReport(
+            reportDate: OffsetDateTime.now(),
+            reportValue: new JsonBuilder([A: 1, B: 2]).toString(),
+            createdBy: editor.emailAddress
+        )
+        dataModelSummaryMetadata.addToSummaryMetadataReports(dataModelSummaryMetadataReport)
+        dataModel.addToSummaryMetadata(dataModelSummaryMetadata)
+
+        // Add summary metadata with report to data type
+        DataType dataType = new PrimitiveType(createdByUser: admin, label: 'Data Type having Summary Metadata')
+        dataModel.addToDataTypes(dataType)
+        checkAndSave(dataModel)
+        SummaryMetadata dataTypeSummaryMetadata = new SummaryMetadata(label: 'Data Type Summary Metadata', createdBy: editor.emailAddress,
+            summaryMetadataType: SummaryMetadataType.MAP)
+        SummaryMetadataReport dataTypeSummaryMetadataReport = new SummaryMetadataReport(
+            reportDate: OffsetDateTime.now(),
+            reportValue: new JsonBuilder([A: 1, B: 2]).toString(),
+            createdBy: editor.emailAddress
+        )
+        dataTypeSummaryMetadata.addToSummaryMetadataReports(dataTypeSummaryMetadataReport)
+        dataType.addToSummaryMetadata(dataTypeSummaryMetadata)
+
+        // Add summary metadata with report to data class
+        DataClass dataClass = new DataClass(createdByUser: editor, label: 'Data Class having Summary Metadata', dataModel: dataModel)
+        checkAndSave(dataClass)
+        SummaryMetadata dataClassSummaryMetadata = new SummaryMetadata(label: 'Data Class Summary Metadata', createdBy: editor.emailAddress,
+            summaryMetadataType: SummaryMetadataType.MAP)
+        SummaryMetadataReport dataClassSummaryMetadataReport = new SummaryMetadataReport(
+            reportDate: OffsetDateTime.now(),
+            reportValue: new JsonBuilder([A: 1, B: 2]).toString(),
+            createdBy: editor.emailAddress
+        )
+        dataClassSummaryMetadata.addToSummaryMetadataReports(dataClassSummaryMetadataReport)
+        dataClass.addToSummaryMetadata(dataClassSummaryMetadata)
+
+        dataModel.addToDataClasses(dataClass)
+        checkAndSave(dataModel)
+
+        // Add summary metadata with report to data element
+        DataElement dataElement = new DataElement(createdByUser: editor, label: 'Data Element having Summary Metadata', dataType: dataType)
+        dataClass.addToDataElements(dataElement)
+        checkAndSave(dataElement)
+
+        SummaryMetadata dataElementSummaryMetadata = new SummaryMetadata(label: 'Data Element Summary Metadata', createdBy: editor.emailAddress,
+            summaryMetadataType: SummaryMetadataType.MAP)
+        SummaryMetadataReport dataElementSummaryMetadataReport = new SummaryMetadataReport(
+            reportDate: OffsetDateTime.now(),
+            reportValue: new JsonBuilder([A: 1, B: 2]).toString(),
+            createdBy: editor.emailAddress
+        )
+        dataElementSummaryMetadata.addToSummaryMetadataReports(dataElementSummaryMetadataReport)
+        dataElement.addToSummaryMetadata(dataElementSummaryMetadata)
+
+        checkAndSave(dataModel)
     }
 
     protected DataModel checkAndSaveNewVersion(DataModel dataModel) {
@@ -1887,6 +1956,47 @@ class DataModelServiceIntegrationSpec extends BaseDataModelIntegrationSpec {
         then:
         ele2Res
         ele2Res.size() == 0
+    }
+
+    void 'test summary metadata is copied to new version'() {
+        given:
+        setupData()
+        setupDataModelWithSummaryMetadata()
+        DataModel dataModel4 = dataModelService.findByLabel('Data Model having Summary Metadata')
+
+        when: 'finalising model and then creating a new doc version is allowed'
+        DataModel dataModel = getAndFinaliseDataModel(dataModel4.id)
+        def result = dataModelService.
+            createNewBranchModelVersion(VersionAwareConstraints.DEFAULT_BRANCH_NAME, dataModel, editor, false, editorSecurityPolicyManager, [
+                moveDataFlows: false,
+                throwErrors  : true
+            ])
+
+        then:
+        checkAndSaveNewVersion(result)
+
+        when: 'load new branch from DB'
+        DataModel newBranch = dataModelService.get(result.id)
+
+        then: 'there is summary metadata on the branch Data Model'
+        newBranch.summaryMetadata.find {it.label == 'Data Model Summary Metadata'}
+        SummaryMetadata foundDataModelSummaryMetadata = newBranch.summaryMetadata.find {it.label == 'Data Model Summary Metadata'}
+        foundDataModelSummaryMetadata.summaryMetadataReports.size() == 1
+
+        and: 'there is summary metadata on the Data Class'
+        DataClass dc = newBranch.childDataClasses.find{it.label =='Data Class having Summary Metadata'}
+        SummaryMetadata foundDataClassSummaryMetadata = dc.summaryMetadata.find {it.label == 'Data Class Summary Metadata'}
+        foundDataClassSummaryMetadata.summaryMetadataReports.size() == 1
+
+        and: 'there is summary metadata on the Data Type'
+        PrimitiveType dt = newBranch.dataTypes.find{it.label =='Data Type having Summary Metadata'}
+        SummaryMetadata foundDataTypeSummaryMetadata = dt.summaryMetadata.find {it.label == 'Data Type Summary Metadata'}
+        foundDataTypeSummaryMetadata.summaryMetadataReports.size() == 1
+
+        and: 'there is summary metadata on the Data Element'
+        DataElement de = dc.dataElements.find{it.label =='Data Element having Summary Metadata'}
+        SummaryMetadata foundDataElementSummaryMetadata = de.summaryMetadata.find {it.label == 'Data Element Summary Metadata'}
+        foundDataElementSummaryMetadata.summaryMetadataReports.size() == 1
     }
 }
 

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/traits/service/SummaryMetadataAwareService.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/traits/service/SummaryMetadataAwareService.groovy
@@ -20,7 +20,9 @@ package uk.ac.ox.softeng.maurodatamapper.datamodel.traits.service
 
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MultiFacetAwareService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadata
+import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadataAware
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadataService
+import uk.ac.ox.softeng.maurodatamapper.security.User
 
 import groovy.transform.SelfType
 
@@ -34,5 +36,31 @@ trait SummaryMetadataAwareService {
 
     void removeSummaryMetadataFromMultiFacetAware(UUID multiFacetAwareId, SummaryMetadata summaryMetadata) {
         removeFacetFromDomain(multiFacetAwareId, summaryMetadata.id, 'summaryMetadata')
+    }
+
+    /**
+     * Copy the summary metadata and summary metadata reports from original to copy
+     * @param original
+     * @param copy
+     * @param copier
+     * @return
+     */
+    SummaryMetadataAware copySummaryMetadataFromOriginal(SummaryMetadataAware original, SummaryMetadataAware copy, User copier) {
+        summaryMetadataService.findAllByMultiFacetAwareItemId(original.id).each {sm ->
+            SummaryMetadata summaryMetadata = new SummaryMetadata(label: sm.label,
+                description: sm.description,
+                summaryMetadataType: sm.summaryMetadataType,
+                createdBy: copier.emailAddress)
+
+            sm.summaryMetadataReports.each {smr ->
+                summaryMetadata.addToSummaryMetadataReports(reportDate: smr.reportDate,
+                    reportValue: smr.reportValue,
+                    createdBy: copier.emailAddress
+                )
+            }
+            copy.addToSummaryMetadata(summaryMetadata)
+        }
+
+        copy
     }
 }


### PR DESCRIPTION
Closes #70 

On New Version and New Branch, ensure that Summary Metadata against Data Model, Data Class, Data Element and Data Type is copied to the new model(s).