### PR TITLE
mc-9777 sendEmailToUser when not using ApiPropertyEnum

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/email/EmailService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/email/EmailService.groovy
@@ -108,6 +108,32 @@ class EmailService implements AnonymisableService {
     }
 
     /**
+     * Alternative to the above method for use when the API Property keys are not in the ApiPropertyEnum
+     * @param baseUrl
+     * @param subjectProperty
+     * @param bodyProperty
+     * @param user
+     * @param informationAwareItem
+     */
+    void sendEmailToUser(String baseUrl,
+                         String subjectProperty,
+                         String bodyProperty,
+                         User user,
+                         InformationAware informationAwareItem) {
+
+        Map<String, String> propertiesMap = buildUserPropertiesMap(user, informationAwareItem, baseUrl, null)
+
+        SendEmailTask task = new SendEmailTask(this)
+            .using(getEmailProviderService())
+            .from(getApiPropertyAndSubstitute(ApiPropertyEnum.EMAIL_FROM_NAME, propertiesMap), getApiPropertyAndSubstitute(ApiPropertyEnum.EMAIL_FROM_ADDRESS, propertiesMap))
+            .to("${user.getFirstName()} ${user.getLastName()}", user.getEmailAddress())
+            .subject(getApiPropertyAndSubstitute(subjectProperty, propertiesMap))
+            .body(getApiPropertyAndSubstitute(bodyProperty, propertiesMap))
+
+        executorService.submit(task)
+    }
+
+    /**
      * Delete all emails sent to the specified address
      * @param sentTo
      */
@@ -145,6 +171,16 @@ class EmailService implements AnonymisableService {
     String getApiPropertyAndSubstitute(ApiPropertyEnum key,
                                        Map<String, String> propertiesMap) {
         ApiProperty property = apiPropertyService.findByApiPropertyEnum(key)
+        if (property) {
+            StringSubstitutor sub = new StringSubstitutor(propertiesMap)
+            return sub.replace(property.value)
+        }
+        null
+    }
+
+    String getApiPropertyAndSubstitute(String key,
+                                       Map<String, String> propertiesMap) {
+        ApiProperty property = apiPropertyService.findByKey(key)
         if (property) {
             StringSubstitutor sub = new StringSubstitutor(propertiesMap)
             return sub.replace(property.value)


### PR DESCRIPTION
When sending emails, plugins may wish to use API Properties which are specific to the plugin, rather than being defined in the ApiPropertyEnum.

This PR adds a method sendEmailToUser with relevant API Property keys passed as strings rather than ApiPropertyEnum.

