### PR TITLE
mc-9808 Allow a simplified creation for ReferenceTypes and ModelDataTypes

### DIFF
--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeController.groovy
@@ -23,7 +23,6 @@ import uk.ac.ox.softeng.maurodatamapper.core.controller.CatalogueItemController
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.CopyInformation
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModelService
-import uk.ac.ox.softeng.maurodatamapper.datamodel.databinding.converters.DataTypeValueConverter
 
 import grails.databinding.DataBindingSource
 import grails.gorm.transactions.Transactional
@@ -148,14 +147,7 @@ class DataTypeController extends CatalogueItemController<DataType> {
     @Transactional
     protected DataType createResource() {
         try {
-            DataTypeValueConverter converter = new DataTypeValueConverter()
-            def body = getObjectToBind()
-            if (converter.canConvert(body)) {
-                DataType resource = converter.convert(body)
-                resource.createdBy = currentUser.emailAddress
-                dataModelService.get(params.dataModelId)?.addToDataTypes(resource)
-                return resource
-            }
+          return dataTypeService.bindDataType(objectToBind, params.dataModelId, currentUser)
         } catch (ApiInvalidModelException ex) {
             transactionStatus.setRollbackOnly()
             respond ex.errors, view: 'create' // STATUS CODE 422

--- a/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ModelDataType.groovy
+++ b/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ModelDataType.groovy
@@ -22,7 +22,6 @@ import uk.ac.ox.softeng.maurodatamapper.core.diff.DiffBuilder
 import uk.ac.ox.softeng.maurodatamapper.core.diff.DiffCache
 import uk.ac.ox.softeng.maurodatamapper.core.diff.bidirectional.ObjectDiff
 import uk.ac.ox.softeng.maurodatamapper.core.model.Model
-import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 import grails.core.GrailsApplication
@@ -39,9 +38,6 @@ class ModelDataType extends DataType<ModelDataType> {
     String modelResourceDomainType
 
     static constraints = {
-        modelResourceDomainType validator: {source, obj ->
-            if (source == DataModel.simpleName) ['invalid.model.type.datatype']
-        }
     }
 
     ModelDataType() {

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ModelDataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ModelDataTypeService.groovy
@@ -23,6 +23,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.container.VersionedFolder
 import uk.ac.ox.softeng.maurodatamapper.core.model.CatalogueItem
 import uk.ac.ox.softeng.maurodatamapper.core.model.Model
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelItemService
+import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
 import uk.ac.ox.softeng.maurodatamapper.core.path.PathService
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.FieldPatchData
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
@@ -38,6 +39,7 @@ import uk.ac.ox.softeng.maurodatamapper.util.Utils
 import grails.gorm.transactions.Transactional
 import groovy.util.logging.Slf4j
 import org.grails.datastore.mapping.model.PersistentEntity
+import org.springframework.beans.factory.annotation.Autowired
 
 @Slf4j
 @Transactional
@@ -47,6 +49,9 @@ class ModelDataTypeService extends ModelItemService<ModelDataType> implements Su
     DataTypeService dataTypeService
     DataModelService dataModelService
     PathService pathService
+
+    @Autowired(required = false)
+    List<ModelService> modelServices
 
     @Override
     boolean handlesPathPrefix(String pathPrefix) {
@@ -222,5 +227,12 @@ class ModelDataTypeService extends ModelItemService<ModelDataType> implements Su
         }
 
         false
+    }
+
+    Model findModelByDomainTypeAndDomainId(String domainType, UUID domainId) {
+        for (ModelService service : modelServices) {
+            if (service.handles(domainType)) return service.get(domainId) as Model
+        }
+        null
     }
 }

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementFunctionalSpec.groovy
@@ -415,6 +415,46 @@ class DataElementFunctionalSpec extends OrderedResourceFunctionalSpec<DataElemen
 
     }
 
+    void 'test finding existing DataType alongside saving DataElement'() {
+
+        when: 'The save action is executed with valid data'
+        POST('',
+             [
+                 label          : 'Functional Test DataElement',
+                 maxMultiplicity: 2,
+                 minMultiplicity: 1,
+                 dataType       : [
+                     label     : 'Functional Test DataType',
+                     domainType: DataType.PRIMITIVE_DOMAIN_TYPE
+                 ]
+             ])
+
+        then:
+        verifyResponse(CREATED, response)
+        responseBody().dataType.id
+
+        when: 'posting again with the same DT type'
+        String dtId = responseBody().dataType.id
+        POST('',
+             [
+                 label          : 'Functional Test DataElement 2',
+                 maxMultiplicity: 2,
+                 minMultiplicity: 1,
+                 dataType       : [
+                     label     : 'Functional Test DataType',
+                     domainType: DataType.PRIMITIVE_DOMAIN_TYPE
+                 ]
+             ])
+
+        then:
+        verifyResponse(CREATED, response)
+        responseBody().dataType.id == dtId
+
+        cleanup:
+        cleanupCreatedDataTypes('Functional Test DataType')
+
+    }
+
     void 'test creation of DataType alongside updating DataElement'() {
         given:
         POST('', validJson)
@@ -474,7 +514,7 @@ class DataElementFunctionalSpec extends OrderedResourceFunctionalSpec<DataElemen
 
     }
 
-    void 'test creation of Reference DataType alongside saving DataElement'() {
+    void 'RT01 : test creation of Reference DataType alongside saving DataElement'() {
 
         when: 'The save action is executed with valid data'
         POST('',
@@ -545,6 +585,71 @@ class DataElementFunctionalSpec extends OrderedResourceFunctionalSpec<DataElemen
 
         cleanup:
         cleanupCreatedDataTypes('Functional Test DataType 3')
+
+    }
+
+    void 'RT02 : test creation of Reference DataType alongside saving DataElement with no label'() {
+
+        when: 'The save action is executed with valid data'
+        POST('',
+             [
+                 label          : 'Functional Test DataElement',
+                 maxMultiplicity: 2,
+                 minMultiplicity: 1,
+                 dataType       : [
+                     domainType    : DataType.REFERENCE_DOMAIN_TYPE,
+                     referenceClass: dataClassId
+                 ]
+             ])
+
+        then: 'The response is correct'
+        verifyResponse CREATED, response
+        responseBody().dataType.label == 'Reference to Functional Test DataClass'
+
+        cleanup:
+        cleanupCreatedDataTypes('Reference to Functional Test DataClass')
+
+    }
+
+    void 'RT03 : test creation of Reference DataType alongside saving DataElement with no label and prexisting'() {
+
+        when: 'The save action is executed with valid data'
+        POST('',
+             [
+                 label          : 'Functional Test DataElement',
+                 maxMultiplicity: 2,
+                 minMultiplicity: 1,
+                 dataType       : [
+                     domainType    : DataType.REFERENCE_DOMAIN_TYPE,
+                     referenceClass: dataClassId
+                 ]
+             ])
+
+        then: 'The response is correct'
+        verifyResponse CREATED, response
+        responseBody().dataType.label == 'Reference to Functional Test DataClass'
+
+
+        when: 'The save action is executed with valid data again'
+        String rdtId = responseBody().dataType.id
+        POST('',
+             [
+                 label          : 'Functional Test DataElement 2',
+                 maxMultiplicity: 2,
+                 minMultiplicity: 1,
+                 dataType       : [
+                     domainType    : DataType.REFERENCE_DOMAIN_TYPE,
+                     referenceClass: dataClassId
+                 ]
+             ])
+
+        then: 'The response is correct'
+        verifyResponse CREATED, response
+        responseBody().dataType.label == 'Reference to Functional Test DataClass'
+        responseBody().dataType.id == rdtId
+
+        cleanup:
+        cleanupCreatedDataTypes('Reference to Functional Test DataClass')
 
     }
 

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeFunctionalSpec.groovy
@@ -238,7 +238,7 @@ class DataTypeFunctionalSpec extends OrderedResourceFunctionalSpec<DataType> {
     }'''
     }
 
-    void "Test the save action correctly persists an instance for reference type"() {
+    void "RT01 : Test the save action correctly persists an instance for reference type"() {
 
         when: "The save action is executed with valid data"
         POST('',
@@ -282,15 +282,140 @@ class DataTypeFunctionalSpec extends OrderedResourceFunctionalSpec<DataType> {
     }'''
     }
 
+    void "RT02 : Test reference type saves without a label"() {
 
-    void "Test the save action correctly persists an instance for modeldata type"() {
         when: "The save action is executed with valid data"
-        UUID modelId = UUID.randomUUID()
+        POST('',
+             [
+                 domainType    : 'ReferenceType',
+                 referenceClass: dataClassId
+             ]
+             , STRING_ARG)
+
+        then: "The response is correct"
+        verifyJsonResponse CREATED, '''{
+      "lastUpdated": "${json-unit.matches:offsetDateTime}",
+      "domainType": "ReferenceType",
+      "availableActions": ["delete","show","update"],
+      "model": "${json-unit.matches:id}",
+      "id": "${json-unit.matches:id}",
+      "label": "Reference to Functional Test DataClass",
+      "breadcrumbs": [
+        {
+          "domainType": "DataModel",
+          "finalised": false,
+          "id": "${json-unit.matches:id}",
+          "label": "Functional Test DataModel"
+        }
+      ],
+      "referenceClass": {
+        "domainType": "DataClass",
+        "model": "${json-unit.matches:id}",
+        "id": "${json-unit.matches:id}",
+        "label": "Functional Test DataClass",
+        "breadcrumbs": [
+          {
+            "domainType": "DataModel",
+            "finalised": false,
+            "id": "${json-unit.matches:id}",
+            "label": "Functional Test DataModel"
+          }
+        ]
+      }
+    }'''
+    }
+
+    void "RT03 : Test reference type saves without a label for a second time"() {
+
+        when: "The save action is executed with valid data"
+        POST('',
+             [
+                 domainType    : 'ReferenceType',
+                 referenceClass: dataClassId
+             ]
+             , STRING_ARG)
+
+        then: "The response is correct"
+        verifyJsonResponse CREATED, '''{
+      "lastUpdated": "${json-unit.matches:offsetDateTime}",
+      "domainType": "ReferenceType",
+      "availableActions": ["delete","show","update"],
+      "model": "${json-unit.matches:id}",
+      "id": "${json-unit.matches:id}",
+      "label": "Reference to Functional Test DataClass",
+      "breadcrumbs": [
+        {
+          "domainType": "DataModel",
+          "finalised": false,
+          "id": "${json-unit.matches:id}",
+          "label": "Functional Test DataModel"
+        }
+      ],
+      "referenceClass": {
+        "domainType": "DataClass",
+        "model": "${json-unit.matches:id}",
+        "id": "${json-unit.matches:id}",
+        "label": "Functional Test DataClass",
+        "breadcrumbs": [
+          {
+            "domainType": "DataModel",
+            "finalised": false,
+            "id": "${json-unit.matches:id}",
+            "label": "Functional Test DataModel"
+          }
+        ]
+      }
+    }'''
+
+        when: "The save action is executed with valid data again"
+        POST('',
+             [
+                 domainType    : 'ReferenceType',
+                 referenceClass: dataClassId
+             ]
+             , STRING_ARG)
+
+        then: "The response is correct"
+        verifyJsonResponse CREATED, '''{
+      "lastUpdated": "${json-unit.matches:offsetDateTime}",
+      "domainType": "ReferenceType",
+      "availableActions": ["delete","show","update"],
+      "model": "${json-unit.matches:id}",
+      "id": "${json-unit.matches:id}",
+      "label": "Reference to Functional Test DataClass (1)",
+      "breadcrumbs": [
+        {
+          "domainType": "DataModel",
+          "finalised": false,
+          "id": "${json-unit.matches:id}",
+          "label": "Functional Test DataModel"
+        }
+      ],
+      "referenceClass": {
+        "domainType": "DataClass",
+        "model": "${json-unit.matches:id}",
+        "id": "${json-unit.matches:id}",
+        "label": "Functional Test DataClass",
+        "breadcrumbs": [
+          {
+            "domainType": "DataModel",
+            "finalised": false,
+            "id": "${json-unit.matches:id}",
+            "label": "Functional Test DataModel"
+          }
+        ]
+      }
+    }'''
+    }
+
+
+    void "MDT01 : Test the save action correctly persists an instance for modeldata type"() {
+        when: "The save action is executed with valid data"
         POST('', [
             domainType             : 'ModelDataType',
             label                  : 'functional modeldata',
-            modelResourceId        : modelId,
-            modelResourceDomainType: 'Terminology'
+            modelResourceId        : otherDataModelId,
+            modelResourceDomainType: 'DataModel'
         ], STRING_ARG)
 
         then: "The response is correct"
@@ -310,7 +435,36 @@ class DataTypeFunctionalSpec extends OrderedResourceFunctionalSpec<DataType> {
         }
       ],
       "modelResourceId": "${json-unit.matches:id}",
-      "modelResourceDomainType": "Terminology"
+      "modelResourceDomainType": "DataModel"
+    }'''
+    }
+
+    void "MDT02 :  Test model data type saves without a label"() {
+        when: "The save action is executed with valid data"
+        POST('', [
+            domainType             : 'ModelDataType',
+            modelResourceId        : otherDataModelId,
+            modelResourceDomainType: 'DataModel'
+        ], STRING_ARG)
+
+        then: "The response is correct"
+        verifyJsonResponse CREATED, '''{
+      "lastUpdated": "${json-unit.matches:offsetDateTime}",
+      "domainType": "ModelDataType",
+      "availableActions": ["delete","show","update"],
+      "model": "${json-unit.matches:id}",
+      "id": "${json-unit.matches:id}",
+      "label": "Reference to Functional Test DataModel 2",
+      "breadcrumbs": [
+        {
+          "domainType": "DataModel",
+          "finalised": false,
+          "id": "${json-unit.matches:id}",
+          "label": "Functional Test DataModel"
+        }
+      ],
+      "modelResourceId": "${json-unit.matches:id}",
+      "modelResourceDomainType": "DataModel"
     }'''
     }
 

--- a/mdm-testing-functional/grails-app/conf/application.yml
+++ b/mdm-testing-functional/grails-app/conf/application.yml
@@ -148,11 +148,6 @@ dataSource:
 environments:
     test:
         spring.flyway.enabled: false
-        maurodatamapper:
-            security:
-                max:
-                    lock:
-                        time: 1
         database:
             name: 'mtf'
             creation: 'CREATE SCHEMA IF NOT EXISTS CORE\;CREATE SCHEMA IF NOT EXISTS SECURITY\;CREATE SCHEMA IF NOT EXISTS DATAMODEL\;CREATE SCHEMA IF NOT EXISTS TERMINOLOGY\;CREATE SCHEMA IF NOT EXISTS DATAFLOW\;CREATE SCHEMA IF NOT EXISTS REFERENCEDATA\;CREATE SCHEMA IF NOT EXISTS FEDERATION'


### PR DESCRIPTION
* Allow POST to DataTypes without a label for RTs and MDTs
* Generate a default label of "Reference to X" where X is the label of the reference
* Confirm the existence of the reference
* If a DT already exists with that default label then generate a new one with the next number in order suffixed
* Allow POST to DataElements without a label in the DataType for creating new DTs alongside the DE
* Use the default label for RTs and MDTs when creating a DE if no label supplied
* Try and find existing DT with same domaintype and label when creating a DE and DT at the same time.
 If the DT exists then use that one rather than creating a new one which will fail as the DT already exists