### PR TITLE
Feature/gh 269 - Copy Data Class hierarchy for Reference Types

### DIFF
--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -178,10 +178,17 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements MdmDomai
             copy.addToRules(copiedRule)
         }
         semanticLinks.each {link ->
-            copy.addToSemanticLinks(createdBy: copier.emailAddress, linkType: link.linkType,
-                                    targetMultiFacetAwareItemId: link.targetMultiFacetAwareItemId,
-                                    targetMultiFacetAwareItemDomainType: link.targetMultiFacetAwareItemDomainType,
-                                    unconfirmed: true)
+            if (link.targetMultiFacetAwareItem) {
+                copy.addToSemanticLinks(createdBy: copier.emailAddress, linkType: link.linkType,
+                                        targetMultiFacetAwareItem: link.targetMultiFacetAwareItem,
+                                        unconfirmed: true)
+            } else {
+                copy.addToSemanticLinks(createdBy: copier.emailAddress, linkType: link.linkType,
+                                        targetMultiFacetAwareItemId: link.targetMultiFacetAwareItemId,
+                                        targetMultiFacetAwareItemDomainType: link.targetMultiFacetAwareItemDomainType,
+                                        unconfirmed: true)
+            }
+
         }
         copy
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -568,6 +568,71 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         parentDataClass.dataClasses.find { it.label == label.trim() }
     }
 
+    /**
+     * pathLabels represents a hierarchy of Data Classes in sourceDataModel. Ensure that the same hierarchy exists in
+     * targetDataModel, by copying classes from sourceDataModel where necessary.
+     * @param sourceDataModel
+     * @param targetDataModel
+     * @param pathLabels
+     * @return
+     */
+    DataClass findOrCopyDataClassHierarchyForReferenceTypeByPath(User user,
+                                                                 UserSecurityPolicyManager userSecurityPolicyManager,
+                                                                 DataModel sourceDataModel,
+                                                                 DataModel targetDataModel,
+                                                                 List<String> pathLabels,
+                                                                 DataClass parentDataClassInSource,
+                                                                 DataClass parentDataClassInTarget) {
+        DataClass sourceDataClass
+        DataClass targetDataClass
+
+        if (!pathLabels) return null
+
+        // If no parent class then assume we are looking in the data model
+        if (!parentDataClassInSource) {
+            sourceDataClass = findDataClass(sourceDataModel, pathLabels[0])
+            targetDataClass = findDataClass(targetDataModel, pathLabels[0])
+        } else {
+            sourceDataClass = findDataClass(parentDataClassInSource, pathLabels[0])
+            targetDataClass = findDataClass(parentDataClassInTarget, pathLabels[0])
+        }
+
+        if (!targetDataClass) {
+            targetDataClass = new DataClass(
+                minMultiplicity: sourceDataClass.minMultiplicity,
+                maxMultiplicity: sourceDataClass.maxMultiplicity,
+                createdBy: user.emailAddress,
+                description: sourceDataClass.description,
+                label: sourceDataClass.label
+            )
+
+            targetDataModel.addToDataClasses(targetDataClass)
+            if (parentDataClassInTarget) {
+                parentDataClassInTarget.addToDataClasses(targetDataClass)
+            }
+
+            if (!targetDataClass.validate())
+                throw new ApiInvalidModelException('DCS06', 'Copied DataClass is invalid', targetDataClass.errors, messageSource)
+
+            save(flush: false, validate: false, targetDataClass)
+        }
+
+
+        pathLabels.removeAt(0)
+
+        if (pathLabels.size() == 0) {
+            return targetDataClass
+        } else {
+            return findOrCopyDataClassHierarchyForReferenceTypeByPath(user,
+                                                                      userSecurityPolicyManager,
+                                                                      sourceDataModel,
+                                                                      targetDataModel,
+                                                                      pathLabels,
+                                                                      sourceDataClass,
+                                                                      targetDataClass)
+        }
+    }
+
     DataClass findDataClassByPath(DataModel dataModel, List<String> pathLabels) {
         if (!pathLabels) return null
         if (pathLabels.size() == 1) {
@@ -703,11 +768,14 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         emptyReferenceTypes.each { rt ->
             ReferenceType ort = originalDataModel.findDataTypeByLabel(rt.label) as ReferenceType
             String originalDataClassPath = buildPath(ort.referenceClass)
-            DataClass copiedDataClass = findDataClassByPath(copiedDataModel, originalDataClassPath.split(/\|/).toList())
-            if (!copiedDataClass) {
-                log.debug('Creating DataClass {} for referenceType {}', ort.referenceClass.label, rt.label)
-                copiedDataClass = copyDataClass(copiedDataModel, ort.referenceClass, copier, userSecurityPolicyManager)
-            }
+
+            DataClass copiedDataClass = findOrCopyDataClassHierarchyForReferenceTypeByPath(copier,
+                                                                                           userSecurityPolicyManager,
+                                                                                           originalDataModel,
+                                                                                           copiedDataModel,
+                                                                                           originalDataClassPath.split(/\|/).toList(),
+                                                                                           null,
+                                                                                           null)
             copiedDataClass.addToReferenceTypes(rt)
         }
         // Recursively loop until no empty reference classes

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -600,11 +600,10 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
         if (!targetDataClass) {
             targetDataClass = new DataClass(
                 minMultiplicity: sourceDataClass.minMultiplicity,
-                maxMultiplicity: sourceDataClass.maxMultiplicity,
-                createdBy: user.emailAddress,
-                description: sourceDataClass.description,
-                label: sourceDataClass.label
+                maxMultiplicity: sourceDataClass.maxMultiplicity
             )
+
+            targetDataClass = copyCatalogueItemInformation(sourceDataClass, targetDataClass, user, userSecurityPolicyManager, false, null)
 
             targetDataModel.addToDataClasses(targetDataClass)
             if (parentDataClassInTarget) {


### PR DESCRIPTION
When adding missing Reference Type Data Classes, copy the hierarchy of Data Classes containing the Reference Type.

Make a small change to the way Semantic Links are copied.

Closes #269 