### PR TITLE
Feature/mc 9577 - CatalogueUser anonymisation

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/email/EmailService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/email/EmailService.groovy
@@ -23,17 +23,19 @@ import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyService
 import uk.ac.ox.softeng.maurodatamapper.core.provider.MauroDataMapperServiceProviderService
 import uk.ac.ox.softeng.maurodatamapper.core.provider.email.EmailProviderService
 import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.InformationAware
+import uk.ac.ox.softeng.maurodatamapper.core.traits.service.AnonymisableService
 import uk.ac.ox.softeng.maurodatamapper.security.User
 
 import grails.gorm.transactions.Transactional
 import groovy.util.logging.Slf4j
 import org.apache.commons.text.StringSubstitutor
+import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 @Slf4j
-class EmailService {
+class EmailService implements AnonymisableService {
 
     MauroDataMapperServiceProviderService mauroDataMapperServiceProviderService
     ApiPropertyService apiPropertyService
@@ -104,6 +106,16 @@ class EmailService {
             .body(getApiPropertyAndSubstitute(bodyProperty, propertiesMap))
 
         executorService.submit(task)
+    }
+
+    /**
+     * Delete all emails sent to the specified address
+     * @param sentTo
+     */
+    void anonymise(String sentTo) {
+        Email.findAllBySentToEmailAddress(sentTo).each { email ->
+            email.delete()
+        }
     }
 
     @Transactional

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/EditService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/EditService.groovy
@@ -20,6 +20,7 @@ package uk.ac.ox.softeng.maurodatamapper.core.facet
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiInvalidModelException
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
 import uk.ac.ox.softeng.maurodatamapper.core.security.UserService
+import uk.ac.ox.softeng.maurodatamapper.core.traits.service.AnonymisableService
 import uk.ac.ox.softeng.maurodatamapper.security.User
 import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
@@ -29,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
 
 @Slf4j
-class EditService {
+class EditService implements AnonymisableService {
 
     @Autowired(required = false)
     UserService userService
@@ -76,5 +77,12 @@ class EditService {
         if (!edit) return null
         edit.user = userService ? userService.findUser(edit.createdBy) ?: AnonymousUser.instance : AnonymousUser.instance
         edit
+    }
+
+    void anonymise(String createdBy) {
+        Edit.findAllByCreatedBy(createdBy).each {edit ->
+            edit.createdBy = AnonymousUser.ANONYMOUS_EMAIL_ADDRESS
+            edit.save(validate: false)
+        }
     }
 }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/service/AnonymisableService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/service/AnonymisableService.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.core.traits.service
+
+/**
+ * Any service which handles a user's email address must implement AnonymisableService and
+ * provide an implementation of method "anonymise" to delete or otherwise anonymise all records
+ * containing that email address
+ */
+trait AnonymisableService {
+    abstract void anonymise(String email)
+}

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/service/DomainService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/service/DomainService.groovy
@@ -18,6 +18,7 @@
 package uk.ac.ox.softeng.maurodatamapper.core.traits.service
 
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 import uk.ac.ox.softeng.maurodatamapper.traits.domain.CreatorAware
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
@@ -29,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
-trait DomainService<K extends CreatorAware> {
+trait DomainService<K extends CreatorAware> implements AnonymisableService {
 
     @Autowired
     GrailsApplication grailsApplication
@@ -86,4 +87,12 @@ trait DomainService<K extends CreatorAware> {
 
     abstract K findByParentIdAndPathIdentifier(UUID parentId, String pathIdentifier)
 
+    void anonymise(String createdBy) {
+        getDomainClass()?.findAllByCreatedBy(createdBy).each {domain ->
+            domain.createdBy = AnonymousUser.ANONYMOUS_EMAIL_ADDRESS
+
+            // Don't validate because any existing errors in data can cause validations to fail
+            domain.save(validate: false)
+        }
+    }
 }

--- a/mdm-plugin-federation/grails-app/services/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedCatalogueService.groovy
+++ b/mdm-plugin-federation/grails-app/services/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedCatalogueService.groovy
@@ -21,7 +21,9 @@ import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiException
 import uk.ac.ox.softeng.maurodatamapper.core.authority.Authority
 import uk.ac.ox.softeng.maurodatamapper.core.authority.AuthorityService
 import uk.ac.ox.softeng.maurodatamapper.core.traits.provider.importer.XmlImportMapping
+import uk.ac.ox.softeng.maurodatamapper.core.traits.service.AnonymisableService
 import uk.ac.ox.softeng.maurodatamapper.federation.web.FederationClient
+import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 import uk.ac.ox.softeng.maurodatamapper.version.Version
 
@@ -40,7 +42,7 @@ import java.time.format.DateTimeFormatter
 
 @Transactional
 @Slf4j
-class SubscribedCatalogueService implements XmlImportMapping {
+class SubscribedCatalogueService implements XmlImportMapping, AnonymisableService {
 
     @Autowired
     HttpClientConfiguration httpClientConfiguration
@@ -192,5 +194,12 @@ class SubscribedCatalogueService implements XmlImportMapping {
         int lastPos = url.lastIndexOf(separator)
 
         return url.substring(lastPos + 1)
+    }
+
+    void anonymise(String createdBy) {
+        SubscribedCatalogue.findAllByCreatedBy(createdBy).each { subscribedCatalogue ->
+            subscribedCatalogue.createdBy = AnonymousUser.ANONYMOUS_EMAIL_ADDRESS
+            subscribedCatalogue.save(validate: false)
+        }
     }
 }

--- a/mdm-plugin-federation/grails-app/services/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedModelService.groovy
+++ b/mdm-plugin-federation/grails-app/services/uk/ac/ox/softeng/maurodatamapper/federation/SubscribedModelService.groovy
@@ -29,6 +29,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
 import uk.ac.ox.softeng.maurodatamapper.core.provider.importer.ModelImporterProviderService
 import uk.ac.ox.softeng.maurodatamapper.core.provider.importer.parameter.FileParameter
 import uk.ac.ox.softeng.maurodatamapper.core.provider.importer.parameter.ModelImporterProviderServiceParameters
+import uk.ac.ox.softeng.maurodatamapper.core.traits.service.AnonymisableService
 import uk.ac.ox.softeng.maurodatamapper.security.SecurableResourceService
 import uk.ac.ox.softeng.maurodatamapper.security.SecurityPolicyManagerService
 import uk.ac.ox.softeng.maurodatamapper.security.User
@@ -37,12 +38,13 @@ import uk.ac.ox.softeng.maurodatamapper.security.UserSecurityPolicyManager
 import grails.gorm.transactions.Transactional
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 
 import java.time.OffsetDateTime
 
 @Slf4j
 @Transactional
-class SubscribedModelService implements SecurableResourceService<SubscribedModel> {
+class SubscribedModelService implements SecurableResourceService<SubscribedModel>, AnonymisableService {
 
     @Autowired(required = false)
     List<ModelService> modelServices
@@ -323,4 +325,10 @@ class SubscribedModelService implements SecurableResourceService<SubscribedModel
         exporterMap
     }
 
+    void anonymise(String createdBy) {
+        SubscribedModel.findAllByCreatedBy(createdBy).each { subscribedModel ->
+            subscribedModel.createdBy = AnonymousUser.ANONYMOUS_EMAIL_ADDRESS
+            subscribedModel.save(validate: false)
+        }
+    }
 }

--- a/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserController.groovy
+++ b/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserController.groovy
@@ -119,7 +119,7 @@ class CatalogueUserController extends EditLoggingController<CatalogueUser> /* im
 
     @Override
     void serviceDeleteResource(CatalogueUser resource) {
-        catalogueUserService.delete(resource)
+        catalogueUserService.delete(resource, params.boolean('permanent') ?: false)
     }
 
     @Override
@@ -137,7 +137,11 @@ class CatalogueUserController extends EditLoggingController<CatalogueUser> /* im
 
     @Override
     protected void deleteResponse(CatalogueUser instance) {
-        super.updateResponse(instance)
+        if (params.boolean('permanent')) {
+            super.deleteResponse(instance)
+        } else {
+            super.updateResponse(instance)
+        }
     }
 
     @Override

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/authentication/ApiKeyService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/authentication/ApiKeyService.groovy
@@ -17,15 +17,17 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.security.authentication
 
+import uk.ac.ox.softeng.maurodatamapper.core.traits.service.AnonymisableService
 import uk.ac.ox.softeng.maurodatamapper.security.CatalogueUser
 import uk.ac.ox.softeng.maurodatamapper.security.CatalogueUserService
 
 import grails.gorm.transactions.Transactional
+import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 
 import java.time.LocalDate
 
 @Transactional
-class ApiKeyService {
+class ApiKeyService implements AnonymisableService {
     CatalogueUserService catalogueUserService
 
     ApiKey get(Serializable id) {
@@ -82,5 +84,12 @@ class ApiKeyService {
     ApiKey enableApiKey(ApiKey apiKey) {
         apiKey.disabled = false
         apiKey
+    }
+
+    void anonymise(String createdBy) {
+        ApiKey.findAllByCreatedBy(createdBy).each { apiKey ->
+            apiKey.createdBy = AnonymousUser.ANONYMOUS_EMAIL_ADDRESS
+            apiKey.save(validate: false)
+        }
     }
 }

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
@@ -19,6 +19,8 @@ package uk.ac.ox.softeng.maurodatamapper.security.role
 
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
+import uk.ac.ox.softeng.maurodatamapper.core.traits.service.AnonymisableService
+import uk.ac.ox.softeng.maurodatamapper.security.basic.AnonymousUser
 import uk.ac.ox.softeng.maurodatamapper.security.CatalogueUser
 import uk.ac.ox.softeng.maurodatamapper.security.SecurableResource
 import uk.ac.ox.softeng.maurodatamapper.security.SecurableResourceService
@@ -29,7 +31,7 @@ import grails.validation.ValidationException
 import org.springframework.beans.factory.annotation.Autowired
 
 @Transactional
-class SecurableResourceGroupRoleService {
+class SecurableResourceGroupRoleService implements AnonymisableService {
 
     @Autowired(required = false)
     List<SecurableResourceService> securableResourceServices
@@ -137,5 +139,12 @@ class SecurableResourceGroupRoleService {
                                                        "SecurableResourceGroupRole retrieval for securable resource [${domainType}] with no " +
                                                        "supporting service")
         service.get(id)
+    }
+
+    void anonymise(String createdBy) {
+        SecurableResourceGroupRole.findAllByCreatedBy(createdBy).each { securableResourceGroupRole ->
+            securableResourceGroupRole.createdBy = AnonymousUser.ANONYMOUS_EMAIL_ADDRESS
+            securableResourceGroupRole.save(validate: false)
+        }
     }
 }

--- a/mdm-security/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleServiceIntegrationSpec.groovy
+++ b/mdm-security/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleServiceIntegrationSpec.groovy
@@ -59,7 +59,7 @@ class SecurableResourceGroupRoleServiceIntegrationSpec extends BaseIntegrationSp
         SecurableResourceGroupRole folderEditors = new SecurableResourceGroupRole(securableResource: folder,
                                                                                   userGroup: editors,
                                                                                   groupRole: groupRoleService.getFromCache('editor').groupRole,
-                                                                                  createdBy: userEmailAddresses.integrationTest)
+                                                                                  createdBy: userEmailAddresses.development)
         checkAndSave(folderEditors)
         checkAndSave(new SecurableResourceGroupRole(securableResource: folder,
                                                     userGroup: readers,
@@ -401,5 +401,29 @@ class SecurableResourceGroupRoleServiceIntegrationSpec extends BaseIntegrationSp
 
         then:
         !resource
+    }
+
+    void 'test anonymisation'() {
+        given:
+        setupData()
+
+        when: 'list securable resource group roles'
+        List<SecurableResourceGroupRole> securableResourceGroupRoleList = securableResourceGroupRoleService.list(max:1000, offset: 0)
+
+        then: 'there are 4; 3 created by integrationTest and 1 by development'
+        securableResourceGroupRoleList.size() == 4
+        securableResourceGroupRoleList.findAll{it.createdBy == userEmailAddresses.integrationTest}.size() == 3
+        securableResourceGroupRoleList.findAll{it.createdBy == userEmailAddresses.development}.size() == 1
+        securableResourceGroupRoleList.findAll{it.createdBy == 'anonymous@maurodatamapper.com'}.size() == 0
+
+        when: 'anonymise the development user'
+        securableResourceGroupRoleService.anonymise(userEmailAddresses.development)
+        securableResourceGroupRoleList = securableResourceGroupRoleService.list(max:1000, offset: 0)
+
+        then: 'the securable resource group role which was created by development is anonymised'
+        securableResourceGroupRoleList.size() == 4
+        securableResourceGroupRoleList.findAll{it.createdBy == userEmailAddresses.integrationTest}.size() == 3
+        securableResourceGroupRoleList.findAll{it.createdBy == userEmailAddresses.development}.size() == 0
+        securableResourceGroupRoleList.findAll{it.createdBy == 'anonymous@maurodatamapper.com'}.size() == 1
     }
 }

--- a/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserControllerSpec.groovy
+++ b/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserControllerSpec.groovy
@@ -83,7 +83,7 @@ class CatalogueUserControllerSpec extends ResourceControllerSpec<CatalogueUser> 
         controller.catalogueUserService = Stub(CatalogueUserService) {
             get(_) >> { UUID id -> CatalogueUser.get(id) }
             findAllByUser(_, _) >> CatalogueUser.list()
-            delete(_) >> { CatalogueUser catalogueUser -> catalogueUser.disabled = true }
+            delete(_, _) >> { CatalogueUser catalogueUser, boolean permanent -> catalogueUser.disabled = true }
             findAllByUserAndUserGroupId(_, _, _) >> { UserSecurityPolicyManager userSecurityPolicyManager, UUID userGroupId, Map pagination ->
                 if (userSecurityPolicyManager.isApplicationAdministrator()) {
                     return CatalogueUser.byUserGroupId(userGroupId).list(pagination)

--- a/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserServiceSpec.groovy
+++ b/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserServiceSpec.groovy
@@ -17,8 +17,18 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.security
 
-
+import uk.ac.ox.softeng.maurodatamapper.security.authentication.ApiKey
+import uk.ac.ox.softeng.maurodatamapper.security.authentication.ApiKeyService
+import uk.ac.ox.softeng.maurodatamapper.core.container.Folder
+import uk.ac.ox.softeng.maurodatamapper.core.container.FolderService
+import uk.ac.ox.softeng.maurodatamapper.core.email.Email
+import uk.ac.ox.softeng.maurodatamapper.core.email.EmailService
+import uk.ac.ox.softeng.maurodatamapper.core.facet.Edit
+import uk.ac.ox.softeng.maurodatamapper.core.facet.EditService
+import uk.ac.ox.softeng.maurodatamapper.core.facet.EditTitle
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.search.SearchParams
+import uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRole
+import uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRoleService
 import uk.ac.ox.softeng.maurodatamapper.security.test.SecurityUsers
 import uk.ac.ox.softeng.maurodatamapper.security.utils.SecurityUtils
 import uk.ac.ox.softeng.maurodatamapper.test.unit.BaseUnitSpec
@@ -28,6 +38,8 @@ import grails.testing.gorm.DomainUnitTest
 import grails.testing.services.ServiceUnitTest
 import groovy.util.logging.Slf4j
 
+import java.time.LocalDate
+
 @Slf4j
 class CatalogueUserServiceSpec extends BaseUnitSpec implements ServiceUnitTest<CatalogueUserService>, DomainUnitTest<CatalogueUser>,
     SecurityUsers {
@@ -36,6 +48,13 @@ class CatalogueUserServiceSpec extends BaseUnitSpec implements ServiceUnitTest<C
 
     def setup() {
         log.debug('Setting up CatalogueUserServiceSpec')
+        mockDomains(ApiKey, Edit, Email, Folder, SecurableResourceGroupRole)
+        mockArtefact(ApiKeyService)
+        mockArtefact(EditService)
+        mockArtefact(EmailService)
+        mockArtefact(FolderService)
+        mockArtefact(UserGroupService)
+        mockArtefact(SecurableResourceGroupRoleService)
         implementSecurityUsers('unitTest')
         id = editor.id
     }
@@ -428,6 +447,92 @@ class CatalogueUserServiceSpec extends BaseUnitSpec implements ServiceUnitTest<C
         lines[0] == 'Email Address,First Name,Last Name,Last Login,Organisation,Job Title,Disabled,Pending'
         lines.any {it == 'newtester1@email.com,wibble1,scruff1,,organisation,chef,false,false'}
         lines.any {it == 'newtester2@email.com,wibble2,scruff2,,organisation,chef but good,true,false'}
+    }
+
+    void "test permanent deletion and anonymisation"() {
+        given:
+        CatalogueUser catalogueUserAdmin = service.createNewUser(
+                emailAddress: 'admin@email.com', firstName: 'admin', lastName: 'scruff1', lastLogin: null, password: 'wobble',
+                organisation: 'organisation', jobTitle: 'admin', disabled: false, pending: false)
+        CatalogueUser catalogueUser1 = service.createNewUser(
+                emailAddress: 'newtester1@email.com', firstName: 'wibble1', lastName: 'scruff1', lastLogin: null, password: 'wobble',
+                organisation: 'organisation', jobTitle: 'chef', disabled: false, pending: false)
+        CatalogueUser catalogueUser2 = service.createNewUser(
+                emailAddress: 'newtester2@email.com', firstName: 'wibble2', lastName: 'scruff2', lastLogin: null, password: 'wobble',
+                organisation: 'organisation', jobTitle: 'chef but good', disabled: false, pending: false)
+
+        UserGroup group = new UserGroup(name: 'readersOnly', createdBy: reader.emailAddress)
+                .addToGroupMembers(catalogueUser1)
+                .addToGroupMembers(catalogueUser2)
+        checkAndSave(group)
+
+        checkAndSave(new ApiKey(refreshable: true, expiryDate: LocalDate.now(), disabled: false, name: 'Key 1', createdBy: catalogueUser1.emailAddress, catalogueUser: catalogueUserAdmin))
+        checkAndSave(new ApiKey(refreshable: true, expiryDate: LocalDate.now(), disabled: false, name: 'Key 2', createdBy: catalogueUser2.emailAddress, catalogueUser: catalogueUserAdmin))
+        checkAndSave(new Edit(title: EditTitle.UPDATE, createdBy: catalogueUser1.emailAddress, description: 'Edit 1', resourceDomainType: 'Folder', resourceId: UUID.randomUUID()))
+        checkAndSave(new Edit(title: EditTitle.UPDATE, createdBy: catalogueUser2.emailAddress, description: 'Edit 2', resourceDomainType: 'Folder', resourceId: UUID.randomUUID()))
+        checkAndSave(new Email(sentToEmailAddress: catalogueUser1.emailAddress, subject: 'Test Email', body: 'Body Content', successfullySent: true))
+        checkAndSave(new Email(sentToEmailAddress: catalogueUser2.emailAddress, subject: 'Test Email', body: 'Body Content', successfullySent: true))
+        checkAndSave(new Folder(label: 'Folder 1', createdBy: catalogueUser1.emailAddress))
+        checkAndSave(new Folder(label: 'Folder 2', createdBy: catalogueUser2.emailAddress))
+
+        when:
+        List<Folder> folders = Folder.findAll()
+        List<Edit> edits = Edit.findAll()
+        List<Email> emails = Email.findAll()
+        List<ApiKey> apiKeys = ApiKey.findAll()
+
+        then:
+        group.groupMembers.size() == 2
+        folders.size() == 2
+        edits.size() == 2
+        emails.size() == 2
+        apiKeys.size() == 2
+
+        and:
+        group.groupMembers.any {it.id == catalogueUser1.id}
+        group.groupMembers.any {it.id == catalogueUser2.id}
+        folders.any {it.createdBy == catalogueUser1.createdBy}
+        folders.any {it.createdBy == catalogueUser2.createdBy}
+        !folders.any {it.createdBy == 'anonymous@maurodatamapper.com'}
+        edits.any {it.createdBy == catalogueUser1.createdBy}
+        edits.any {it.createdBy == catalogueUser2.createdBy}
+        !edits.any {it.createdBy == 'anonymous@maurodatamapper.com'}
+        emails.any{it.sentToEmailAddress == catalogueUser1.emailAddress}
+        emails.any{it.sentToEmailAddress == catalogueUser2.emailAddress}
+        apiKeys.any {it.createdBy == catalogueUser1.createdBy}
+        apiKeys.any {it.createdBy == catalogueUser2.createdBy}
+        !apiKeys.any {it.createdBy == 'anonymous@maurodatamapper.com'}
+
+
+
+        when:
+        service.delete(catalogueUser2, true)
+        folders = Folder.findAll()
+        edits = Edit.findAll()
+        emails = Email.findAll()
+        apiKeys = ApiKey.findAll()
+
+        then:
+        group.groupMembers.size() == 1
+        folders.size() == 2
+        edits.size() == 2
+        emails.size() == 1
+        apiKeys.size() == 2
+
+        and:
+        group.groupMembers.any {it.id == catalogueUser1.id}
+        !group.groupMembers.any {it.id == catalogueUser2.id}
+        folders.any {it.createdBy == catalogueUser1.createdBy}
+        !folders.any {it.createdBy == catalogueUser2.createdBy}
+        folders.any {it.createdBy == 'anonymous@maurodatamapper.com'}
+        edits.any {it.createdBy == catalogueUser1.createdBy}
+        !edits.any {it.createdBy == catalogueUser2.createdBy}
+        edits.any {it.createdBy == 'anonymous@maurodatamapper.com'}
+        emails.any{it.sentToEmailAddress == catalogueUser1.emailAddress}
+        !emails.any{it.sentToEmailAddress == catalogueUser2.emailAddress}
+        apiKeys.any {it.createdBy == catalogueUser1.createdBy}
+        !apiKeys.any {it.createdBy == catalogueUser2.createdBy}
+        apiKeys.any {it.createdBy == 'anonymous@maurodatamapper.com'}
     }
 
     private CatalogueUser basicAuthentication(String emailAddress, String password) {

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/security/CatalogueUserFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/security/CatalogueUserFunctionalSpec.groovy
@@ -29,6 +29,7 @@ import io.micronaut.http.HttpResponse
 
 import static io.micronaut.http.HttpStatus.CREATED
 import static io.micronaut.http.HttpStatus.METHOD_NOT_ALLOWED
+import static io.micronaut.http.HttpStatus.NO_CONTENT
 import static io.micronaut.http.HttpStatus.NOT_FOUND
 import static io.micronaut.http.HttpStatus.OK
 import static io.micronaut.http.HttpStatus.UNPROCESSABLE_ENTITY
@@ -574,6 +575,34 @@ class CatalogueUserFunctionalSpec extends FunctionalSpec {
 
         cleanup:
         cleanupFunctionalSpecUser()
+    }
+
+    void "Test the permanent delete action correctly deletes an instance"() {
+        given:
+        String id = adminRegisterNewUser()
+        loginAdmin()
+
+        when: 'Get the user just created'
+        loginAdmin()
+        GET("$endpoint/$id")
+
+        then: 'The response is OK'
+        verifyResponse OK, response
+
+        when: "The permanent delete action is executed on an existing instance as admin"
+        DELETE("$endpoint/$id?permanent=true")
+
+        then: "The response is NO_CONTENT"
+        verifyResponse NO_CONTENT, response
+
+        when: 'Get the user again'
+        GET("$endpoint/$id")
+
+        then: 'The response is now NOT_FOUND'
+        verifyResponse NOT_FOUND, response
+
+        cleanup:
+        logout()
     }
 
     void "Test getting the user preferences"() {


### PR DESCRIPTION
Support the anonymisation of a CatalogueUser by:
- Adding an AnonymisableService which must be implemented by all services which handle any data that may require to be anonymised in future. Each service must implement the ```anonymise``` method in a way relevant for that service.
- Implementing the ```anonymise``` method for all DomainServices, plus other core services which do not implement DomainService.
- Changing the endpoint which deletes a Catalogue User so that when the query parameter ```?permanent=true``` is specified (i.e. ```DELETE api/catalogueUsers/{catalogueUserId}?permanent=true```) then anonymisation occurs. Without this parameter, the default behaviour of simply marking the user's disabled flag is retained.

In most cases the anonymisation is done by updating the email address stored in the ```createdBy``` property to anonymous@maurodatamapper.com. An exception to this is Email; in this case the relevant emails are deleted rather than updated.