### PR TITLE
Separate subscribed catalogue admin endpoints

### DIFF
--- a/mdm-plugin-federation/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedCatalogueController.groovy
+++ b/mdm-plugin-federation/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedCatalogueController.groovy
@@ -48,6 +48,14 @@ class SubscribedCatalogueController extends EditLoggingController<SubscribedCata
     }
 
     @Override
+    def show() {
+        def resource = queryForResource(params.id ?: params.subscribedCatalogueId)
+        resource ? respond(resource, [model: [userSecurityPolicyManager: currentUserSecurityPolicyManager],
+                                      view : (params.openAccess ? 'show_min' : 'show')])
+                 : notFound(params.id)
+    }
+
+    @Override
     void serviceDeleteResource(SubscribedCatalogue resource) {
         subscribedCatalogueService.delete(resource)
     }

--- a/mdm-plugin-federation/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedCatalogueInterceptor.groovy
+++ b/mdm-plugin-federation/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedCatalogueInterceptor.groovy
@@ -48,7 +48,8 @@ class SubscribedCatalogueInterceptor extends SecurableResourceInterceptor {
         } else if (!currentUserSecurityPolicyManager.isAuthenticated()) {
             notFound(SubscribedCatalogue, getId())
         } else {
-            actionName == 'index' ||
+            actionName == 'index' && params.openAccess ||
+            actionName == 'show' && params.openAccess ||
             actionName == 'publishedModels' ||
             actionName == 'newerVersions' ||
             currentUserSecurityPolicyManager.isApplicationAdministrator() ?: forbiddenDueToNotApplicationAdministrator()

--- a/mdm-plugin-federation/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/federation/UrlMappings.groovy
+++ b/mdm-plugin-federation/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/federation/UrlMappings.groovy
@@ -28,12 +28,26 @@ class UrlMappings {
            */
             get "/feeds/all"(controller: 'feed', action: 'index')
 
-            '/subscribedCatalogues'(resources: 'subscribedCatalogue') {
-                get '/publishedModels'(controller: 'subscribedCatalogue', action: 'publishedModels')
-                get "/publishedModels/$publishedModelId/newerVersions"(controller: 'subscribedCatalogue', action: 'newerVersions')
-                get '/testConnection'(controller: 'subscribedCatalogue', action: 'testConnection')
-                '/subscribedModels'(resources: 'subscribedModel', excludes: DEFAULT_EXCLUDES)
-                get "/subscribedModels/$id/newerVersions"(controller: 'subscribedModel', action: 'newerVersions')
+            group '/admin', {
+                '/subscribedCatalogues'(resources: 'subscribedCatalogue') {
+                    get '/testConnection'(controller: 'subscribedCatalogue', action: 'testConnection')
+                }
+            }
+
+            group '/subscribedCatalogues', {
+                get '/'(controller: 'subscribedCatalogue', action: 'index') {
+                    openAccess = true
+                }
+                group "/$subscribedCatalogueId", {
+                    get '/'(controller: 'subscribedCatalogue', action: 'show') {
+                        openAccess = true
+                    }
+                    get '/testConnection'(controller: 'subscribedCatalogue', action: 'testConnection')
+                    get '/publishedModels'(controller: 'subscribedCatalogue', action: 'publishedModels')
+                    get "/publishedModels/$publishedModelId/newerVersions"(controller: 'subscribedCatalogue', action: 'newerVersions')
+                    '/subscribedModels'(resources: 'subscribedModel', excludes: DEFAULT_EXCLUDES)
+                    get "/subscribedModels/$id/newerVersions"(controller: 'subscribedModel', action: 'newerVersions')
+                }
             }
 
             get '/published/models'(controller: 'publish', action: 'index')

--- a/mdm-plugin-federation/grails-app/views/subscribedCatalogue/show_min.gson
+++ b/mdm-plugin-federation/grails-app/views/subscribedCatalogue/show_min.gson
@@ -1,0 +1,7 @@
+import uk.ac.ox.softeng.maurodatamapper.federation.SubscribedCatalogue
+
+model {
+    SubscribedCatalogue subscribedCatalogue
+}
+
+json tmpl.subscribedCatalogue(subscribedCatalogue)


### PR DESCRIPTION
- Move subscribed catalogue admin actions under /admin URL
- Update subscribed catalogue functional tests