### PR TITLE
Feature/gh 222

### DIFF
--- a/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElement.groovy
+++ b/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElement.groovy
@@ -184,12 +184,19 @@ class DataElement implements ModelItem<DataElement, DataModel>, MultiplicityAwar
     }
 
     ObjectDiff<DataElement> diff(DataElement otherDataElement, String context) {
-        catalogueItemDiffBuilder(DataElement, this, otherDataElement)
-            .appendString('dataType.label', this.dataType.label, otherDataElement.dataType.label)
+        ObjectDiff<DataElement> diff = catalogueItemDiffBuilder(DataElement, this, otherDataElement)
             .appendNumber('minMultiplicity', this.minMultiplicity, otherDataElement.minMultiplicity)
             .appendNumber('maxMultiplicity', this.maxMultiplicity, otherDataElement.maxMultiplicity)
 
+        // Aside from branch and version, is this Data Element pointing to a different Data Type?
+        if (!this.dataType.getPath().matches(otherDataElement.dataType.getPath(), this.dataClass.dataModel.getPath().last().modelIdentifier)) {
+            diff.
+                appendString('dataTypePath',
+                             this.dataType.getPath().toString(),
+                             otherDataElement.dataType.getPath().toString())
+        }
 
+        diff
     }
 
     static DetachedCriteria<DataElement> by() {

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -565,6 +565,28 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
      * Special handler to apply a modification patch to a DataType.
      * In the diff we set a mergeField called dataTypePath. In this method we use that dataTypePath to find the
      * relevant DataType.
+     * 1. Find the data type in source
+     * 2. Use the path of that data type to find the same data type in target
+     * 3. Set the data type of the target data element to be that data type
+     *
+     * Note that this leads to a merge conflict in in the following scenario (as highlighted by test MD05 in DataModelFunctionalSpec):
+     * 1. Common ancestor model has dataType1 and dataType2. dataElement has a dataType of dataType1.
+     * 2. Create source and main branches from the common ancestor
+     * 3. On source branch, change the dataElement to have a dataType of dataType2
+     * 4. Merge the source into main.
+     * 5. Make some more other changes to the source branch
+     * 6. Get the mergeDiff for source into main again.
+     * The mergeDiff looks like
+     * {
+     *   "fieldName": "dataTypePath",
+     *    "path": "dm:Functional Test DataModel 1$source|dc:existingClass|de:existingDataElement@dataTypePath",
+     *    "sourceValue": "dm:Functional Test DataModel 1$source|dt:existingDataType2",
+     *    "targetValue": "dm:Functional Test DataModel 1$main|dt:existingDataType2",
+     *    "commonAncestorValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+     *    "isMergeConflict": true,
+     *    "type": "modification"
+     * }
+     * because both source and main have a different data type to the one in common ancestor.
      * @param modificationPatch
      * @param targetDomain
      * @param fieldName
@@ -573,13 +595,24 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
     @Override
     boolean handlesModificationPatchOfField(FieldPatchData modificationPatch, MdmDomain targetBeingPatched, DataElement targetDomain, String fieldName) {
         if (fieldName == 'dataTypePath') {
-            DataType dt = pathService.findResourceByPath(Path.from(modificationPatch.sourceValue))
+            // This is the dataType that has been changed on the source
+            DataType sourceDataType = pathService.findResourceByPath(Path.from(modificationPatch.sourceValue))
 
-            if (dt) {
-                targetDomain.dataType = dt
+            if (!sourceDataType) {
+                throw new ApiInternalException('DES01', "Cannot find DataType with path ${modificationPatch.sourceValue}")
+            }
+
+            // We need the equivalent (i.e. matches by path) dataType on the target
+            DataType targetDataType = pathService.findResourceByPathFromRootResource(targetDomain.dataClass.dataModel, sourceDataType.getPath()
+                .getChildPath())
+
+            if (targetDataType) {
+                targetDomain.dataType = targetDataType
                 return true
             } else {
-                throw new ApiInternalException('DES01', "Cannot find DataType with path ${modificationPatch.sourceValue}")
+                throw new ApiInternalException(
+                    'DES02',
+                    "Cannot find DataType with path ${sourceDataType.getPath().getChildPath()} on target DataModel ${targetDomain.dataClass.dataModel.id}")
             }
         }
 

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelFunctionalSpec.groovy
@@ -1201,9 +1201,11 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
     void 'MD05 : test finding merge diff on a branch which has already been merged'() {
         given:
         TestMergeData mergeData = builder.buildComplexModelsForMerging(folderId.toString())
+        log.debug('-------------- First Merge Diff ------------------')
         GET("$mergeData.source/mergeDiff/$mergeData.target")
         verifyResponse OK, response
         List<Map> patches = responseBody().diffs
+        log.debug('-------------- First Merge Into ------------------')
         PUT("$mergeData.source/mergeInto/$mergeData.target", [
             patch: [
                 targetId: responseBody().targetId,
@@ -1222,9 +1224,10 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
             dataType: mergeData.sourceMap.addLeftOnlyDataType
         ])
         verifyResponse CREATED, response
-        log.debug('-------------- Second Merge Request ------------------')
 
         and:
+        log.debug('-------------- Second Merge Diff ------------------')
+        // See comments in DataElementService.handlesModificationPatchOfField for explanation of why we get a merge conflict on dataTypePath
         GET("$mergeData.source/mergeDiff/$mergeData.target", STRING_ARG)
 
         then:
@@ -1624,7 +1627,7 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
 
         then:
         verifyResponse OK, response
-        responseBody().diffs.size() == 16
+        responseBody().diffs.size() == 17
 
         when:
         List<Map> patches = responseBody().diffs
@@ -1665,13 +1668,13 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
         GET("$mergeData.target/dataClasses/$mergeData.targetMap.existingClass/dataElements")
 
         then:
-        responseBody().items.label as Set == ['addLeftOnly'] as Set
+        responseBody().items.label as Set == ['addLeftOnly', 'existingDataElement'] as Set
 
         when:
         GET("$mergeData.target/dataTypes")
 
         then:
-        responseBody().items.label as Set == ['addLeftOnly'] as Set
+        responseBody().items.label as Set == ['addLeftOnly', 'existingDataType1', 'existingDataType2'] as Set
 
         when:
         GET("${mergeData.target}/metadata")
@@ -1854,7 +1857,7 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
 
         then:
         verifyResponse(OK, response)
-        responseBody().count == 1
+        responseBody().count == 2
 
         when:
         GET("$mergeData.target/dataClasses")
@@ -4394,7 +4397,7 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
   "targetId": "${json-unit.matches:id}",
   "path": "dm:Functional Test DataModel 1$source",
   "label": "Functional Test DataModel 1",
-  "count": 16,
+  "count": 17,
   "diffs": [
     {
       "fieldName": "description",
@@ -4457,6 +4460,15 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
       "type": "creation"
     },
     {
+      "fieldName": "dataTypePath",
+      "path": "dm:Functional Test DataModel 1$source|dc:existingClass|de:existingDataElement@dataTypePath",
+      "sourceValue": "dm:Functional Test DataModel 1$source|dt:existingDataType2",
+      "targetValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "commonAncestorValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "isMergeConflict": false,
+      "type": "modification"
+    },
+    {
       "fieldName": "description",
       "path": "dm:Functional Test DataModel 1$source|dc:modifyAndModifyReturningDifference@description",
       "sourceValue": "DescriptionLeft",
@@ -4517,7 +4529,7 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
   "targetId": "${json-unit.matches:id}",
   "path": "dm:Functional Test DataModel 1$source",
   "label": "Functional Test DataModel 1",
-  "count": 2,
+  "count": 3,
   "diffs": [
     {
       "path": "dm:Functional Test DataModel 1$source|dc:addLeftOnly|dc:addAnotherLeftToAddLeftOnly",
@@ -4530,6 +4542,15 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
       "isMergeConflict": false,
       "isSourceModificationAndTargetDeletion": false,
       "type": "creation"
+    },
+    {
+      "fieldName": "dataTypePath",
+      "path": "dm:Functional Test DataModel 1$source|dc:existingClass|de:existingDataElement@dataTypePath",
+      "sourceValue": "dm:Functional Test DataModel 1$source|dt:existingDataType2",
+      "targetValue": "dm:Functional Test DataModel 1$main|dt:existingDataType2",
+      "commonAncestorValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "isMergeConflict": true,
+      "type": "modification"
     }
   ]
 }'''

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementSpec.groovy
@@ -41,7 +41,7 @@ class DataElementSpec extends ModelItemSpec<DataElement> implements DomainUnitTe
     DataType dataType
 
     def setup() {
-        log.debug('Setting up DataClassSpec unit')
+        log.debug('Setting up DataElementSpec unit')
         mockDomains(DataModel, DataClass, DataType, PrimitiveType, ReferenceType, EnumerationType, EnumerationValue, DataElement)
 
         dataSet = new DataModel(createdBy: StandardEmailAddress.UNIT_TEST, label: 'dataSet', folder: testFolder, authority: testAuthority)
@@ -148,9 +148,9 @@ class DataElementSpec extends ModelItemSpec<DataElement> implements DomainUnitTe
     }
 
     void 'DER01: test diffing DE rules with identical rules'() {
-        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'd', representation: 'a+b'))
-        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'd', representation: 'a+b'))
 
         when:
@@ -161,9 +161,9 @@ class DataElementSpec extends ModelItemSpec<DataElement> implements DomainUnitTe
     }
 
     void 'DER02: test diffing DE rules with different rule names'() {
-        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'd', representation: 'a+b'))
-        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 3').addToRuleRepresentations(language: 'd', representation: 'a+b'))
 
         when:
@@ -174,9 +174,9 @@ class DataElementSpec extends ModelItemSpec<DataElement> implements DomainUnitTe
     }
 
     void 'DER03: test diffing DE rules with different languages rules'() {
-        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'd', representation: 'a+b'))
-        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'e', representation: 'a+b'))
 
         when:
@@ -187,9 +187,9 @@ class DataElementSpec extends ModelItemSpec<DataElement> implements DomainUnitTe
     }
 
     void 'DER04: test diffing DE rules with different rules representations'() {
-        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement a = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'd', representation: 'a+b'))
-        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType).addToRules(name: 'rule 1')
+        DataElement b = new DataElement(label: 'Functional Data Element', dataType: dataType, dataClass: dataClass).addToRules(name: 'rule 1')
             .addToRules(new Rule(name: 'rule 2').addToRuleRepresentations(language: 'd', representation: 'a+e'))
 
         when:

--- a/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/merge/DataModelPluginMergeBuilder.groovy
+++ b/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/merge/DataModelPluginMergeBuilder.groovy
@@ -115,6 +115,13 @@ class DataModelPluginMergeBuilder extends BaseTestMergeBuilder {
         verifyResponse CREATED, response
         POST("dataModels/$dataModel1Id/metadata", [namespace: 'functional.test', key: 'modifyAndDelete', value: 'some other original value 2'])
         verifyResponse CREATED, response
+        POST("dataModels/$dataModel1Id/dataTypes", [label: 'existingDataType1', domainType: 'PrimitiveType'])
+        verifyResponse CREATED, response
+        String dataType1Id = responseBody().id
+        POST("dataModels/$dataModel1Id/dataTypes", [label: 'existingDataType2', domainType: 'PrimitiveType'])
+        verifyResponse CREATED, response
+        POST("dataModels/$dataModel1Id/dataClasses/$caExistingClass/dataElements", [label: 'existingDataElement', dataType: dataType1Id])
+        verifyResponse CREATED, response
 
         if (terminologyId) {
             buildCommonAncestorModelDataTypePointingExternally(dataModel1Id, terminologyId)
@@ -190,6 +197,10 @@ class DataModelPluginMergeBuilder extends BaseTestMergeBuilder {
         Map sourceMap = [
             dataModelId                         : getIdFromPath(source, "${pathing}dm:Functional Test DataModel ${suffix}\$source"),
             existingClass                       : getIdFromPath(source, "${pathing}dm:Functional Test DataModel ${suffix}\$source|dc:existingClass"),
+            existingDataElement                 : getIdFromPath(source, "${pathing}dm:Functional Test DataModel " +
+                                                                        "${suffix}\$source|dc:existingClass|de:existingDataElement"),
+            existingDataType2                   : getIdFromPath(source, "${pathing}dm:Functional Test DataModel " +
+                                                                        "${suffix}\$source|dt:existingDataType2"),
             deleteLeftOnlyFromExistingClass     :
                 getIdFromPath(source, "${pathing}dm:Functional Test DataModel ${suffix}\$source|dc:existingClass|dc:deleteLeftOnlyFromExistingClass"),
             deleteLeftOnly                      : getIdFromPath(source, "${pathing}dm:Functional Test DataModel ${suffix}\$source|dc:deleteLeftOnly"),
@@ -261,6 +272,10 @@ class DataModelPluginMergeBuilder extends BaseTestMergeBuilder {
         verifyResponse OK, response
         DELETE("dataModels/$sourceMap.dataModelId/metadata/$sourceMap.metadataDeleteFromSource")
         verifyResponse NO_CONTENT, response
+
+        PUT("dataModels/$sourceMap.dataModelId/dataClasses/$sourceMap.existingClass/dataElements/$sourceMap.existingDataElement",
+            [dataType: sourceMap.existingDataType2])
+        verifyResponse OK, response
 
         // Update the model data type that was pointing to the Simple Test Terminology to point to the Complex Test Terminology'
         if (sourceMap.externallyPointingModelDataTypeId && sourceMap.complexTerminologyId) {

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/datamodel/DataModelFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/datamodel/DataModelFunctionalSpec.groovy
@@ -2233,8 +2233,9 @@ class DataModelFunctionalSpec extends ModelUserAccessPermissionChangingAndVersio
 
         then:
         verifyResponse OK, response
-        responseBody().count == 2
-        responseBody().items.label as Set == ['addLeftOnly', 'Functional Test Model Data Type Pointing Externally'] as Set
+        responseBody().count == 4
+        responseBody().items.label as Set == ['addLeftOnly', 'Functional Test Model Data Type Pointing Externally', 'existingDataType1',
+                                              'existingDataType2'] as Set
         def mdt = responseBody().items.find {it.label == 'Functional Test Model Data Type Pointing Externally' }
 
         and:

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/versionedfolder/container/VersionedFolderFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/versionedfolder/container/VersionedFolderFunctionalSpec.groovy
@@ -1160,7 +1160,7 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
 
         then: 'the branched model data type points to the branched terminology'
         verifyResponse(OK, response)
-        responseBody().count == 2
+        responseBody().count == 4
         def mdt = responseBody().items.find{it.label == 'Functional Test Model Data Type'}
         def mdt2 = responseBody().items.find{it.label == 'Functional Test Model Data Type Pointing Externally'}
         mdt.id == getIdFromPath(branchId, 'dm:Functional Test DataModel 1$main|dt:Functional Test Model Data Type')
@@ -2499,15 +2499,20 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         responseBody().items.label as Set == [
                 'addLeftOnly',
                 'Functional Test Data Element with Model Data Type',
-                'Functional Test Data Element with Model Data Type Pointing Externally'] as Set
+                'Functional Test Data Element with Model Data Type Pointing Externally',
+                'existingDataElement'] as Set
 
         when:
         GET("dataModels/$targetDataModelMap.dataModelId/dataTypes", MAP_ARG, true)
 
         then:
         verifyResponse(OK, response)
-        responseBody().count == 3
-        responseBody().items.label as Set == ['addLeftOnly', 'Functional Test Model Data Type', 'Functional Test Model Data Type Pointing Externally'] as Set
+        responseBody().count == 5
+        responseBody().items.label as Set == ['addLeftOnly',
+                                              'Functional Test Model Data Type',
+                                              'Functional Test Model Data Type Pointing Externally',
+                                              'existingDataType1',
+                                              'existingDataType2'] as Set
         def mdt1 = responseBody().items.find {it.label == 'Functional Test Model Data Type' }
         def mdt2 = responseBody().items.find {it.label == 'Functional Test Model Data Type Pointing Externally' }
 

--- a/mdm-testing-functional/src/integration-test/resources/versionedFolders/MergeDiff.json
+++ b/mdm-testing-functional/src/integration-test/resources/versionedFolders/MergeDiff.json
@@ -3,7 +3,7 @@
   "targetId": "${json-unit.matches:id}",
   "path": "vf:Functional Test VersionedFolder Complex$source",
   "label": "Functional Test VersionedFolder Complex",
-  "count": 64,
+  "count": 65,
   "diffs": [
     {
       "fieldName": "description",
@@ -139,6 +139,15 @@
       "isMergeConflict": false,
       "isSourceModificationAndTargetDeletion": false,
       "type": "creation"
+    },
+    {
+      "fieldName": "dataTypePath",
+      "path": "vf:Functional Test VersionedFolder Complex$source|dm:Functional Test DataModel 1$source|dc:existingClass|de:existingDataElement@dataTypePath",
+      "sourceValue": "dm:Functional Test DataModel 1$source|dt:existingDataType2",
+      "targetValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "commonAncestorValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "isMergeConflict": false,
+      "type": "modification"
     },
     {
       "fieldName": "description",

--- a/mdm-testing-functional/src/integration-test/resources/versionedFolders/SubFolderMergeDiff.json
+++ b/mdm-testing-functional/src/integration-test/resources/versionedFolders/SubFolderMergeDiff.json
@@ -3,7 +3,7 @@
   "targetId": "${json-unit.matches:id}",
   "path": "vf:Functional Test VersionedFolder With Sub Folders$source",
   "label": "Functional Test VersionedFolder With Sub Folders",
-  "count": 101,
+  "count": 104,
   "diffs": [
     {
       "fieldName": "description",
@@ -85,6 +85,15 @@
       "isMergeConflict": false,
       "isSourceModificationAndTargetDeletion": false,
       "type": "creation"
+    },
+    {
+      "fieldName": "dataTypePath",
+      "path": "vf:Functional Test VersionedFolder With Sub Folders$source|fo:Sub Folder 2 in VersionedFolder|dm:Functional Test DataModel 2$source|dc:existingClass|de:existingDataElement@dataTypePath",
+      "sourceValue": "dm:Functional Test DataModel 2$source|dt:existingDataType2",
+      "targetValue": "dm:Functional Test DataModel 2$1.0.0|dt:existingDataType1",
+      "commonAncestorValue": "dm:Functional Test DataModel 2$1.0.0|dt:existingDataType1",
+      "isMergeConflict": false,
+      "type": "modification"
     },
     {
       "fieldName": "description",
@@ -280,6 +289,15 @@
       "isMergeConflict": false,
       "isSourceModificationAndTargetDeletion": false,
       "type": "creation"
+    },
+    {
+      "fieldName": "dataTypePath",
+      "path": "vf:Functional Test VersionedFolder With Sub Folders$source|fo:Sub Folder in VersionedFolder|fo:Sub-Sub Folder in VersionedFolder|dm:Functional Test DataModel 3$source|dc:existingClass|de:existingDataElement@dataTypePath",
+      "sourceValue": "dm:Functional Test DataModel 3$source|dt:existingDataType2",
+      "targetValue": "dm:Functional Test DataModel 3$1.0.0|dt:existingDataType1",
+      "commonAncestorValue": "dm:Functional Test DataModel 3$1.0.0|dt:existingDataType1",
+      "isMergeConflict": false,
+      "type": "modification"
     },
     {
       "fieldName": "description",
@@ -541,6 +559,15 @@
       "isMergeConflict": false,
       "isSourceModificationAndTargetDeletion": false,
       "type": "creation"
+    },
+    {
+      "fieldName": "dataTypePath",
+      "path": "vf:Functional Test VersionedFolder With Sub Folders$source|dm:Functional Test DataModel 1$source|dc:existingClass|de:existingDataElement@dataTypePath",
+      "sourceValue": "dm:Functional Test DataModel 1$source|dt:existingDataType2",
+      "targetValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "commonAncestorValue": "dm:Functional Test DataModel 1$1.0.0|dt:existingDataType1",
+      "isMergeConflict": false,
+      "type": "modification"
     },
     {
       "fieldName": "description",

--- a/mdm-testing-functional/src/integration-test/resources/versionedFolders/complexDiff.json
+++ b/mdm-testing-functional/src/integration-test/resources/versionedFolders/complexDiff.json
@@ -2,7 +2,7 @@
   "leftId": "${json-unit.matches:id}",
   "rightId": "${json-unit.matches:id}",
   "label": "Functional Test VersionedFolder Complex",
-  "count": 86,
+  "count": 87,
   "diffs": [
     {
       "description": {
@@ -696,7 +696,7 @@
             "leftId": "${json-unit.matches:id}",
             "rightId": "${json-unit.matches:id}",
             "label": "Functional Test DataModel 1",
-            "count": 24,
+            "count": 25,
             "diffs": [
               {
                 "description": {
@@ -1072,7 +1072,7 @@
                           "finalised": false
                         }
                       ],
-                      "count": 5,
+                      "count": 6,
                       "diffs": [
                         {
                           "dataClasses": {
@@ -1179,6 +1179,48 @@
                                     }
                                   ]
                                 }
+                              }
+                            ],
+                            "modified": [
+                              {
+                                "leftId": "${json-unit.matches:id}",
+                                "rightId": "${json-unit.matches:id}",
+                                "label": "existingDataElement",
+                                "leftBreadcrumbs": [
+                                  {
+                                    "id": "${json-unit.matches:id}",
+                                    "label": "Functional Test DataModel 1",
+                                    "domainType": "DataModel",
+                                    "finalised": false
+                                  },
+                                  {
+                                    "id": "${json-unit.matches:id}",
+                                    "label": "existingClass",
+                                    "domainType": "DataClass"
+                                  }
+                                ],
+                                "rightBreadcrumbs": [
+                                  {
+                                    "id": "${json-unit.matches:id}",
+                                    "label": "Functional Test DataModel 1",
+                                    "domainType": "DataModel",
+                                    "finalised": false
+                                  },
+                                  {
+                                    "id": "${json-unit.matches:id}",
+                                    "label": "existingClass",
+                                    "domainType": "DataClass"
+                                  }
+                                ],
+                                "count": 1,
+                                "diffs": [
+                                  {
+                                    "dataTypePath": {
+                                      "left": "dm:Functional Test DataModel 1$source|dt:existingDataType2",
+                                      "right": "dm:Functional Test DataModel 1$main|dt:existingDataType1"
+                                    }
+                                  }
+                                ]
                               }
                             ]
                           }


### PR DESCRIPTION
Closes #222 

Handle merging when the Data Type of a Data Element has been changed in a branch.

- Use ```dataTypePath``` rather than ```dataType.label``` as a diff identifier, and use pathing to identify when the Data Type of a Data Element has really ben changed
- Update merge test data builder and test results