### PR TITLE
Feature/gh 247 - Disallow duplicate keys on apply; set lastUpdatedBy on update

### DIFF
--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
@@ -67,6 +67,16 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
         saveResponse instance
     }
 
+    /**
+     * Override the base method so that we can set instance.lastUpdatedBy
+     */
+    @Transactional
+    @Override
+    protected boolean validateResource(ApiProperty instance, String view) {
+        instance.lastUpdatedBy = currentUser.emailAddress
+        super.validateResource(instance, view)
+    }
+
     @Override
     protected ApiProperty saveResource(ApiProperty resource) {
         ApiProperty apiProperty = super.saveResource(resource)

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
@@ -101,7 +101,9 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
         Collection instances = createResources()
 
         instances.each {instance ->
-            saveResource instance
+            if (instance.validate()) {
+                saveResource instance
+            }
         }
 
         // Respond with the index listing

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -103,14 +103,14 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         [count: 2,
          items: [
                  [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbe',
-                  key     : 'functional.test.key1',
+                  key     : 'functional.test.key.one',
                   value   : 'Some random thing1',
                   category: 'Functional Test',
                   publiclyVisible: false,
                   lastUpdatedBy: 'hello@example.com',
                   lastUpdated: '2021-10-27T11:02:32.682Z'],
                  [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbf',
-                  key     : 'functional.test.key2',
+                  key     : 'functional.test.key.two',
                   value   : 'Some random thing2',
                   category: 'Functional Test',
                   publiclyVisible: false,
@@ -128,7 +128,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
             <items>
                 <apiProperty>
                     <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
-                    <key>functional.test.xml.key.1</key>
+                    <key>functional.test.xml.key.one</key>
                     <value>XML value 1</value>
                     <category>XMLTests</category>
                     <publiclyVisible>false</publiclyVisible>
@@ -138,7 +138,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
                 </apiProperty>
                 <apiProperty>
                     <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbf</id>
-                    <key>functional.test.xml.key.2</key>
+                    <key>functional.test.xml.key.two</key>
                     <value>XML value 2</value>
                     <category>XMLTests</category>
                     <publiclyVisible>false</publiclyVisible>
@@ -325,16 +325,24 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 
         then: 'The response is correct and contains properties with keys functional.test.key1 and functional.test.key2'
         verifyResponse(HttpStatus.OK, response)
-        response.body().items.any{it.key == "functional.test.key1"}
-        response.body().items.any{it.key == "functional.test.key2"}
+        response.body().items.findAll{it.key == "functional.test.key.one"}.size() == 1
+        response.body().items.findAll{it.key == "functional.test.key.two"}.size() == 1
 
         and: 'The lastUpdatedBy property was ignored from the posted data'
-        response.body().items.find{it.key == "functional.test.key1"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
-        response.body().items.find{it.key == "functional.test.key2"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+        response.body().items.find{it.key == "functional.test.key.one"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+        response.body().items.find{it.key == "functional.test.key.two"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+
+        when: 'Replay the POST'
+        POST(getSaveCollectionPath(), getValidJsonCollection(), MAP_ARG, true)
+
+        then: 'There are not duplicates in the response'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().items.findAll{it.key == "functional.test.key.one"}.size() == 1
+        response.body().items.findAll{it.key == "functional.test.key.two"}.size() == 1
 
         cleanup:
-        String id1 = response.body().items.find{it.key == "functional.test.key1"}.id
-        String id2 = response.body().items.find{it.key == "functional.test.key2"}.id
+        String id1 = response.body().items.find{it.key == "functional.test.key.one"}.id
+        String id2 = response.body().items.find{it.key == "functional.test.key.two"}.id
         DELETE(getDeleteEndpoint(id1))
         assert response.status() == HttpStatus.NO_CONTENT
         DELETE(getDeleteEndpoint(id2))
@@ -348,16 +356,24 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 
         then: 'The response is correct and contains properties with keys functional.test.xml.key.1 and functional.test.xml.key.2'
         verifyResponse(HttpStatus.OK, response)
-        response.body().items.any{it.key == "functional.test.xml.key.1"}
-        response.body().items.any{it.key == "functional.test.xml.key.2"}
+        response.body().items.findAll{it.key == "functional.test.xml.key.one"}.size() == 1
+        response.body().items.findAll{it.key == "functional.test.xml.key.two"}.size() == 1
 
         and: 'The lastUpdatedBy property was ignored from the posted data'
-        response.body().items.find{it.key == "functional.test.xml.key.1"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
-        response.body().items.find{it.key == "functional.test.xml.key.2"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+        response.body().items.find{it.key == "functional.test.xml.key.one"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+        response.body().items.find{it.key == "functional.test.xml.key.two"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+
+        when: 'Replay the POST'
+        POST(getSaveCollectionPath(), getValidXmlCollection(), MAP_ARG, true, 'application/xml')
+
+        then: 'There are not duplicates in the response'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().items.findAll{it.key == "functional.test.xml.key.one"}.size() == 1
+        response.body().items.findAll{it.key == "functional.test.xml.key.two"}.size() == 1
 
         cleanup:
-        String id1 = response.body().items.find{it.key == "functional.test.xml.key.1"}.id
-        String id2 = response.body().items.find{it.key == "functional.test.xml.key.2"}.id
+        String id1 = response.body().items.find{it.key == "functional.test.xml.key.one"}.id
+        String id2 = response.body().items.find{it.key == "functional.test.xml.key.two"}.id
         DELETE(getDeleteEndpoint(id1))
         assert response.status() == HttpStatus.NO_CONTENT
         DELETE(getDeleteEndpoint(id2))
@@ -371,12 +387,20 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 
         then: 'The response is correct and contains properties with keys a.csv.collection.key and another.csv.collection.key'
         verifyResponse(HttpStatus.OK, response)
-        response.body().items.any{it.key == "a.csv.collection.key"}
-        response.body().items.any{it.key == "another.csv.collection.key"}
+        response.body().items.findAll{it.key == "a.csv.collection.key"}.size() == 1
+        response.body().items.findAll{it.key == "another.csv.collection.key"}.size() == 1
 
         and: 'The lastUpdatedBy property was ignored from the posted data'
         response.body().items.find{it.key == "a.csv.collection.key"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
         response.body().items.find{it.key == "another.csv.collection.key"}.lastUpdatedBy == "unlogged_user@mdm-core.com"
+
+        when: 'Replay the POST'
+        POST(getSaveCollectionPath(), getValidCsvCollection(), MAP_ARG, true, 'text/csv')
+
+        then: 'There are not duplicates in the response'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().items.findAll{it.key == "a.csv.collection.key"}.size() == 1
+        response.body().items.findAll{it.key == "another.csv.collection.key"}.size() == 1
 
         cleanup:
         String id1 = response.body().items.find{it.key == "a.csv.collection.key"}.id

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -447,8 +447,8 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         when: 'Replay the POST'
         POST('/apply', getValidJsonCollection(), MAP_ARG, false)
 
-        then: 'There are still only 2 extra items in the index'
-        response.body().count == propertyCount + 2
+        then: 'It is unprocessable'
+        verifyResponse UNPROCESSABLE_ENTITY, response
 
         cleanup:
         removeValidIdObject(id1)
@@ -479,16 +479,16 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         response.body().items.find{it.key == "another.csv.collection.key"}.lastUpdatedBy == "admin@maurodatamapper.com"
         response.body().items.find{it.key == "a.csv.collection.key"}.createdBy == "admin@maurodatamapper.com"
         response.body().items.find{it.key == "another.csv.collection.key"}.createdBy == "admin@maurodatamapper.com"
-
-        when: 'Replay the POST'
-        POST('/apply', getValidCsvCollection(), MAP_ARG, false)
-
-        then: 'There are still only 2 extra items in the index'
-        response.body().count == propertyCount + 2
-
-        cleanup:
         String id1 = response.body().items.find{it.key == "a.csv.collection.key"}.id
         String id2 = response.body().items.find{it.key == "another.csv.collection.key"}.id
+
+        when: 'Replay the POST'
+        POST('/apply', getValidCsvCollection(), MAP_ARG, false, 'text/csv')
+
+        then: 'It is unprocessable'
+        verifyResponse UNPROCESSABLE_ENTITY, response
+
+        cleanup:
         removeValidIdObject(id1)
         removeValidIdObject(id2)
     }
@@ -517,16 +517,16 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         response.body().items.find{it.key == "functional.test.xml.key.two"}.lastUpdatedBy == "admin@maurodatamapper.com"
         response.body().items.find{it.key == "functional.test.xml.key.one"}.createdBy == "admin@maurodatamapper.com"
         response.body().items.find{it.key == "functional.test.xml.key.two"}.createdBy == "admin@maurodatamapper.com"
-
-        when: 'Replay the POST'
-        POST('/apply', getValidXmlCollection(), MAP_ARG, false)
-
-        then: 'There are still only 2 extra items in the index'
-        response.body().count == propertyCount + 2
-
-        cleanup:
         String id1 = response.body().items.find{it.key == "functional.test.xml.key.one"}.id
         String id2 = response.body().items.find{it.key == "functional.test.xml.key.two"}.id
+
+        when: 'Replay the POST'
+        POST('/apply', getValidXmlCollection(), MAP_ARG, false,'application/xml')
+
+        then: 'It is unprocessable'
+        verifyResponse UNPROCESSABLE_ENTITY, response
+
+        cleanup:
         removeValidIdObject(id1)
         removeValidIdObject(id2)
     }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -111,10 +111,10 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
     Map getValidJsonCollection() {
         [count: 2,
          items: [
-                 [key     : 'functional.test.key1',
+                 [key     : 'functional.test.key.one',
                   value   : 'Some random thing1',
                   category: 'Functional Test'],
-                 [key     : 'functional.test.key2',
+                 [key     : 'functional.test.key.two',
                   value   : 'Some random thing2',
                   category: 'Functional Test']
          ]
@@ -129,7 +129,7 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
             <items>
                 <apiProperty>
                     <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbe</id>
-                    <key>functional.test.xml.key.1</key>
+                    <key>functional.test.xml.key.one</key>
                     <value>XML value 1</value>
                     <category>XMLTests</category>
                     <publiclyVisible>false</publiclyVisible>
@@ -139,7 +139,7 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
                 </apiProperty>
                 <apiProperty>
                     <id>e2b3398f-f3e5-4d70-8793-25526bbe0dbf</id>
-                    <key>functional.test.xml.key.2</key>
+                    <key>functional.test.xml.key.two</key>
                     <value>XML value 2</value>
                     <category>XMLTests</category>
                     <publiclyVisible>false</publiclyVisible>
@@ -427,18 +427,30 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         given:
         loginAdmin()
 
+        and: 'Count the number of properties before the test'
+        GET("")
+        verifyResponse OK, response
+        def propertyCount = response.body().count
+
         when: 'The save action is executed with valid JSON collection data'
         log.debug('Valid content save')
         POST('/apply', getValidJsonCollection(), MAP_ARG, false)
 
         then: 'The response is correct and contains properties with keys functional.test.key1 and functional.test.key2'
-        verifyResponse(OK, response)
-        response.body().items.any{it.key == "functional.test.key1"}
-        response.body().items.any{it.key == "functional.test.key2"}
+        verifyResponse OK, response
+        response.body().count == propertyCount + 2
+        response.body().items.any{it.key == "functional.test.key.one"}
+        response.body().items.any{it.key == "functional.test.key.two"}
+        String id1 = response.body().items.find{it.key == "functional.test.key.one"}.id
+        String id2 = response.body().items.find{it.key == "functional.test.key.two"}.id
+
+        when: 'Replay the POST'
+        POST('/apply', getValidJsonCollection(), MAP_ARG, false)
+
+        then: 'There are still only 2 extra items in the index'
+        response.body().count == propertyCount + 2
 
         cleanup:
-        String id1 = response.body().items.find{it.key == "functional.test.key1"}.id
-        String id2 = response.body().items.find{it.key == "functional.test.key2"}.id
         removeValidIdObject(id1)
         removeValidIdObject(id2)
     }
@@ -447,12 +459,18 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         given:
         loginAdmin()
 
+        and: 'Count the number of properties before the test'
+        GET("")
+        verifyResponse OK, response
+        def propertyCount = response.body().count
+
         when: 'The save action is executed with valid CSV collection data'
         log.debug('Valid content save')
         POST('/apply', getValidCsvCollection(), MAP_ARG, false, 'text/csv')
 
         then: 'The response is correct and contains properties with keys functional.test.key1 and functional.test.key2'
         verifyResponse(OK, response)
+        response.body().count == propertyCount + 2
         response.body().items.any{it.key == "a.csv.collection.key"}
         response.body().items.any{it.key == "another.csv.collection.key"}
 
@@ -461,6 +479,12 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         response.body().items.find{it.key == "another.csv.collection.key"}.lastUpdatedBy == "admin@maurodatamapper.com"
         response.body().items.find{it.key == "a.csv.collection.key"}.createdBy == "admin@maurodatamapper.com"
         response.body().items.find{it.key == "another.csv.collection.key"}.createdBy == "admin@maurodatamapper.com"
+
+        when: 'Replay the POST'
+        POST('/apply', getValidCsvCollection(), MAP_ARG, false)
+
+        then: 'There are still only 2 extra items in the index'
+        response.body().count == propertyCount + 2
 
         cleanup:
         String id1 = response.body().items.find{it.key == "a.csv.collection.key"}.id
@@ -473,24 +497,36 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         given:
         loginAdmin()
 
+        and: 'Count the number of properties before the test'
+        GET("")
+        verifyResponse OK, response
+        def propertyCount = response.body().count
+
         when: 'The save action is executed with valid CSV collection data'
         log.debug('Valid content save')
         POST('/apply', getValidXmlCollection(), MAP_ARG, false, 'application/xml')
 
-        then: 'The response is correct and contains properties with keys functional.test.key1 and functional.test.key2'
+        then: 'The response is correct and contains properties with keys functional.test.key.one and functional.test.key.two'
         verifyResponse(OK, response)
-        response.body().items.any{it.key == "functional.test.xml.key.1"}
-        response.body().items.any{it.key == "functional.test.xml.key.2"}
+        response.body().count == propertyCount + 2
+        response.body().items.any{it.key == "functional.test.xml.key.one"}
+        response.body().items.any{it.key == "functional.test.xml.key.two"}
 
         and: 'The lastUpdatedBy and createdBy properties were ignored from the posted data'
-        response.body().items.find{it.key == "functional.test.xml.key.1"}.lastUpdatedBy == "admin@maurodatamapper.com"
-        response.body().items.find{it.key == "functional.test.xml.key.2"}.lastUpdatedBy == "admin@maurodatamapper.com"
-        response.body().items.find{it.key == "functional.test.xml.key.1"}.createdBy == "admin@maurodatamapper.com"
-        response.body().items.find{it.key == "functional.test.xml.key.2"}.createdBy == "admin@maurodatamapper.com"
+        response.body().items.find{it.key == "functional.test.xml.key.one"}.lastUpdatedBy == "admin@maurodatamapper.com"
+        response.body().items.find{it.key == "functional.test.xml.key.two"}.lastUpdatedBy == "admin@maurodatamapper.com"
+        response.body().items.find{it.key == "functional.test.xml.key.one"}.createdBy == "admin@maurodatamapper.com"
+        response.body().items.find{it.key == "functional.test.xml.key.two"}.createdBy == "admin@maurodatamapper.com"
+
+        when: 'Replay the POST'
+        POST('/apply', getValidXmlCollection(), MAP_ARG, false)
+
+        then: 'There are still only 2 extra items in the index'
+        response.body().count == propertyCount + 2
 
         cleanup:
-        String id1 = response.body().items.find{it.key == "functional.test.xml.key.1"}.id
-        String id2 = response.body().items.find{it.key == "functional.test.xml.key.2"}.id
+        String id1 = response.body().items.find{it.key == "functional.test.xml.key.one"}.id
+        String id2 = response.body().items.find{it.key == "functional.test.xml.key.two"}.id
         removeValidIdObject(id1)
         removeValidIdObject(id2)
     }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -531,6 +531,33 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         removeValidIdObject(id2)
     }
 
+    void 'A07 : Test the update action correctly persists the update, in particular setting the lastUpdatedBy property'() {
+        given:
+        loginAdmin()
+
+        when:
+        POST('', validJson)
+
+        then:
+        verifyResponse CREATED, response
+        response.body().id
+        response.body().lastUpdatedBy == userEmailAddresses.admin
+        String id1 = response.body().id
+
+        when: 'Update'
+        loginCreator()
+        PUT("$id1", validUpdateJson)
+
+        then:
+        verifyResponse OK, response
+        response.body().id == id1
+        response.body().value == "Some different random thing"
+        response.body().lastUpdatedBy == userEmailAddresses.creator
+
+        cleanup:
+        removeValidIdObject(id1)
+    }
+
     void 'EXX : Test editor endpoints are all forbidden'() {
         given:
         def id = getValidId()


### PR DESCRIPTION
Closes #247 

- Change the endpoint ```POST /admin/properties/apply``` so that each instance of the posted collection is validated before save. If any item in the collection fails validation then reject the entire collection. 
- Add tests to cover both a replay of the same collection, and also duplicate keys in the same collection
- Change the endpoint ```PUT /admin/properties/{id}``` to set the lastUpdatedBy field. Add a test for this.