### PR TITLE
Restrict profile validation to submitted data only

### DIFF
--- a/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/JsonProfileSpec.groovy
+++ b/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/JsonProfileSpec.groovy
@@ -39,9 +39,7 @@ class JsonProfileSpec extends BaseIntegrationSpec {
         Profile profile = new JsonProfile(id: UUID.randomUUID(), domainType: 'BasicModel', label: 'Test')
 
         then:
-        !profile.validate()
-        GormUtils.outputDomainErrors(messageSource, profile)
-        profile.errors.hasFieldErrors('sections')
+        profile.validate() // validates as profile validation restricted to current values (issue gh-277)
     }
 
     void '2 test validation when section with no fields'() {
@@ -52,9 +50,7 @@ class JsonProfileSpec extends BaseIntegrationSpec {
         ])
 
         then:
-        !profile.validate()
-        GormUtils.outputDomainErrors(messageSource, profile)
-        profile.errors.hasFieldErrors('sections[0].fields')
+        profile.validate() // validates as profile validation restricted to current values (issue gh-277)
     }
 
     void '3 test validation when section with mandatory fields'() {

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
@@ -36,9 +36,8 @@ class ProfileSection implements Cloneable, Validateable {
 
     @Override
     boolean validate() {
-        validate null, null, null
         fields.eachWithIndex {field, i ->
-            field.validate()
+            field.validate(['currentValue'])
             if (field.hasErrors()) {
                 field.errors.fieldErrors.each {err ->
                     this.errors.rejectValue("fields[$i].${err.field}", err.code, err.arguments, err.defaultMessage)

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
@@ -35,7 +35,6 @@ abstract class Profile implements Comparable<Profile>, Validateable {
 
     @Override
     boolean validate() {
-        validate null, null, null
         sections.eachWithIndex {sec, i ->
             sec.validate()
             if (sec.hasErrors()) {

--- a/mdm-testing-functional/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/InvalidProfileService.groovy
+++ b/mdm-testing-functional/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/InvalidProfileService.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.profile
+
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderService
+
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class InvalidProfileService extends JsonProfileProviderService {
+
+    @Override
+    String getMetadataNamespace() {
+        getNamespace() + '.invalid'
+    }
+
+    @Override
+    String getDisplayName() {
+        'Partially Invalid Profile'
+    }
+
+    @Override
+    String getJsonResourceFile() {
+        'InvalidProfile.json'
+    }
+
+    @Override
+    List<String> profileApplicableForDomains() {
+        ['DataModel']
+    }
+}

--- a/mdm-testing-functional/src/main/resources/InvalidProfile.json
+++ b/mdm-testing-functional/src/main/resources/InvalidProfile.json
@@ -1,0 +1,24 @@
+[
+  {
+    "sectionName": "Partially Invalid Section",
+    "sectionDescription": "Section with one valid and one invalid field",
+    "fields": [
+      {
+        "fieldName": "Valid Field",
+        "metadataPropertyName": "validField",
+        "description": "A field which is valid",
+        "minMultiplicity": 1,
+        "maxMultiplicity": 1,
+        "dataType": "text"
+      },
+      {
+        "fieldName": "Invalid Field with blank description",
+        "metadataPropertyName": "blankDescriptionField",
+        "description": "",
+        "minMultiplicity": 1,
+        "maxMultiplicity": 1,
+        "dataType": "int"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Don't validate profile structure as part of profile `/validate` endpoint (resolves #277)