### PR TITLE
gh-275 Control access into non-secured domains contained inside other non-secured domains

### DIFF
--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/AnnotationController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/AnnotationController.groovy
@@ -59,7 +59,7 @@ class AnnotationController extends FacetController<Annotation> {
     protected Annotation createResource() {
         Annotation resource = super.createResource() as Annotation
         if (params.annotationId) {
-            annotationService.get(params.annotationId)?.addToChildAnnotations(resource)
+            annotationService.findByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.annotationId)?.addToChildAnnotations(resource)
         }
         if (!resource.label && resource.parentAnnotation) {
             resource.label = "${resource.parentAnnotation.label} [${resource.parentAnnotation.childAnnotations.size()}]"

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/AnnotationInterceptor.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/AnnotationInterceptor.groovy
@@ -17,10 +17,13 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core.facet
 
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.core.interceptor.FacetInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class AnnotationInterceptor extends FacetInterceptor {
+
+    AnnotationService annotationService
 
     @Override
     Class getFacetClass() {
@@ -31,6 +34,14 @@ class AnnotationInterceptor extends FacetInterceptor {
     void checkAdditionalIds() {
         Utils.toUuid(params, 'annotationId')
     }
+
+    @Override
+    void checkParentId() throws ApiBadRequestException {
+        if (params.annotationId && !annotationService.existsByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.annotationId)) {
+            throw new ApiBadRequestException('AI01', 'Provided annotationId is not inside provided multiFacetAwareItemId')
+        }
+    }
+
 
     boolean before() {
         facetResourceChecks()

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/rule/RuleRepresentationController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/rule/RuleRepresentationController.groovy
@@ -46,9 +46,9 @@ class RuleRepresentationController extends EditLoggingController<RuleRepresentat
         //Create the RuleRepresentation
         RuleRepresentation resource = super.createResource() as RuleRepresentation
         //Create an association between the Rule and RuleRepresentation
-        ruleService.get(params.ruleId)?.addToRuleRepresentations(resource)
+        ruleService.findByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.ruleId)?.addToRuleRepresentations(resource)
         resource
-    }    
+    }
 
     @Override
     protected RuleRepresentation saveResource(RuleRepresentation resource) {
@@ -57,7 +57,7 @@ class RuleRepresentationController extends EditLoggingController<RuleRepresentat
         ruleService.
             addCreatedEditToMultiFacetAwareItemOfRule(currentUser, resource, params.multiFacetAwareItemDomainType, params.multiFacetAwareItemId)
         resource
-    }     
+    }
 
     @Override
     protected RuleRepresentation updateResource(RuleRepresentation resource) {
@@ -67,12 +67,12 @@ class RuleRepresentationController extends EditLoggingController<RuleRepresentat
         ruleService.
             addUpdatedEditToMultiFacetAwareItemOfRule(currentUser, resource, params.multiFacetAwareItemDomainType, params.multiFacetAwareItemId,
                                                       dirtyPropertyNames)
-    }        
+    }
 
     @Override
     void deleteResource(RuleRepresentation resource) {
         serviceDeleteResource(resource)
-    } 
+    }
 
     @Override
     void serviceDeleteResource(RuleRepresentation resource) {
@@ -85,6 +85,6 @@ class RuleRepresentationController extends EditLoggingController<RuleRepresentat
         ruleService.get(params.ruleId)?.removeFromRuleRepresentations(resource)
 
         //Delete the RuleRepresentation
-        ruleRepresentationService.delete(resource, true)           
+        ruleRepresentationService.delete(resource, true)
     }
 }

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/rule/RuleRepresentationInterceptor.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/rule/RuleRepresentationInterceptor.groovy
@@ -17,10 +17,14 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core.facet.rule
 
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.core.facet.RuleService
 import uk.ac.ox.softeng.maurodatamapper.core.interceptor.FacetInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class RuleRepresentationInterceptor extends FacetInterceptor {
+
+    RuleService ruleService
 
     @Override
     Class getFacetClass() {
@@ -35,5 +39,12 @@ class RuleRepresentationInterceptor extends FacetInterceptor {
     @Override
     void checkAdditionalIds() {
         Utils.toUuid(params, 'ruleId')
+    }
+
+    @Override
+    void checkParentId() throws ApiBadRequestException {
+        if (!ruleService.existsByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.ruleId)) {
+            throw new ApiBadRequestException('AI01', 'Provided ruleId is not inside provided multiFacetAwareItemId')
+        }
     }
 }

--- a/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/facet/Annotation.groovy
+++ b/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/facet/Annotation.groovy
@@ -158,7 +158,7 @@ class Annotation implements MultiFacetItemAware, InformationAware, Diffable<Anno
         new DetachedCriteria<Annotation>(Annotation).inList('multiFacetAwareItemId', multiFacetAwareItemIds)
     }
 
-    static DetachedCriteria<Annotation> byyMultiFacetAwareItemIdAndId(Serializable multiFacetAwareItemId, Serializable resourceId) {
+    static DetachedCriteria<Annotation> byMultiFacetAwareItemIdAndId(Serializable multiFacetAwareItemId, Serializable resourceId) {
         byMultiFacetAwareItemId(multiFacetAwareItemId).idEq(Utils.toUuid(resourceId))
     }
 

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/AnnotationService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/AnnotationService.groovy
@@ -78,9 +78,13 @@ class AnnotationService implements MultiFacetItemAwareService<Annotation> {
         annotation
     }
 
+    boolean existsByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
+        Annotation.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).count() == 1
+    }
+
     @Override
     Annotation findByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
-        Annotation.byyMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).get()
+        Annotation.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).get()
     }
 
     @Override

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/RuleService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/RuleService.groovy
@@ -108,6 +108,11 @@ class RuleService implements MultiFacetItemAwareService<Rule> {
         true
     }
 
+
+    boolean existsByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
+        Rule.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).count() == 1
+    }
+
     @Override
     Rule findByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
         Rule.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).get()

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/interceptor/FacetInterceptor.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/interceptor/FacetInterceptor.groovy
@@ -58,12 +58,17 @@ abstract class FacetInterceptor implements MdmInterceptor {
         // No-op
     }
 
+    void checkParentId() throws ApiBadRequestException {
+        // no op
+    }
+
     void facetResourceChecks() {
         Utils.toUuid(params, 'id')
-        params.multiFacetAwareItemDomainType = params.multiFacetAwareItemDomainType?: params.catalogueItemDomainType ?: params.containerDomainType
+        params.multiFacetAwareItemDomainType = params.multiFacetAwareItemDomainType ?: params.catalogueItemDomainType ?: params.containerDomainType
         params.multiFacetAwareItemId = params.multiFacetAwareItemId ?: params.catalogueItemId ?: params.containerId
         checkAdditionalIds()
         mapDomainTypeToClass(getOwningType(), true)
+        checkParentId()
     }
 
     boolean checkActionAllowedOnFacet() {

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/interceptor/ModelItemInterceptor.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/interceptor/ModelItemInterceptor.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.core.interceptor
+
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.core.traits.controller.MdmInterceptor
+import uk.ac.ox.softeng.maurodatamapper.util.Utils
+
+/**
+ * @since 02/03/2022
+ */
+abstract class ModelItemInterceptor implements MdmInterceptor {
+
+    abstract Class getModelItemClass()
+
+    abstract Class getModelClass()
+
+    abstract String getModelIdParameterField()
+
+    abstract String getOtherModelIdParameterField()
+
+    void checkIds() {
+        Utils.toUuid(params, getModelIdParameterField())
+        Utils.toUuid(params, getOtherModelIdParameterField())
+        Utils.toUuid(params, 'id')
+    }
+
+    void checkModelId() throws ApiBadRequestException {
+        if (!params[modelIdParameterField]) throw new ApiBadRequestException('MII01', 'No Model Id provided against secured resource')
+    }
+
+    /**
+     * Check that when an is MI accessed through another MI the parent MI is contained inside the Model
+     * Should throw ApiBadRequestException
+     */
+    void checkParentModelItemId() throws ApiBadRequestException {
+    }
+
+    void performChecks() {
+        checkIds()
+        checkModelId()
+        checkParentModelItemId()
+    }
+
+    boolean checkStandardActions() {
+        checkActionAuthorisationOnUnsecuredResource(getModelItemClass(), params.id, getModelClass(), params[modelIdParameterField])
+    }
+
+    boolean canReadModel() {
+        currentUserSecurityPolicyManager.userCanReadSecuredResourceId(getModelClass(), params[modelIdParameterField]) ?:
+        notFound(getModelClass(), params[modelIdParameterField].toString()
+        )
+    }
+
+    boolean canEditModelAndReadOtherModel() {
+        boolean canRead = currentUserSecurityPolicyManager.userCanReadSecuredResourceId(getModelClass(), params[modelIdParameterField])
+        if (!currentUserSecurityPolicyManager.userCanEditSecuredResourceId(getModelClass(), params[modelIdParameterField])) {
+            return forbiddenOrNotFound(canRead, getModelClass(), params[modelIdParameterField])
+        }
+        if (!currentUserSecurityPolicyManager.userCanReadSecuredResourceId(getModelClass(), params[otherModelIdParameterField])) {
+            return notFound(getModelClass(), params[otherModelIdParameterField])
+        }
+        true
+    }
+}

--- a/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/facet/NestedAnnotationControllerSpec.groovy
+++ b/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/facet/NestedAnnotationControllerSpec.groovy
@@ -90,7 +90,7 @@ class NestedAnnotationControllerSpec extends ResourceControllerSpec<Annotation> 
             {String domain, UUID bid -> basicModel.id == bid ? basicModel : null}
             findByMultiFacetAwareItemIdAndId(_, _) >> {UUID iid, Serializable mid ->
                 if (iid != basicModel.id) return null
-                mid == domain.id ? domain : null
+                mid == domain.id ? domain : Annotation.get(mid)
             }
             findAllWhereRootAnnotationOfMultiFacetAwareItemId(_, _) >> {
                 Annotation.whereRootAnnotationOfMultiFacetAwareItemId(basicModel.id).list()

--- a/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentController.groovy
+++ b/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentController.groovy
@@ -95,7 +95,7 @@ class DataClassComponentController extends EditLoggingController<DataClassCompon
     @Override
     protected DataClassComponent createResource() {
         DataClassComponent resource = super.createResource() as DataClassComponent
-        resource.dataFlow = dataFlowService.get(params.dataFlowId)
+        resource.dataFlow = dataFlowService.findByTargetDataModelIdAndId(params.dataModelId, params.dataFlowId)
         if (resource.targetDataClasses && resource.sourceDataClasses) {
             dataClassService.addDataClassesAreFromDataClasses(resource.targetDataClasses, resource.sourceDataClasses, currentUser)
         }

--- a/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentInterceptor.groovy
+++ b/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentInterceptor.groovy
@@ -17,12 +17,15 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.dataflow.component
 
-
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.dataflow.DataFlowService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.traits.controller.DataModelSecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class DataClassComponentInterceptor extends DataModelSecuredInterceptor {
+
+    DataFlowService dataFlowService
 
     @Override
     Class getModelItemClass() {
@@ -35,6 +38,13 @@ class DataClassComponentInterceptor extends DataModelSecuredInterceptor {
         Utils.toUuid(params, 'dataFlowId')
         Utils.toUuid(params, 'dataClassComponentId')
         Utils.toUuid(params, 'dataClassId')
+    }
+
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        if (!dataFlowService.existsByTargetDataModelIdAndId(params.dataModelId, params.dataFlowId)) {
+            throw new ApiBadRequestException('DEI01', 'Provided dataFlowId is not inside provided dataModelId')
+        }
     }
 
     boolean before() {

--- a/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentController.groovy
+++ b/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentController.groovy
@@ -108,7 +108,7 @@ class DataElementComponentController extends EditLoggingController<DataElementCo
     @Override
     protected DataElementComponent createResource() {
         DataElementComponent resource = super.createResource() as DataElementComponent
-        resource.dataClassComponent = dataClassComponentService.get(params.dataClassComponentId)
+        resource.dataClassComponent = dataClassComponentService.findByDataFlowIdAndId(params.dataFlowId, params.dataClassComponentId)
 
         if (!resource.dataClassComponent) {
             resource.dataClassComponent = dataClassComponentService.findOrCreateDataClassComponentForDataElementComponent(resource, currentUser)

--- a/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentInterceptor.groovy
+++ b/mdm-plugin-dataflow/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentInterceptor.groovy
@@ -17,11 +17,16 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.dataflow.component
 
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.dataflow.DataFlowService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.traits.controller.DataModelSecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class DataElementComponentInterceptor extends DataModelSecuredInterceptor {
+
+    DataFlowService dataFlowService
+    DataClassComponentService dataClassComponentService
 
     @Override
     Class getModelItemClass() {
@@ -36,6 +41,16 @@ class DataElementComponentInterceptor extends DataModelSecuredInterceptor {
         Utils.toUuid(params, 'dataElementComponentId')
         Utils.toUuid(params, 'dataElementId')
         Utils.toUuid(params, 'dataClassId')
+    }
+
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        if (!dataFlowService.existsByTargetDataModelIdAndId(params.dataModelId, params.dataFlowId)) {
+            throw new ApiBadRequestException('DEI01', 'Provided dataFlowId is not inside provided dataModelId')
+        }
+        if (!dataClassComponentService.existsByDataFlowIdAndId(params.dataFlowId, params.dataClassComponentId)) {
+            throw new ApiBadRequestException('DEI01', 'Provided dataClassComponentId is not inside provided dataFlowId')
+        }
     }
 
     boolean before() {

--- a/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/DataFlowService.groovy
+++ b/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/DataFlowService.groovy
@@ -121,6 +121,10 @@ class DataFlowService extends ModelItemService<DataFlow> {
         DataFlow.byTargetDataModelIdAndId(dataModelId, Utils.toUuid(id)).get()
     }
 
+    boolean existsByTargetDataModelIdAndId(UUID dataModelId, Serializable id) {
+        DataFlow.byTargetDataModelIdAndId(dataModelId, Utils.toUuid(id)).count() == 1
+    }
+
     List<DataFlow> findAllReadableByUser(UserSecurityPolicyManager userSecurityPolicyManager, Map pagination = [:]) {
         if (!userSecurityPolicyManager.listReadableSecuredResourceIds(DataModel)) return []
         DataFlow.byDataModelIdInList(

--- a/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentService.groovy
+++ b/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentService.groovy
@@ -144,6 +144,10 @@ class DataClassComponentService extends ModelItemService<DataClassComponent> {
         DataClassComponent.byDataFlowIdAndId(dataFlowId, Utils.toUuid(id)).get()
     }
 
+    boolean existsByDataFlowIdAndId(UUID dataFlowId, Serializable id) {
+        DataClassComponent.byDataFlowIdAndId(dataFlowId, Utils.toUuid(id)).count() == 1
+    }
+
     List<DataClassComponent> findAllByDataFlowId(UUID dataFlowId, Map pagination = [:]) {
         DataClassComponent.byDataFlowId(dataFlowId).list(pagination)
     }

--- a/mdm-plugin-dataflow/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/dataflow/DataFlowInterceptorSpec.groovy
+++ b/mdm-plugin-dataflow/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/dataflow/DataFlowInterceptorSpec.groovy
@@ -46,7 +46,7 @@ class DataFlowInterceptorSpec extends ContainedResourceInterceptorUnitSpec imple
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 
     @Override

--- a/mdm-plugin-dataflow/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentInterceptorSpec.groovy
+++ b/mdm-plugin-dataflow/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentInterceptorSpec.groovy
@@ -18,6 +18,7 @@
 package uk.ac.ox.softeng.maurodatamapper.dataflow.component
 
 import uk.ac.ox.softeng.maurodatamapper.dataflow.DataFlow
+import uk.ac.ox.softeng.maurodatamapper.dataflow.DataFlowService
 import uk.ac.ox.softeng.maurodatamapper.dataflow.component.DataClassComponent
 import uk.ac.ox.softeng.maurodatamapper.dataflow.component.DataElementComponent
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
@@ -33,6 +34,9 @@ class DataClassComponentInterceptorSpec extends ContainedResourceInterceptorUnit
     def setup() {
         log.debug('Setting up DataClassComponentInterceptorSpec')
         mockDomains(DataModel, DataClass, DataClassComponent, DataElementComponent, DataFlow)
+        interceptor.dataFlowService = Stub(DataFlowService) {
+            existsByTargetDataModelIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -48,7 +52,7 @@ class DataClassComponentInterceptorSpec extends ContainedResourceInterceptorUnit
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 
     @Override

--- a/mdm-plugin-dataflow/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentInterceptorSpec.groovy
+++ b/mdm-plugin-dataflow/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentInterceptorSpec.groovy
@@ -18,6 +18,7 @@
 package uk.ac.ox.softeng.maurodatamapper.dataflow.component
 
 import uk.ac.ox.softeng.maurodatamapper.dataflow.DataFlow
+import uk.ac.ox.softeng.maurodatamapper.dataflow.DataFlowService
 import uk.ac.ox.softeng.maurodatamapper.dataflow.component.DataClassComponent
 import uk.ac.ox.softeng.maurodatamapper.dataflow.component.DataElementComponent
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
@@ -34,6 +35,12 @@ class DataElementComponentInterceptorSpec extends ContainedResourceInterceptorUn
     def setup() {
         log.debug('Setting up DataElementComponentInterceptorSpec')
         mockDomains(DataModel, DataClass, DataClassComponent, DataElementComponent, DataFlow)
+        interceptor.dataFlowService = Stub(DataFlowService) {
+            existsByTargetDataModelIdAndId(_, _) >> true
+        }
+        interceptor.dataClassComponentService = Stub(DataClassComponentService) {
+            existsByDataFlowIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -50,7 +57,7 @@ class DataElementComponentInterceptorSpec extends ContainedResourceInterceptorUn
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 
     @Override

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/summarymetadata/SummaryMetadataReportController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/summarymetadata/SummaryMetadataReportController.groovy
@@ -51,7 +51,7 @@ class SummaryMetadataReportController extends EditLoggingController<SummaryMetad
     protected SummaryMetadataReport createResource() {
         SummaryMetadataReport resource = super.createResource() as SummaryMetadataReport
         resource.clearErrors()
-        resource.summaryMetadata = summaryMetadataService.get(params.summaryMetadataId)
+        resource.summaryMetadata = summaryMetadataService.findByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.summaryMetadataId)
         resource
     }
 

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/summarymetadata/SummaryMetadataReportInterceptor.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/summarymetadata/SummaryMetadataReportInterceptor.groovy
@@ -17,12 +17,15 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.facet.summarymetadata
 
-
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.core.interceptor.FacetInterceptor
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadata
+import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadataService
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class SummaryMetadataReportInterceptor extends FacetInterceptor {
+
+    SummaryMetadataService summaryMetadataService
 
     @Override
     Class getFacetClass() {
@@ -36,6 +39,14 @@ class SummaryMetadataReportInterceptor extends FacetInterceptor {
 
     boolean before() {
         facetResourceChecks()
+        checkParentId()
         checkActionAllowedOnFacet()
+    }
+
+    @Override
+    void checkParentId() throws ApiBadRequestException {
+        if (!summaryMetadataService.existsByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.summaryMetadataId)) {
+            throw new ApiBadRequestException('AI01', 'Provided summaryMetadataId is not inside provided multiFacetAwareItemId')
+        }
     }
 }

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassController.groovy
@@ -282,7 +282,7 @@ class DataClassController extends CatalogueItemController<DataClass> {
     protected DataClass createResource() {
         DataClass resource = super.createResource() as DataClass
         if (params.dataClassId) {
-            dataClassService.get(params.dataClassId)?.addToDataClasses(resource)
+            dataClassService.findByDataModelIdAndId(params.dataModelId, params.dataClassId)?.addToDataClasses(resource)
         }
         dataModelService.get(params.dataModelId)?.addToDataClasses(resource)
 

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassInterceptor.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassInterceptor.groovy
@@ -17,11 +17,13 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.item
 
-
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.datamodel.traits.controller.DataModelSecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class DataClassInterceptor extends DataModelSecuredInterceptor {
+
+    DataClassService dataClassService
 
     @Override
     Class getModelItemClass() {
@@ -36,15 +38,22 @@ class DataClassInterceptor extends DataModelSecuredInterceptor {
         Utils.toUuid(params, 'otherDataElementId')
     }
 
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        if (params.dataClassId && !dataClassService.existsByDataModelIdAndId(params.dataModelId, params.dataClassId)) {
+            throw new ApiBadRequestException('DCI01', 'Provided dataClassId is not inside provided dataModelId')
+        }
+    }
+
     boolean before() {
         performChecks()
 
         if (actionName in ['content', 'all', 'search']) {
-            return canReadDataModel()
+            return canReadModel()
         }
 
         if (actionName in ['copyDataClass', 'extendDataClass', 'importDataElement', 'importDataClass']) {
-            return canEditDataModelAndReadOtherDataModel()
+            return canEditModelAndReadOtherModel()
         }
 
         checkStandardActions()

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementController.groovy
@@ -160,7 +160,8 @@ class DataElementController extends CatalogueItemController<DataElement> {
     @Override
     protected DataElement createResource() {
         DataElement resource = super.createResource() as DataElement
-        dataClassService.get(params.dataClassId)?.addToDataElements(resource)
+        // Protect against mismatch DM and DC (DC not inside DM
+        dataClassService.findByDataModelIdAndId(params.dataModelId, params.dataClassId)?.addToDataElements(resource)
         resource
     }
 

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementInterceptor.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementInterceptor.groovy
@@ -17,11 +17,14 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.item
 
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.traits.controller.DataModelSecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class DataElementInterceptor extends DataModelSecuredInterceptor {
+
+    DataClassService dataClassService
 
     @Override
     Class getModelItemClass() {
@@ -34,6 +37,13 @@ class DataElementInterceptor extends DataModelSecuredInterceptor {
         Utils.toUuid(params, 'dataClassId')
         Utils.toUuid(params, 'otherDataClassId')
         Utils.toUuid(params, 'otherDataElementId')
+    }
+
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        if (params.containsKey('dataClassId') && !dataClassService.existsByDataModelIdAndId(params.dataModelId, params.dataClassId)) {
+            throw new ApiBadRequestException('DEI01', 'Provided dataClassId is not inside provided dataModelId')
+        }
     }
 
     boolean before() {
@@ -50,7 +60,7 @@ class DataElementInterceptor extends DataModelSecuredInterceptor {
         }
 
         if (actionName == 'copyDataElement') {
-            return canEditDataModelAndReadOtherDataModel()
+            return canEditModelAndReadOtherModel()
         }
 
         checkStandardActions()

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeInterceptor.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeInterceptor.groovy
@@ -26,7 +26,7 @@ class DataTypeInterceptor extends DataModelSecuredInterceptor {
         performChecks()
 
         if (actionName == 'copyDataType') {
-            return canEditDataModelAndReadOtherDataModel()
+            return canEditModelAndReadOtherModel()
         }
         checkStandardActions()
     }

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueController.groovy
@@ -55,7 +55,7 @@ class EnumerationValueController extends CatalogueItemController<EnumerationValu
     @Override
     protected EnumerationValue createResource() {
         EnumerationValue resource = super.createResource() as EnumerationValue
-        enumerationTypeService.get(params.enumerationTypeId ?: params.dataTypeId)?.addToEnumerationValues(resource)
+        enumerationTypeService.findByDataModelIdAndId(params.dataModelId, params.enumerationTypeId ?: params.dataTypeId)?.addToEnumerationValues(resource)
         resource
     }
 }

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueInterceptor.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueInterceptor.groovy
@@ -17,10 +17,14 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.enumeration
 
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.EnumerationTypeService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.traits.controller.DataModelSecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class EnumerationValueInterceptor extends DataModelSecuredInterceptor {
+
+    EnumerationTypeService enumerationTypeService
 
     @Override
     void checkIds() {
@@ -37,5 +41,13 @@ class EnumerationValueInterceptor extends DataModelSecuredInterceptor {
     @Override
     Class getModelItemClass() {
         EnumerationValue
+    }
+
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        UUID dtId = params.enumerationTypeId ?: params.dataTypeId
+        if (!enumerationTypeService.existsByDataModelIdAndId(params.dataModelId, dtId)) {
+            throw new ApiBadRequestException('EVI01', 'Provided enumerationTypeId/dataTypeId is not inside provided dataModelId')
+        }
     }
 }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/SummaryMetadataService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/SummaryMetadataService.groovy
@@ -90,6 +90,10 @@ class SummaryMetadataService implements MultiFacetItemAwareService<SummaryMetada
         copy
     }
 
+    boolean existsByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
+        SummaryMetadata.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).count() == 1
+    }
+
     @Override
     SummaryMetadata findByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
         SummaryMetadata.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).get()

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -420,6 +420,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         false
     }
 
+    boolean existsByDataModelIdAndId(UUID dataModelId, Serializable id) {
+        DataClass.byDataModelId(dataModelId).idEq(id).count() == 1
+    }
+
     DataClass findByDataModelIdAndId(UUID dataModelId, Serializable id) {
         DataClass.byDataModelId(dataModelId).idEq(id).find()
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/EnumerationTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/EnumerationTypeService.groovy
@@ -209,4 +209,12 @@ class EnumerationTypeService extends ModelItemService<EnumerationType> implement
             }
         }
     }
+
+    EnumerationType findByDataModelIdAndId(Serializable dataModelId, Serializable id) {
+        EnumerationType.byDataModelIdAndId(dataModelId, id).find() as EnumerationType
+    }
+
+    boolean existsByDataModelIdAndId(Serializable dataModelId, Serializable id) {
+        EnumerationType.byDataModelIdAndId(dataModelId, id).count() == 1
+    }
 }

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/test/functional/CatalogueItemSummaryMetadataReportFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/test/functional/CatalogueItemSummaryMetadataReportFunctionalSpec.groovy
@@ -57,11 +57,6 @@ abstract class CatalogueItemSummaryMetadataReportFunctionalSpec extends Catalogu
         "summaryMetadata/${summaryMetadata.id}/summaryMetadataReports"
     }
 
-    @Override
-    String getCopyResourcePath(String copyId) {
-        "${catalogueItemDomainResourcePath}/${copyId}/${facetResourcePath}"
-    }
-
     String getCatalogueItemCopyPath() {
         "dataModels/${destinationDataModelId}/${catalogueItemDomainResourcePath}/${sourceDataModelId}/${catalogueItemId}"
     }
@@ -104,13 +99,15 @@ abstract class CatalogueItemSummaryMetadataReportFunctionalSpec extends Catalogu
 
     HttpResponse requestCIF01CopiedCatalogueItemFacet(HttpResponse response) {
         String copyId = response.body().id
-        GET(getCopyResourcePath(copyId), MAP_ARG, true)
+        // Get the SM that was copied
+        GET("${catalogueItemDomainResourcePath}/${copyId}/summaryMetadata", MAP_ARG, true)
     }
 
     void verifyCIF01CopiedFacetSuccessfully(HttpResponse response) {
         verifyResponse(HttpStatus.OK, response)
-        assert response.body().count == 1
-        assert response.body().items.size() == 1
+        // summary metadata should not be copied for DC/DT/DE
+        assert response.body().count == 0
+        assert response.body().items.size() == 0
     }
 
     void 'CIF01 : Test facet copied with catalogue item'() {

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/traits/controller/DataModelSecuredInterceptor.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/traits/controller/DataModelSecuredInterceptor.groovy
@@ -17,51 +17,27 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.traits.controller
 
-import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
-import uk.ac.ox.softeng.maurodatamapper.core.traits.controller.MdmInterceptor
+
+import uk.ac.ox.softeng.maurodatamapper.core.interceptor.ModelItemInterceptor
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
-import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 /**
  * @since 20/03/2020
  */
-abstract class DataModelSecuredInterceptor implements MdmInterceptor {
+abstract class DataModelSecuredInterceptor extends ModelItemInterceptor {
 
-    abstract Class getModelItemClass()
-
-    void checkIds() {
-        Utils.toUuid(params, 'dataModelId')
-        Utils.toUuid(params, 'id')
-        Utils.toUuid(params, 'otherDataModelId')
+    @Override
+    Class getModelClass() {
+        DataModel
     }
 
-    void checkDataModelId() {
-        if (!params.dataModelId) throw new ApiBadRequestException('DMSI01', 'No DataModel Id provided against secured resource')
+    @Override
+    String getModelIdParameterField() {
+        'dataModelId'
     }
 
-    void performChecks() {
-        checkIds()
-        checkDataModelId()
-    }
-
-    boolean checkStandardActions() {
-        checkActionAuthorisationOnUnsecuredResource(getModelItemClass(), params.id, DataModel, params.dataModelId)
-    }
-
-    boolean canReadDataModel() {
-        currentUserSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, params.dataModelId) ?: notFound(DataModel,
-                                                                                                                 params.dataModelId.toString()
-        )
-    }
-
-    boolean canEditDataModelAndReadOtherDataModel() {
-        boolean canRead = currentUserSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, params.dataModelId)
-        if (!currentUserSecurityPolicyManager.userCanEditSecuredResourceId(DataModel, params.dataModelId)) {
-            return forbiddenOrNotFound(canRead, DataModel, params.dataModelId)
-        }
-        if (!currentUserSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, params.otherDataModelId)) {
-            return notFound(DataModel, params.otherDataModelId)
-        }
-        true
+    @Override
+    String getOtherModelIdParameterField() {
+        'otherDataModelId'
     }
 }

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/summarymetadata/SummaryMetadataReportInterceptorSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/summarymetadata/SummaryMetadataReportInterceptorSpec.groovy
@@ -19,6 +19,7 @@ package uk.ac.ox.softeng.maurodatamapper.datamodel.facet.summarymetadata
 
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadata
+import uk.ac.ox.softeng.maurodatamapper.datamodel.facet.SummaryMetadataService
 import uk.ac.ox.softeng.maurodatamapper.test.unit.interceptor.VariableContainedResourceInterceptorSpec
 
 import grails.testing.web.interceptor.InterceptorUnitTest
@@ -28,6 +29,9 @@ class SummaryMetadataReportInterceptorSpec extends VariableContainedResourceInte
 
     def setup() {
         mockDomains(DataModel, SummaryMetadata)
+        interceptor.summaryMetadataService = Stub(SummaryMetadataService) {
+            existsByMultiFacetAwareItemIdAndId(_, _) >> true
+        }
     }
 
     @Override

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassInterceptorSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassInterceptorSpec.groovy
@@ -34,6 +34,9 @@ class DataClassInterceptorSpec extends ContainedResourceInterceptorUnitSpec impl
     def setup() {
         log.debug('Setting up DataClassInterceptorSpec')
         mockDomains(DataModel, DataClass, DataElement, DataType, PrimitiveType, ReferenceType, EnumerationType, EnumerationValue)
+        interceptor.dataClassService = Stub(DataClassService) {
+            existsByDataModelIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -48,7 +51,7 @@ class DataClassInterceptorSpec extends ContainedResourceInterceptorUnitSpec impl
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 
     @Override

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementInterceptorSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementInterceptorSpec.groovy
@@ -34,6 +34,9 @@ class DataElementInterceptorSpec extends ContainedResourceInterceptorUnitSpec im
     def setup() {
         log.debug('Setting up DataElementInterceptorSpec')
         mockDomains(DataModel, DataClass, DataElement, DataType, PrimitiveType, ReferenceType, EnumerationType, EnumerationValue)
+        interceptor.dataClassService = Stub(DataClassService) {
+            existsByDataModelIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -53,6 +56,6 @@ class DataElementInterceptorSpec extends ContainedResourceInterceptorUnitSpec im
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 }

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeInterceptorSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeInterceptorSpec.groovy
@@ -51,6 +51,6 @@ class DataTypeInterceptorSpec extends ContainedResourceInterceptorUnitSpec imple
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 }

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueInterceptorSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueInterceptorSpec.groovy
@@ -17,12 +17,12 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.enumeration
 
-
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClass
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataElement
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.EnumerationType
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.EnumerationTypeService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.PrimitiveType
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.ReferenceType
 import uk.ac.ox.softeng.maurodatamapper.test.unit.interceptor.ContainedResourceInterceptorUnitSpec
@@ -37,6 +37,9 @@ class EnumerationValueInterceptorSpec extends ContainedResourceInterceptorUnitSp
         log.debug('Setting up EnumerationValueInterceptorSpec')
         mockDomains(DataModel, DataClass, DataElement, DataType, PrimitiveType,
                     ReferenceType, EnumerationType, EnumerationValue)
+        interceptor.enumerationTypeService = Stub(EnumerationTypeService) {
+            existsByDataModelIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -56,6 +59,6 @@ class EnumerationValueInterceptorSpec extends ContainedResourceInterceptorUnitSp
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 }

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/ReferenceSummaryMetadataReportController.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/ReferenceSummaryMetadataReportController.groovy
@@ -51,7 +51,7 @@ class ReferenceSummaryMetadataReportController extends EditLoggingController<Ref
     protected ReferenceSummaryMetadataReport createResource() {
         ReferenceSummaryMetadataReport resource = super.createResource() as ReferenceSummaryMetadataReport
         resource.clearErrors()
-        resource.summaryMetadata = referenceSummaryMetadataService.get(params.referenceSummaryMetadataId)
+        resource.summaryMetadata = referenceSummaryMetadataService.findByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.referenceSummaryMetadataId)
         resource
     }
 

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/ReferenceSummaryMetadataReportInterceptor.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/ReferenceSummaryMetadataReportInterceptor.groovy
@@ -17,12 +17,15 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.referencedata.facet.summarymetadata
 
-
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
 import uk.ac.ox.softeng.maurodatamapper.core.interceptor.FacetInterceptor
 import uk.ac.ox.softeng.maurodatamapper.referencedata.facet.ReferenceSummaryMetadata
+import uk.ac.ox.softeng.maurodatamapper.referencedata.facet.ReferenceSummaryMetadataService
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class ReferenceSummaryMetadataReportInterceptor extends FacetInterceptor {
+
+    ReferenceSummaryMetadataService referenceSummaryMetadataService
 
     @Override
     Class getFacetClass() {
@@ -37,5 +40,12 @@ class ReferenceSummaryMetadataReportInterceptor extends FacetInterceptor {
     boolean before() {
         facetResourceChecks()
         checkActionAllowedOnFacet()
+    }
+
+    @Override
+    void checkParentId() throws ApiBadRequestException {
+        if (!referenceSummaryMetadataService.existsByMultiFacetAwareItemIdAndId(params.multiFacetAwareItemId, params.referenceSummaryMetadataId)) {
+            throw new ApiBadRequestException('RSMRII01', 'Provided referenceSummaryMetadataId is not inside provided multiFacetAwareItemId')
+        }
     }
 }

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueInterceptor.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueInterceptor.groovy
@@ -30,7 +30,7 @@ class ReferenceDataValueInterceptor extends ReferenceDataModelSecuredInterceptor
         performChecks()
 
         if (actionName in ['search']) {
-            return canReadReferenceDataModel()
+            return canReadModel()
         }
 
         checkStandardActions()

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueController.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueController.groovy
@@ -55,7 +55,9 @@ class ReferenceEnumerationValueController extends CatalogueItemController<Refere
     @Override
     protected ReferenceEnumerationValue createResource() {
         ReferenceEnumerationValue resource = super.createResource() as ReferenceEnumerationValue
-        referenceEnumerationTypeService.get(params.referenceEnumerationTypeId ?: params.referenceDataTypeId)?.addToReferenceEnumerationValues(resource)
+        referenceEnumerationTypeService.findByReferenceDataModelIdAndId(
+            params.referenceDataModelId,
+            params.referenceEnumerationTypeId ?: params.referenceDataTypeId)?.addToReferenceEnumerationValues(resource)
         resource
     }
 }

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueInterceptor.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueInterceptor.groovy
@@ -17,10 +17,14 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.referencedata.item.datatype.enumeration
 
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.referencedata.item.datatype.ReferenceEnumerationTypeService
 import uk.ac.ox.softeng.maurodatamapper.referencedata.traits.controller.ReferenceDataModelSecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class ReferenceEnumerationValueInterceptor extends ReferenceDataModelSecuredInterceptor {
+
+    ReferenceEnumerationTypeService referenceEnumerationTypeService
 
     @Override
     void checkIds() {
@@ -37,5 +41,13 @@ class ReferenceEnumerationValueInterceptor extends ReferenceDataModelSecuredInte
     @Override
     Class getModelItemClass() {
         ReferenceEnumerationValue
+    }
+
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        UUID dtId = params.referenceEnumerationTypeId ?: params.referenceDataTypeId
+        if (!referenceEnumerationTypeService.existsByReferenceDataModelIdAndId(params.referenceDataModelId, dtId)) {
+            throw new ApiBadRequestException('REVI01', 'Provided referenceEnumerationTypeId/referenceDataTypeId is not inside provided referenceDataModelId')
+        }
     }
 }

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/ReferenceSummaryMetadataService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/ReferenceSummaryMetadataService.groovy
@@ -81,6 +81,10 @@ class ReferenceSummaryMetadataService implements MultiFacetItemAwareService<Refe
         domain.addToReferenceSummaryMetadata(facet)
     }
 
+    boolean existsByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
+        ReferenceSummaryMetadata.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).count() == 1
+    }
+
     @Override
     ReferenceSummaryMetadata findByMultiFacetAwareItemIdAndId(UUID multiFacetAwareItemId, Serializable id) {
         ReferenceSummaryMetadata.byMultiFacetAwareItemIdAndId(multiFacetAwareItemId, id).get()

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceEnumerationTypeService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceEnumerationTypeService.groovy
@@ -180,4 +180,12 @@ class ReferenceEnumerationTypeService extends ModelItemService<ReferenceEnumerat
     List<ReferenceEnumerationType> findAllByMetadataNamespace(String namespace, Map pagination) {
         ReferenceEnumerationType.byMetadataNamespace(namespace).list(pagination)
     }
+
+    boolean existsByReferenceDataModelIdAndId(Serializable referenceDataModelId, Serializable id) {
+        ReferenceEnumerationType.byReferenceDataModelIdAndId(referenceDataModelId, id).count() == 1
+    }
+
+    ReferenceEnumerationType findByReferenceDataModelIdAndId(Serializable referenceDataModelId, Serializable id) {
+        ReferenceEnumerationType.byReferenceDataModelIdAndId(referenceDataModelId, id).find() as ReferenceEnumerationType
+    }
 }

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/report/ReferenceDataElementReferenceSummaryMetadataReportFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/report/ReferenceDataElementReferenceSummaryMetadataReportFunctionalSpec.groovy
@@ -49,10 +49,6 @@ class ReferenceDataElementReferenceSummaryMetadataReportFunctionalSpec extends C
     @Shared
     ReferenceDataType referenceDataType
 
-    String getCatalogueItemCopyPath() {
-        """referenceDataModels/${destinationDataModelId}/${catalogueItemDomainResourcePath}/${sourceDataModelId}/${catalogueItemId}"""
-    }
-
     @Transactional
     String getSourceDataModelId() {
         ReferenceDataModel.findByLabel('Functional Test DataModel').id.toString()
@@ -61,11 +57,6 @@ class ReferenceDataElementReferenceSummaryMetadataReportFunctionalSpec extends C
     @Transactional
     String getDestinationDataModelId() {
         ReferenceDataModel.findByLabel('Destination Test DataModel').id.toString()
-    }
-
-    @Override
-    String getFacetResourcePath() {
-        "referenceSummaryMetadata/${summaryMetadata.id}/summaryMetadataReports"
     }
 
     @RunOnce
@@ -83,8 +74,7 @@ class ReferenceDataElementReferenceSummaryMetadataReportFunctionalSpec extends C
                                       referenceDataModel: referenceDataModel, referenceDataType: referenceDataType).save(flush: true)
         summaryMetadata = new ReferenceSummaryMetadata(label: 'Functional Test Summary Metadata', createdBy: StandardEmailAddress.FUNCTIONAL_TEST,
                                                        multiFacetAwareItem: referenceDataElement,
-                                                       summaryMetadataType: ReferenceSummaryMetadataType.NUMBER).
-            save(flush: true)
+                                                       summaryMetadataType: ReferenceSummaryMetadataType.NUMBER).save(flush: true)
         sessionFactory.currentSession.flush()
     }
 

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/report/ReferenceDataModelReferenceSummaryMetadataReportFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/report/ReferenceDataModelReferenceSummaryMetadataReportFunctionalSpec.groovy
@@ -50,10 +50,6 @@ class ReferenceDataModelReferenceSummaryMetadataReportFunctionalSpec extends Cat
     @Shared
     ReferenceDataType referenceDataType
 
-    String getCatalogueItemCopyPath() {
-        """referenceDataModels/${destinationDataModelId}/${catalogueItemDomainResourcePath}/${sourceDataModelId}/${catalogueItemId}"""
-    }
-
     @Transactional
     String getSourceDataModelId() {
         ReferenceDataModel.findByLabel('Functional Test DataModel').id.toString()
@@ -62,11 +58,6 @@ class ReferenceDataModelReferenceSummaryMetadataReportFunctionalSpec extends Cat
     @Transactional
     String getDestinationDataModelId() {
         ReferenceDataModel.findByLabel('Destination Test DataModel').id.toString()
-    }
-
-    @Override
-    String getFacetResourcePath() {
-        "referenceSummaryMetadata/${summaryMetadata.id}/summaryMetadataReports"
     }
 
     @RunOnce
@@ -83,7 +74,7 @@ class ReferenceDataModelReferenceSummaryMetadataReportFunctionalSpec extends Cat
         referenceDataElement = new ReferenceDataElement(label: 'Functional Test DataElement', createdBy: StandardEmailAddress.FUNCTIONAL_TEST,
                                       referenceDataModel: referenceDataModel, referenceDataType: referenceDataType).save(flush: true)
         summaryMetadata = new ReferenceSummaryMetadata(label: 'Functional Test Summary Metadata', createdBy: StandardEmailAddress.FUNCTIONAL_TEST,
-                                                       multiFacetAwareItem: referenceDataElement,
+                                                       multiFacetAwareItem: referenceDataModel,
                                                        summaryMetadataType: ReferenceSummaryMetadataType.NUMBER).save(flush: true)
         sessionFactory.currentSession.flush()
     }

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/report/ReferenceDataTypeReferenceSummaryMetadataReportFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/report/ReferenceDataTypeReferenceSummaryMetadataReportFunctionalSpec.groovy
@@ -49,10 +49,6 @@ class ReferenceDataTypeReferenceSummaryMetadataReportFunctionalSpec extends Cata
     @Shared
     ReferenceDataType referenceDataType
 
-    String getCatalogueItemCopyPath() {
-        """referenceDataModels/${destinationDataModelId}/${catalogueItemDomainResourcePath}/${sourceDataModelId}/${catalogueItemId}"""
-    }
-
     @Transactional
     String getSourceDataModelId() {
         ReferenceDataModel.findByLabel('Functional Test DataModel').id.toString()
@@ -61,11 +57,6 @@ class ReferenceDataTypeReferenceSummaryMetadataReportFunctionalSpec extends Cata
     @Transactional
     String getDestinationDataModelId() {
         ReferenceDataModel.findByLabel('Destination Test DataModel').id.toString()
-    }
-
-    @Override
-    String getFacetResourcePath() {
-        "referenceSummaryMetadata/${summaryMetadata.id}/summaryMetadataReports"
     }
 
     @RunOnce
@@ -82,7 +73,7 @@ class ReferenceDataTypeReferenceSummaryMetadataReportFunctionalSpec extends Cata
         referenceDataElement = new ReferenceDataElement(label: 'Functional Test DataElement', createdBy: StandardEmailAddress.FUNCTIONAL_TEST,
                                       referenceDataModel: referenceDataModel, referenceDataType: referenceDataType).save(flush: true)
         summaryMetadata = new ReferenceSummaryMetadata(label: 'Functional Test Summary Metadata', createdBy: StandardEmailAddress.FUNCTIONAL_TEST,
-                                                       multiFacetAwareItem: referenceDataElement,
+                                                       multiFacetAwareItem: referenceDataType,
                                                        summaryMetadataType: ReferenceSummaryMetadataType.NUMBER).save(flush: true)
         sessionFactory.currentSession.flush()
     }

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/test/functional/CatalogueItemReferenceSummaryMetadataReportFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/test/functional/CatalogueItemReferenceSummaryMetadataReportFunctionalSpec.groovy
@@ -56,16 +56,11 @@ abstract class CatalogueItemReferenceSummaryMetadataReportFunctionalSpec extends
 
     @Override
     String getFacetResourcePath() {
-        "summaryMetadata/${summaryMetadata.id}/summaryMetadataReports"
-    }
-
-    @Override
-    String getCopyResourcePath(String copyId) {
-        "${catalogueItemDomainResourcePath}/${copyId}/${facetResourcePath}"
+        "referenceSummaryMetadata/${summaryMetadata.id}/summaryMetadataReports"
     }
 
     String getCatalogueItemCopyPath() {
-        "dataModels/${destinationDataModelId}/${catalogueItemDomainResourcePath}/${sourceDataModelId}/${catalogueItemId}"
+        "referenceDataModels/${destinationDataModelId}/${catalogueItemDomainResourcePath}/${sourceDataModelId}/${catalogueItemId}"
     }
 
     @Override
@@ -106,13 +101,14 @@ abstract class CatalogueItemReferenceSummaryMetadataReportFunctionalSpec extends
 
     HttpResponse requestCIF01CopiedCatalogueItemFacet(HttpResponse response) {
         String copyId = response.body().id
-        GET(getCopyResourcePath(copyId), MAP_ARG, true)
+        GET("${catalogueItemDomainResourcePath}/${copyId}/referenceSummaryMetadata", MAP_ARG, true)
     }
 
     void verifyCIF01CopiedFacetSuccessfully(HttpResponse response) {
         verifyResponse(HttpStatus.OK, response)
-        assert response.body().count == 1
-        assert response.body().items.size() == 1
+        // summary metadata should not be copied for DC/DT/DE
+        assert response.body().count == 0
+        assert response.body().items.size() == 0
     }
 
     void 'CIF01 : Test facet copied with catalogue item'() {

--- a/mdm-plugin-referencedata/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/traits/controller/ReferenceDataModelSecuredInterceptor.groovy
+++ b/mdm-plugin-referencedata/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/traits/controller/ReferenceDataModelSecuredInterceptor.groovy
@@ -17,41 +17,28 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.referencedata.traits.controller
 
-import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
-import uk.ac.ox.softeng.maurodatamapper.core.traits.controller.MdmInterceptor
+
+import uk.ac.ox.softeng.maurodatamapper.core.interceptor.ModelItemInterceptor
 import uk.ac.ox.softeng.maurodatamapper.referencedata.ReferenceDataModel
-import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 /**
  * @since 20/03/2020
  */
-abstract class ReferenceDataModelSecuredInterceptor implements MdmInterceptor {
+abstract class ReferenceDataModelSecuredInterceptor extends ModelItemInterceptor {
 
-    abstract Class getModelItemClass()
-
-    void checkIds() {
-        Utils.toUuid(params, 'referenceDataModelId')
-        Utils.toUuid(params, 'id')
-        Utils.toUuid(params, 'otherReferenceDataModelId')
+    @Override
+    Class getModelClass() {
+        ReferenceDataModel
     }
 
-    void checkReferenceDataModelId() {
-        if (!params.referenceDataModelId) throw new ApiBadRequestException('DMSI01', 'No Reference Data Model Id provided against secured resource')
+    @Override
+    String getModelIdParameterField() {
+        'referenceDataModelId'
     }
 
-    void performChecks() {
-        checkIds()
-        checkReferenceDataModelId()
-    }
-
-    boolean checkStandardActions() {
-        checkActionAuthorisationOnUnsecuredResource(getModelItemClass(), params.id, ReferenceDataModel, params.referenceDataModelId)
-    }
-
-    boolean canReadReferenceDataModel() {
-        currentUserSecurityPolicyManager.userCanReadSecuredResourceId(ReferenceDataModel, params.referenceDataModelId) ?: notFound(ReferenceDataModel,
-                                                                                                                 params.referenceDataModelId.toString()
-        )
+    @Override
+    String getOtherModelIdParameterField() {
+        'otherReferenceDataModelId'
     }
 
     boolean canCopyFromReferenceDataModelToOtherReferenceDataModel() {

--- a/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/ReferenceSummaryMetadataReportInterceptorSpec.groovy
+++ b/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/facet/summarymetadata/ReferenceSummaryMetadataReportInterceptorSpec.groovy
@@ -19,6 +19,7 @@ package uk.ac.ox.softeng.maurodatamapper.referencedata.facet.summarymetadata
 
 import uk.ac.ox.softeng.maurodatamapper.referencedata.ReferenceDataModel
 import uk.ac.ox.softeng.maurodatamapper.referencedata.facet.ReferenceSummaryMetadata
+import uk.ac.ox.softeng.maurodatamapper.referencedata.facet.ReferenceSummaryMetadataService
 import uk.ac.ox.softeng.maurodatamapper.test.unit.interceptor.VariableContainedResourceInterceptorSpec
 
 import grails.testing.web.interceptor.InterceptorUnitTest
@@ -28,6 +29,9 @@ class ReferenceSummaryMetadataReportInterceptorSpec extends VariableContainedRes
 
     def setup() {
         mockDomains(ReferenceDataModel, ReferenceSummaryMetadata)
+        interceptor.referenceSummaryMetadataService = Stub(ReferenceSummaryMetadataService) {
+            existsByMultiFacetAwareItemIdAndId(_, _) >> true
+        }
     }
 
     @Override

--- a/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementInterceptorSpec.groovy
+++ b/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementInterceptorSpec.groovy
@@ -52,6 +52,6 @@ class ReferenceDataElementInterceptorSpec extends ContainedResourceInterceptorUn
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 }

--- a/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceDataTypeInterceptorSpec.groovy
+++ b/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceDataTypeInterceptorSpec.groovy
@@ -51,6 +51,6 @@ class ReferenceDataTypeInterceptorSpec extends ContainedResourceInterceptorUnitS
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 }

--- a/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueInterceptorSpec.groovy
+++ b/mdm-plugin-referencedata/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueInterceptorSpec.groovy
@@ -22,6 +22,7 @@ import uk.ac.ox.softeng.maurodatamapper.referencedata.ReferenceDataModel
 import uk.ac.ox.softeng.maurodatamapper.referencedata.item.ReferenceDataElement
 import uk.ac.ox.softeng.maurodatamapper.referencedata.item.datatype.ReferenceDataType
 import uk.ac.ox.softeng.maurodatamapper.referencedata.item.datatype.ReferenceEnumerationType
+import uk.ac.ox.softeng.maurodatamapper.referencedata.item.datatype.ReferenceEnumerationTypeService
 import uk.ac.ox.softeng.maurodatamapper.referencedata.item.datatype.ReferencePrimitiveType
 import uk.ac.ox.softeng.maurodatamapper.test.unit.interceptor.ContainedResourceInterceptorUnitSpec
 
@@ -35,6 +36,9 @@ class ReferenceEnumerationValueInterceptorSpec extends ContainedResourceIntercep
         log.debug('Setting up ReferenceEnumerationValueInterceptorSpec')
         mockDomains(ReferenceDataModel, ReferenceDataElement, ReferenceDataType, ReferencePrimitiveType,
                     ReferenceEnumerationType, ReferenceEnumerationValue)
+        interceptor.referenceEnumerationTypeService = Stub(ReferenceEnumerationTypeService) {
+            existsByReferenceDataModelIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -54,6 +58,6 @@ class ReferenceEnumerationValueInterceptorSpec extends ContainedResourceIntercep
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'DMSI01'
+        'MII01'
     }
 }

--- a/mdm-plugin-terminology/grails-app/conf/application.yml
+++ b/mdm-plugin-terminology/grails-app/conf/application.yml
@@ -176,7 +176,6 @@ environments:
             url: 'jdbc:h2:mem:${database.name};LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;INIT=${database.creation}'
     development:
         dataSource:
-            dbCreate: create-drop
             username: maurodatamapper
             password: MauroDataMapper1234
 

--- a/mdm-plugin-terminology/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermInterceptor.groovy
+++ b/mdm-plugin-terminology/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermInterceptor.groovy
@@ -36,7 +36,7 @@ class TermInterceptor extends TerminologySecuredInterceptor {
     }
 
     @Override
-    void checkTerminologyId() {
+    void checkModelId() {
         if (!params.codeSetId && !params.terminologyId) {
             throw new ApiBadRequestException('TSI01', 'No TerminologyId or CodeSet provided against secured resource')
         }
@@ -46,7 +46,7 @@ class TermInterceptor extends TerminologySecuredInterceptor {
         performChecks()
 
         if (actionName in ['search', 'tree']) {
-            return canReadTerminology()
+            return canReadModel()
         }
 
         if (isIndex() && params.containsKey('codeSetId')) {

--- a/mdm-plugin-terminology/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipInterceptor.groovy
+++ b/mdm-plugin-terminology/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipInterceptor.groovy
@@ -17,11 +17,16 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.terminology.item.term
 
-
+import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
+import uk.ac.ox.softeng.maurodatamapper.terminology.item.TermRelationshipTypeService
+import uk.ac.ox.softeng.maurodatamapper.terminology.item.TermService
 import uk.ac.ox.softeng.maurodatamapper.terminology.traits.controller.TerminologySecuredInterceptor
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 class TermRelationshipInterceptor extends TerminologySecuredInterceptor {
+
+    TermService termService
+    TermRelationshipTypeService termRelationshipTypeService
 
     @Override
     Class getModelItemClass() {
@@ -33,6 +38,16 @@ class TermRelationshipInterceptor extends TerminologySecuredInterceptor {
         super.checkIds()
         Utils.toUuid(params, 'termId')
         Utils.toUuid(params, 'termRelationshipTypeId')
+    }
+
+    @Override
+    void checkParentModelItemId() throws ApiBadRequestException {
+        if (params.containsKey('termId') && !termService.existsByTerminologyIdAndId(params.terminologyId, params.termId)) {
+            throw new ApiBadRequestException('DEI01', 'Provided termId is not inside provided terminology')
+        }
+        if (params.containsKey('termRelationshipTypeId') && !termRelationshipTypeService.existsByTerminologyIdAndId(params.terminologyId, params.termRelationshipTypeId)) {
+            throw new ApiBadRequestException('DEI01', 'Provided termRelationshipTypeId is not inside provided terminology')
+        }
     }
 
     boolean before() {

--- a/mdm-plugin-terminology/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationship.groovy
+++ b/mdm-plugin-terminology/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationship.groovy
@@ -60,7 +60,10 @@ class TermRelationship implements ModelItem<TermRelationship, Terminology> {
 
     static constraints = {
         CallableConstraints.call(ModelItemConstraints, delegate)
-        sourceTerm validator: {val, obj -> val == obj.targetTerm ? ['invalid.same.property.message', 'targetTerm'] : true}
+        sourceTerm validator: {val, obj ->
+            if (val == obj.targetTerm) return ['invalid.same.property.message', 'targetTerm']
+            if (val.terminology != obj.targetTerm.terminology) return ['invalid.relationship.different.terminologies']
+        }
     }
 
     static mapping = {

--- a/mdm-plugin-terminology/grails-app/i18n/messages.properties
+++ b/mdm-plugin-terminology/grails-app/i18n/messages.properties
@@ -15,4 +15,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
+invalid.relationship.different.terminologies=Term Relationship must use Terms from inside the same Terminology
+invalid.relationship.different.terms=Term Relationship must define one of its Terms as the termId requested

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermRelationshipTypeService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermRelationshipTypeService.groovy
@@ -93,6 +93,10 @@ class TermRelationshipTypeService extends ModelItemService<TermRelationshipType>
         TermRelationshipType.byTerminologyIdAndId(terminologyId, Utils.toUuid(id)).find()
     }
 
+    boolean existsByTerminologyIdAndId(UUID terminologyId, Serializable id) {
+        TermRelationshipType.byTerminologyIdAndId(terminologyId, Utils.toUuid(id)).count() == 1
+    }
+
     @Override
     TermRelationshipType copy(Model copiedTerminology, TermRelationshipType original, CatalogueItem nonModelParent,
                               UserSecurityPolicyManager userSecurityPolicyManager) {

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermService.groovy
@@ -184,6 +184,11 @@ class TermService extends ModelItemService<Term> {
         Term.byTerminologyId(terminologyId).id().list() as List<UUID>
     }
 
+    boolean existsByTerminologyIdAndId(UUID terminologyId, Serializable id) {
+        Term.byTerminologyIdAndId(terminologyId, Utils.toUuid(id)).count() == 1
+    }
+
+
     Term findByTerminologyIdAndId(UUID terminologyId, Serializable id) {
         Term.byTerminologyIdAndId(terminologyId, Utils.toUuid(id)).find()
     }

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipService.groovy
@@ -51,6 +51,12 @@ class TermRelationshipService extends ModelItemService<TermRelationship> {
         TermRelationship.count()
     }
 
+    @Override
+    TermRelationship validate(TermRelationship modelItem) {
+        modelItem.validate()
+        modelItem
+    }
+
     void delete(Serializable id) {
         TermRelationship termRelationship = get(id)
         if (termRelationship) delete(termRelationship)

--- a/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyFunctionalSpec.groovy
+++ b/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyFunctionalSpec.groovy
@@ -890,7 +890,7 @@ class TerminologyFunctionalSpec extends ResourceFunctionalSpec<Terminology> impl
         responseBody().parentalRelationship
 
         when: 'checking relationships'
-        GET("$id/terms/$terms.DAM/termRelationships")
+        GET("$branchId/terms/$terms.DAM/termRelationships")
 
         then:
         verifyResponse(OK, response)
@@ -900,7 +900,7 @@ class TerminologyFunctionalSpec extends ResourceFunctionalSpec<Terminology> impl
         responseBody().items.first().relationshipType.id == relationshipTypes.inverseOf
 
         when: 'checking relationships'
-        GET("$id/terms/$terms.MLO/termRelationships")
+        GET("$branchId/terms/$terms.MLO/termRelationships")
 
         then:
         verifyResponse(OK, response)
@@ -917,7 +917,7 @@ class TerminologyFunctionalSpec extends ResourceFunctionalSpec<Terminology> impl
         }
 
         when: 'checking relationships'
-        GET("$id/terms/$terms.SMLO/termRelationships")
+        GET("$branchId/terms/$terms.SMLO/termRelationships")
 
         then:
         verifyResponse(OK, response)

--- a/mdm-plugin-terminology/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/traits/controller/TerminologySecuredInterceptor.groovy
+++ b/mdm-plugin-terminology/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/traits/controller/TerminologySecuredInterceptor.groovy
@@ -17,49 +17,26 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.terminology.traits.controller
 
-import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiBadRequestException
-import uk.ac.ox.softeng.maurodatamapper.core.traits.controller.MdmInterceptor
+import uk.ac.ox.softeng.maurodatamapper.core.interceptor.ModelItemInterceptor
 import uk.ac.ox.softeng.maurodatamapper.terminology.Terminology
-import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 /**
  * @since 20/03/2020
  */
-abstract class TerminologySecuredInterceptor implements MdmInterceptor {
+abstract class TerminologySecuredInterceptor extends ModelItemInterceptor {
 
-    abstract Class getModelItemClass()
-
-    void checkIds() {
-        Utils.toUuid(params, 'terminologyId')
-        Utils.toUuid(params, 'id')
+    @Override
+    Class getModelClass() {
+        Terminology
     }
 
-    void checkTerminologyId() {
-        if (!params.terminologyId) throw new ApiBadRequestException('TSI01', 'No Terminology Id provided against secured resource')
+    @Override
+    String getModelIdParameterField() {
+        'terminologyId'
     }
 
-    void performChecks() {
-        checkIds()
-        checkTerminologyId()
-    }
-
-    boolean checkStandardActions() {
-        checkActionAuthorisationOnUnsecuredResource(getModelItemClass(), params.id, Terminology, params.terminologyId)
-    }
-
-    boolean canReadTerminology() {
-        currentUserSecurityPolicyManager.userCanReadSecuredResourceId(Terminology, params.terminologyId) ?:
-        notFound(Terminology, params.terminologyId.toString())
-    }
-
-    boolean canCopyFromTerminologyToOtherTerminology() {
-        boolean canRead = currentUserSecurityPolicyManager.userCanReadSecuredResourceId(Terminology, params.terminologyId)
-        if (!currentUserSecurityPolicyManager.userCanEditSecuredResourceId(Terminology, params.terminologyId)) {
-            return forbiddenOrNotFound(canRead, Terminology, params.terminologyId)
-        }
-        if (!currentUserSecurityPolicyManager.userCanReadSecuredResourceId(Terminology, params.otherTerminologyId)) {
-            return notFound(Terminology, params.otherTerminologyId)
-        }
-        true
+    @Override
+    String getOtherModelIdParameterField() {
+        'otherTerminologyId'
     }
 }

--- a/mdm-plugin-terminology/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermRelationshipTypeInterceptorSpec.groovy
+++ b/mdm-plugin-terminology/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermRelationshipTypeInterceptorSpec.groovy
@@ -50,7 +50,7 @@ class TermRelationshipTypeInterceptorSpec extends ContainedResourceInterceptorUn
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'TSI01'
+        'MII01'
     }
 
     @Override

--- a/mdm-plugin-terminology/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipInterceptorSpec.groovy
+++ b/mdm-plugin-terminology/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipInterceptorSpec.groovy
@@ -22,6 +22,7 @@ import uk.ac.ox.softeng.maurodatamapper.terminology.CodeSet
 import uk.ac.ox.softeng.maurodatamapper.terminology.Terminology
 import uk.ac.ox.softeng.maurodatamapper.terminology.item.Term
 import uk.ac.ox.softeng.maurodatamapper.terminology.item.TermRelationshipType
+import uk.ac.ox.softeng.maurodatamapper.terminology.item.TermService
 import uk.ac.ox.softeng.maurodatamapper.test.unit.interceptor.ContainedResourceInterceptorUnitSpec
 
 import grails.testing.web.interceptor.InterceptorUnitTest
@@ -33,6 +34,9 @@ class TermRelationshipInterceptorSpec extends ContainedResourceInterceptorUnitSp
     def setup() {
         log.debug('Setting up TermRelationshipInterceptorSpec')
         mockDomains(Folder, Terminology, Term, TermRelationship, TermRelationshipType, CodeSet)
+        interceptor.termService = Stub(TermService) {
+            existsByTerminologyIdAndId(_, _) >> true
+        }
     }
 
     @Override
@@ -47,7 +51,7 @@ class TermRelationshipInterceptorSpec extends ContainedResourceInterceptorUnitSp
 
     @Override
     String getExpectedExceptionCodeForNoContainingItem() {
-        'TSI01'
+        'MII01'
     }
 
     @Override

--- a/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/facet/CatalogueItemFacetFunctionalSpec.groovy
+++ b/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/facet/CatalogueItemFacetFunctionalSpec.groovy
@@ -22,6 +22,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.container.Folder
 import uk.ac.ox.softeng.maurodatamapper.test.functional.ResourceFunctionalSpec
 
 import grails.gorm.transactions.Transactional
+import grails.testing.spock.RunOnce
 import groovy.util.logging.Slf4j
 import org.grails.datastore.gorm.GormEntity
 import spock.lang.Shared
@@ -45,8 +46,9 @@ abstract class CatalogueItemFacetFunctionalSpec<D extends GormEntity> extends Re
         "${getCatalogueItemDomainResourcePath()}/${getCatalogueItemId()}/${getFacetResourcePath()}"
     }
 
+    @RunOnce
     @Transactional
-    def setupSpec() {
+    def setup() {
         log.debug('Check and setup folder')
         folder = new Folder(label: 'Functional Test Folder', createdBy: FUNCTIONAL_TEST)
         checkAndSave(folder)

--- a/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/unit/interceptor/ResourceInterceptorUnitSpec.groovy
+++ b/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/unit/interceptor/ResourceInterceptorUnitSpec.groovy
@@ -17,7 +17,6 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.test.unit.interceptor
 
-
 import uk.ac.ox.softeng.maurodatamapper.security.basic.NoAccessSecurityPolicyManager
 import uk.ac.ox.softeng.maurodatamapper.security.basic.PublicAccessSecurityPolicyManager
 import uk.ac.ox.softeng.maurodatamapper.test.unit.BaseUnitSpec


### PR DESCRIPTION
* Implement a ModelItemInterceptor to standardise MI access
* Update Interceptors where relevant to check the parent non-secured resource is actually inside the named provided resource
 This ensures access is stopped before it gets to the controllers
 It does require DB checking but theres no better way to prevent access across all endpoints
* Update controllers to get the parent object using the secured resource
 Whilst the interceptors should prevent getting here this is a fall back and just good practice
* Add validation to TermRelationship to check Terms are inside the same terminology
* Add validation to the TermRelationshipController to ensure the terms used in the body match the one in the URL
* Add service method for "exists" which uses count and a boolean return.
 This is faster than a find call