### PR TITLE
Profile datatype fixes and restrict dynamic profile endpoints to finalised versions

### DIFF
--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/version/Version.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/version/Version.groovy
@@ -32,7 +32,7 @@ class Version implements Comparable<Version> {
     int patch
     boolean snapshot
 
-    static final Pattern VERSION_PATTERN = ~/(\d+)(\.(\d+)(\.(\d+))?)?(-SNAPSHOT)?/
+    static final Pattern VERSION_PATTERN = ~/((\d+)(\.(\d+)(\.(\d+))?)?(-SNAPSHOT)?)|SNAPSHOT/
 
     @Override
     int compareTo(Version that) {
@@ -71,6 +71,9 @@ class Version implements Comparable<Version> {
 
     @Override
     String toString() {
+        if (major == 0 && minor == 0 && patch == 0 && snapshot) {
+            return 'SNAPSHOT'
+        }
         snapshot ? "${major}.${minor}.${patch}-SNAPSHOT" : "${major}.${minor}.${patch}"
     }
 
@@ -91,15 +94,17 @@ class Version implements Comparable<Version> {
 
         if (!versionStr) throw new IllegalStateException("Must have a version")
 
+        if (versionStr == 'SNAPSHOT') return new Version(0, 0, 0, true)
+
         Matcher m = VERSION_PATTERN.matcher(versionStr)
         if (!m.matches()) {
             throw new IllegalStateException("Version '${versionStr}' does not match the expected pattern")
         }
 
-        new Version(major: m.group(1).toInteger(),
-                    minor: m.group(3)?.toInteger() ?: 0,
-                    patch: m.group(5)?.toInteger() ?: 0,
-                    snapshot: m.group(6) ? true : false
+        new Version(major: m.group(2).toInteger(),
+                    minor: m.group(4)?.toInteger() ?: 0,
+                    patch: m.group(6)?.toInteger() ?: 0,
+                    snapshot: m.group(7) ? true : false
         )
     }
 

--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/version/Version.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/version/Version.groovy
@@ -94,7 +94,7 @@ class Version implements Comparable<Version> {
 
         if (!versionStr) throw new IllegalStateException("Must have a version")
 
-        if (versionStr == 'SNAPSHOT') return new Version(0, 0, 0, true)
+        if (versionStr == 'SNAPSHOT') return new Version(major: 0, minor: 0, patch: 0, snapshot: true)
 
         Matcher m = VERSION_PATTERN.matcher(versionStr)
         if (!m.matches()) {

--- a/mdm-common/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/version/VersionSpec.groovy
+++ b/mdm-common/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/version/VersionSpec.groovy
@@ -33,6 +33,7 @@ class VersionSpec extends Specification {
         version.major == 3
         version.minor == 1
         version.patch == 2
+        version.snapshot == false
 
         when:
         version = Version.from('3.1.0')
@@ -41,6 +42,7 @@ class VersionSpec extends Specification {
         version.major == 3
         version.minor == 1
         version.patch == 0
+        version.snapshot == false
     }
 
     void 'conversion of simple version string'() {
@@ -51,6 +53,7 @@ class VersionSpec extends Specification {
         version.major == 3
         version.minor == 1
         version.patch == 0
+        version.snapshot == false
 
         when:
         version = Version.from('3.0')
@@ -59,6 +62,7 @@ class VersionSpec extends Specification {
         version.major == 3
         version.minor == 0
         version.patch == 0
+        version.snapshot == false
 
         when:
         version = Version.from('0.1')
@@ -67,6 +71,7 @@ class VersionSpec extends Specification {
         version.major == 0
         version.minor == 1
         version.patch == 0
+        version.snapshot == false
     }
 
     void 'conversion of major only version string'() {
@@ -77,6 +82,7 @@ class VersionSpec extends Specification {
         version.major == 3
         version.minor == 0
         version.patch == 0
+        version.snapshot == false
 
         when:
         version = Version.from('2')
@@ -85,6 +91,7 @@ class VersionSpec extends Specification {
         version.major == 2
         version.minor == 0
         version.patch == 0
+        version.snapshot == false
 
         when:
         version = Version.from('1')
@@ -93,6 +100,45 @@ class VersionSpec extends Specification {
         version.major == 1
         version.minor == 0
         version.patch == 0
+        version.snapshot == false
+    }
+
+    void 'conversion of snapshot version string'(){
+        when:
+        Version version = Version.from('SNAPSHOT')
+
+        then:
+        version.major == 0
+        version.minor == 0
+        version.patch == 0
+        version.snapshot == true
+
+        and:
+        version.toString() == 'SNAPSHOT'
+
+        when:
+        version = Version.from('1.0.0-SNAPSHOT')
+
+        then:
+        version.major == 1
+        version.minor == 0
+        version.patch == 0
+        version.snapshot == true
+
+        and:
+        version.toString() == '1.0.0-SNAPSHOT'
+
+        when:
+        version = Version.from('1.2.3-SNAPSHOT')
+
+        then:
+        version.major == 1
+        version.minor == 2
+        version.patch == 3
+        version.snapshot == true
+
+        and:
+        version.toString() == '1.2.3-SNAPSHOT'
     }
 
     void 'comparison of versions'() {

--- a/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
+++ b/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
@@ -72,7 +72,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true, params.boolean('latestVersionByMetadataNamespace', false))
+        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true, params.boolean('latestVersionByMetadataNamespace', true))
     }
 
     def nonProfileMetadata() {

--- a/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
+++ b/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
@@ -189,7 +189,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         Profile submittedInstance = profileProviderService.getNewProfile()
         bindData(submittedInstance, request)
 
-        Profile validatedInstance = profileService.validateProfile(profileProviderService, submittedInstance)
+        Profile validatedInstance = profileService.validateProfileValues(profileProviderService, submittedInstance)
 
         if (validatedInstance.hasErrors()) {
             respond validatedInstance.errors

--- a/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
+++ b/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
@@ -50,11 +50,11 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
 
 
     def profileProviders() {
-        respond profileProviderServices: profileService.getAllProfileProviderServices(true).sort()
+        respond profileProviderServices: profileService.getAllProfileProviderServices()
     }
 
     def dynamicProfileProviders() {
-        respond profileProviderServices: profileService.getAllDynamicProfileProviderServices().sort()
+        respond profileProviderServices: profileService.getAllDynamicProfileProviderServices()
     }
 
     def usedProfiles() {
@@ -63,7 +63,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUsedProfileServices(multiFacetAware, true).sort()
+        respond profileProviderServices: profileService.getUsedProfileServices(multiFacetAware, true, params.boolean('latestVersionByMetadataNamespace', false))
     }
 
     def unusedProfiles() {
@@ -72,7 +72,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true).sort()
+        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true, params.boolean('latestVersionByMetadataNamespace', false))
     }
 
     def nonProfileMetadata() {
@@ -81,7 +81,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        Set<ProfileProviderService> usedProfiles = profileService.getUsedProfileServices(multiFacetAware, true)
+        Set<ProfileProviderService> usedProfiles = profileService.getUsedProfileServices(multiFacetAware)
         Set<String> profileNamespaces = usedProfiles.collect {it.metadataNamespace}
         respond metadataService.findAllByMultiFacetAwareItemIdAndNotNamespaces(multiFacetAware.id, profileNamespaces.asList(), params),
                 view: "/metadata/index"

--- a/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
+++ b/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/ProfileController.groovy
@@ -50,11 +50,11 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
 
 
     def profileProviders() {
-        respond profileProviderServices: profileService.getAllProfileProviderServices()
+        respond profileProviderServices: profileService.getAllProfileProviderServices(true).sort()
     }
 
     def dynamicProfileProviders() {
-        respond profileProviderServices: profileService.getAllDynamicProfileProviderServices()
+        respond profileProviderServices: profileService.getAllDynamicProfileProviderServices().sort()
     }
 
     def usedProfiles() {
@@ -63,7 +63,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUsedProfileServices(multiFacetAware, true)
+        respond profileProviderServices: profileService.getUsedProfileServices(multiFacetAware, true).sort()
     }
 
     def unusedProfiles() {
@@ -72,7 +72,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true)
+        respond profileProviderServices: profileService.getUnusedProfileServices(multiFacetAware, true).sort()
     }
 
     def nonProfileMetadata() {
@@ -81,7 +81,7 @@ class ProfileController implements ResourcelessMdmController, DataBinder {
         if (!multiFacetAware) {
             return notFound(params.multiFacetAwareItemClass, params.multiFacetAwareItemId)
         }
-        Set<ProfileProviderService> usedProfiles = profileService.getUsedProfileServices(multiFacetAware)
+        Set<ProfileProviderService> usedProfiles = profileService.getUsedProfileServices(multiFacetAware, true)
         Set<String> profileNamespaces = usedProfiles.collect {it.metadataNamespace}
         respond metadataService.findAllByMultiFacetAwareItemIdAndNotNamespaces(multiFacetAware.id, profileNamespaces.asList(), params),
                 view: "/metadata/index"

--- a/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/UrlMappings.groovy
+++ b/mdm-plugin-profile/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/profile/UrlMappings.groovy
@@ -53,6 +53,8 @@ class UrlMappings {
                 get "/profile/$profileNamespace/$profileName/$profileVersion?"(controller: 'profile', action: 'show')
                 delete "/profile/$profileNamespace/$profileName/$profileVersion?"(controller: 'profile', action: 'delete')
                 post "/profile/$profileNamespace/$profileName/$profileVersion?"(controller: 'profile', action: 'save')
+                post "/profile/$profileNamespace/$profileName/validate"(controller: 'profile', action: 'validate')
+                post "/profile/$profileNamespace/$profileName/$profileVersion/validate"(controller: 'profile', action: 'validate')
             }
 
             // Methods to retrieve and save many profiles for many multiFacetAware items belonging to a Model

--- a/mdm-plugin-profile/grails-app/init/uk/ac/ox/softeng/maurodatamapper/profile/BootStrap.groovy
+++ b/mdm-plugin-profile/grails-app/init/uk/ac/ox/softeng/maurodatamapper/profile/BootStrap.groovy
@@ -37,11 +37,14 @@ class BootStrap {
 
         try {
             loadAndSetConfigurableFieldType(ConfigurableProfileFieldTypes.DATE_FORMAT_KEY,
-                                            ConfigurableProfileFieldTypes.DATE_FORMAT_DEFAULT)
+                                            ConfigurableProfileFieldTypes.DATE_FORMAT_DEFAULT,
+                                            ConfigurableProfileFieldTypes.instance.dateFormats)
             loadAndSetConfigurableFieldType(ConfigurableProfileFieldTypes.DATETIME_FORMAT_KEY,
-                                            ConfigurableProfileFieldTypes.DATETIME_FORMAT_DEFAULT)
+                                            ConfigurableProfileFieldTypes.DATETIME_FORMAT_DEFAULT,
+                                            ConfigurableProfileFieldTypes.instance.dateTimeFormats)
             loadAndSetConfigurableFieldType(ConfigurableProfileFieldTypes.TIME_FORMAT_KEY,
-                                            ConfigurableProfileFieldTypes.TIME_FORMAT_DEFAULT)
+                                            ConfigurableProfileFieldTypes.TIME_FORMAT_DEFAULT,
+                                            ConfigurableProfileFieldTypes.instance.timeFormats)
         } catch (Exception ignored) {
             log.warn('Couldn\'t load configurable profile field types from ApiProperties, will use defaults')
         }
@@ -49,7 +52,7 @@ class BootStrap {
     def destroy = {
     }
 
-    void loadAndSetConfigurableFieldType(String key, String[] defaultValues) {
+    void loadAndSetConfigurableFieldType(String key, String[] defaultValues, String[] target) {
         ApiProperty.withNewTransaction {
             ApiProperty apiProperty = apiPropertyService.findByKey(key)
             if (!apiProperty) {
@@ -61,7 +64,7 @@ class BootStrap {
                                               createdBy: BootStrapUser.instance.emailAddress)
                 GormUtils.checkAndSave(messageSource, apiProperty)
             }
-            ConfigurableProfileFieldTypes.instance.dateFormats = apiProperty.value.split(',')
+            target = apiProperty.value.split(',')
         }
     }
 }

--- a/mdm-plugin-profile/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/ProfileService.groovy
+++ b/mdm-plugin-profile/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/ProfileService.groovy
@@ -93,6 +93,12 @@ class ProfileService implements DataBinder {
         cleanProfile
     }
 
+    Profile validateProfileValues(ProfileProviderService profileProviderService, Profile submittedProfile) {
+        Profile cleanProfile = profileProviderService.createCleanProfileFromProfile(submittedProfile)
+        cleanProfile.validateCurrentValues()
+        cleanProfile
+    }
+
     void deleteProfile(ProfileProviderService profileProviderService, MultiFacetAware multiFacetAwareItem, User currentUser) {
 
         Set<Metadata> mds = profileProviderService.getAllProfileMetadataByMultiFacetAwareItemId(multiFacetAwareItem.id)
@@ -308,7 +314,7 @@ class ProfileService implements DataBinder {
 
                     if (validateOnly) {
                         ProfileProvided validated = new ProfileProvided()
-                        validated.profile = validateProfile(profileProviderService, submittedInstance)
+                        validated.profile = validateProfileValues(profileProviderService, submittedInstance)
                         validated.profileProviderService = profileProviderService
                         handledInstances.add(validated)
                     } else {

--- a/mdm-plugin-profile/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/ProfileService.groovy
+++ b/mdm-plugin-profile/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/ProfileService.groovy
@@ -69,13 +69,13 @@ class ProfileService implements DataBinder {
     ProfileProviderService findProfileProviderService(String profileNamespace, String profileName, String profileVersion = null) {
 
         if (profileVersion) {
-            return getAllProfileProviderServices().find {
+            return getAllProfileProviderServices(true).find {
                 it.namespace == profileNamespace &&
                 it.getName() in [profileName, Utils.safeUrlEncode(profileName)] &&
                 it.version == profileVersion
             }
         }
-        getAllProfileProviderServices().findAll {
+        getAllProfileProviderServices(true).findAll {
             it.namespace == profileNamespace &&
             it.getName() in [profileName, Utils.safeUrlEncode(profileName)]
         }.max()
@@ -227,7 +227,7 @@ class ProfileService implements DataBinder {
     }
 
     Set<ProfileProviderService> getAllDynamicProfileProviderServices() {
-        getAllProfileProviderServices().findAll {
+        getAllProfileProviderServices(true).findAll {
             it.definingDataModel != null
         }
     }

--- a/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/JsonProfileSpec.groovy
+++ b/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/JsonProfileSpec.groovy
@@ -39,9 +39,7 @@ class JsonProfileSpec extends BaseIntegrationSpec {
         Profile profile = new JsonProfile(id: UUID.randomUUID(), domainType: 'BasicModel', label: 'Test')
 
         then:
-        !profile.validate()
-        GormUtils.outputDomainErrors(messageSource, profile)
-        profile.errors.hasFieldErrors('sections')
+        profile.validate() // validates as profile validation restricted to current values (issue gh-277)
     }
 
     void '2 test validation when section with no fields'() {
@@ -52,9 +50,7 @@ class JsonProfileSpec extends BaseIntegrationSpec {
         ])
 
         then:
-        !profile.validate()
-        GormUtils.outputDomainErrors(messageSource, profile)
-        profile.errors.hasFieldErrors('sections[0].fields')
+        profile.validate() // validates as profile validation restricted to current values (issue gh-277)
     }
 
     void '3 test validation when section with mandatory fields'() {

--- a/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/JsonProfileSpec.groovy
+++ b/mdm-plugin-profile/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/JsonProfileSpec.groovy
@@ -134,8 +134,13 @@ class JsonProfileSpec extends BaseIntegrationSpec {
                 new ProfileField(fieldName: 'field3', metadataPropertyName: 'field3', minMultiplicity: 1, maxMultiplicity: 1, dataType: ProfileFieldDataType.BOOLEAN,
                                  currentValue: 'blob'),
                 new ProfileField(fieldName: 'field4', metadataPropertyName: 'field4', minMultiplicity: 1, maxMultiplicity: 1, dataType: ProfileFieldDataType.INT,
-                                 currentValue: '11'
-                ),
+                                 currentValue: '11'),
+                new ProfileField(fieldName: 'field5', metadataPropertyName: 'field5', minMultiplicity: 1, maxMultiplicity: 1, dataType: ProfileFieldDataType.DATE,
+                                 currentValue: '31/12/1999'),
+                new ProfileField(fieldName: 'field5', metadataPropertyName: 'field5', minMultiplicity: 1, maxMultiplicity: 1, dataType: ProfileFieldDataType.DATE,
+                                 currentValue: '2000-01-01'),
+                new ProfileField(fieldName: 'field7', metadataPropertyName: 'field7', minMultiplicity: 1, maxMultiplicity: 1, dataType: 'Custom Type',
+                                 currentValue: 'custom123')
             ])
         ])
 
@@ -147,6 +152,8 @@ class JsonProfileSpec extends BaseIntegrationSpec {
 
         profile.errors.hasFieldErrors('sections[0].fields[2].currentValue')
         profile.errors.getFieldError('sections[0].fields[2].currentValue').code == 'typeMismatch'
+
+        profile.errors.errorCount == 2
     }
 
 

--- a/mdm-plugin-profile/src/integration-test/resources/url-mappings/tracked_endpoints.txt
+++ b/mdm-plugin-profile/src/integration-test/resources/url-mappings/tracked_endpoints.txt
@@ -17,3 +17,5 @@
 | POST   | /api/${multiFacetAwareItemDomainType}/${multiFacetAwareItemId}/profile/${profileNamespace}/${profileName}/${profileVersion}? | save |
 | DELETE | /api/${multiFacetAwareItemDomainType}/${multiFacetAwareItemId}/profile/${profileNamespace}/${profileName}/${profileVersion}? | delete |
 | GET    | /api/${multiFacetAwareItemDomainType}/${multiFacetAwareItemId}/profile/${profileNamespace}/${profileName}/${profileVersion}? | show |
+| POST   | /api/${multiFacetAwareItemDomainType}/${multiFacetAwareItemId}/profile/${profileNamespace}/${profileName}/validate | validate |
+| POST   | /api/${multiFacetAwareItemDomainType}/${multiFacetAwareItemId}/profile/${profileNamespace}/${profileName}/${profileVersion}/validate | validate |

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ConfigurableProfileFieldTypes.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ConfigurableProfileFieldTypes.groovy
@@ -28,9 +28,9 @@ class ConfigurableProfileFieldTypes {
     public static final String[] DATETIME_FORMAT_DEFAULT = ['dd/MM/yyyy\'T\'HH:mm:ss', 'dd-MM-yyyy\'T\'HH:mm:ss']
     public static final String[] TIME_FORMAT_DEFAULT = ['HH:mm:ss', 'HH:mm']
 
-    String[] dateFormats = new String[10]
-    String[] dateTimeFormats = new String[10]
-    String[] timeFormats = new String[10]
+    String[] dateFormats
+    String[] dateTimeFormats
+    String[] timeFormats
 
     String[] getDateFormats() {
         dateFormats ?: DATE_FORMAT_DEFAULT

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileFieldDataType.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileFieldDataType.groovy
@@ -48,7 +48,7 @@ enum ProfileFieldDataType {
     }
 
     static ProfileFieldDataType findForLabel(String label) {
-        values().find {it.label.equalsIgnoreCase(label)}
+        values().find {it.label.equalsIgnoreCase(label)} ?: STRING
     }
 
     static ProfileFieldDataType findFor(String value) {

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
@@ -36,13 +36,13 @@ class ProfileSection implements Cloneable, Validateable {
     @Override
     boolean validate(List fieldsToValidate, Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {
         if (!params?.currentValuesOnly) {
-            Validateable.super.validate null, null, null
+            Validateable.super.validate null, params, null
         }
         fields.eachWithIndex {field, i ->
             if (params?.currentValuesOnly) {
-                field.validate(['currentValue'], params)
+                field.validate(['currentValue'], (Map<String, Object>) params)
             } else {
-                field.validate(params)
+                field.validate((Map<String, Object>) params)
             }
             if (field.hasErrors()) {
                 field.errors.fieldErrors.each {err ->

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
@@ -17,7 +17,6 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.profile.domain
 
-
 import grails.validation.Validateable
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
@@ -35,9 +34,16 @@ class ProfileSection implements Cloneable, Validateable {
     }
 
     @Override
-    boolean validate() {
+    boolean validate(List fieldsToValidate, Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {
+        if (!params?.currentValuesOnly) {
+            Validateable.super.validate null, null, null
+        }
         fields.eachWithIndex {field, i ->
-            field.validate(['currentValue'])
+            if (params?.currentValuesOnly) {
+                field.validate(['currentValue'], params)
+            } else {
+                field.validate(params)
+            }
             if (field.hasErrors()) {
                 field.errors.fieldErrors.each {err ->
                     this.errors.rejectValue("fields[$i].${err.field}", err.code, err.arguments, err.defaultMessage)
@@ -45,6 +51,11 @@ class ProfileSection implements Cloneable, Validateable {
             }
         }
         !hasErrors()
+    }
+
+    boolean validateCurrentValues() {
+        Map<String, Object> params = [currentValuesOnly: (Object) true]
+        validate(params)
     }
 
     void setSectionName(String name) {

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/domain/ProfileSection.groovy
@@ -36,9 +36,8 @@ class ProfileSection implements Cloneable, Validateable {
 
     @Override
     boolean validate() {
-        validate null, null, null
         fields.eachWithIndex {field, i ->
-            field.validate()
+            field.validate(['currentValue'])
             if (field.hasErrors()) {
                 field.errors.fieldErrors.each {err ->
                     this.errors.rejectValue("fields[$i].${err.field}", err.code, err.arguments, err.defaultMessage)

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
@@ -35,7 +35,6 @@ abstract class Profile implements Comparable<Profile>, Validateable {
 
     @Override
     boolean validate() {
-        validate null, null, null
         sections.eachWithIndex {sec, i ->
             sec.validate()
             if (sec.hasErrors()) {

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
@@ -34,9 +34,12 @@ abstract class Profile implements Comparable<Profile>, Validateable {
     abstract Set<String> getKnownFields()
 
     @Override
-    boolean validate() {
+    boolean validate(List fieldsToValidate, Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {
+        if (!params?.currentValuesOnly) {
+            Validateable.super.validate null, null, null
+        }
         sections.eachWithIndex {sec, i ->
-            sec.validate()
+            sec.validate(params)
             if (sec.hasErrors()) {
                 sec.errors.fieldErrors.each {err ->
                     this.errors.rejectValue("sections[$i].${err.field}", err.code, err.arguments, err.defaultMessage)
@@ -44,6 +47,11 @@ abstract class Profile implements Comparable<Profile>, Validateable {
             }
         }
         !hasErrors()
+    }
+
+    boolean validateCurrentValues() {
+        Map<String, Object> params = [currentValuesOnly: (Object) true]
+        validate(params)
     }
 
     List<ProfileField> getAllFields() {

--- a/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
+++ b/mdm-plugin-profile/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/profile/object/Profile.groovy
@@ -36,10 +36,10 @@ abstract class Profile implements Comparable<Profile>, Validateable {
     @Override
     boolean validate(List fieldsToValidate, Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {
         if (!params?.currentValuesOnly) {
-            Validateable.super.validate null, null, null
+            Validateable.super.validate null, params, null
         }
         sections.eachWithIndex {sec, i ->
-            sec.validate(params)
+            sec.validate((Map<String, Object>) params)
             if (sec.hasErrors()) {
                 sec.errors.fieldErrors.each {err ->
                     this.errors.rejectValue("sections[$i].${err.field}", err.code, err.arguments, err.defaultMessage)

--- a/mdm-testing-functional/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/InvalidProfileService.groovy
+++ b/mdm-testing-functional/grails-app/services/uk/ac/ox/softeng/maurodatamapper/profile/InvalidProfileService.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.profile
+
+import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderService
+
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class InvalidProfileService extends JsonProfileProviderService {
+
+    @Override
+    String getMetadataNamespace() {
+        getNamespace() + '.invalid'
+    }
+
+    @Override
+    String getDisplayName() {
+        'Partially Invalid Profile'
+    }
+
+    @Override
+    String getJsonResourceFile() {
+        'InvalidProfile.json'
+    }
+
+    @Override
+    List<String> profileApplicableForDomains() {
+        ['DataModel']
+    }
+}

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
@@ -2490,7 +2490,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         verifyResponse OK, response
 
         when: 'get the unused profiles on the simple data model'
-        localResponse = GET("dataModels/${simpleModelId}/profiles/unused", Argument.listOf(Map))
+        localResponse = GET("dataModels/${simpleModelId}/profiles/unused?latestVersionByMetadataNamespace=false", Argument.listOf(Map))
 
         then: 'now 2 of these are for the Dynamic Profile Model, because we get the finalised profile branch'
         verifyResponse(OK, localResponse)
@@ -2608,7 +2608,6 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, response)
-        log.debug('responseBody()={}', responseBody())
         responseBody().sections.size() == 1
         responseBody().domainType == 'DataModel'
         responseBody().id == id

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
@@ -1308,6 +1308,9 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         POST("profiles/${profileSpecificationProfileService.namespace}/${profileSpecificationProfileService.name}/dataModels/${dynamicProfileModelId}", profileMap)
         verifyResponse(OK, response)
 
+        PUT("dataModels/$dynamicProfileModelId/finalise", [versionChangeType: 'Major'])
+        verifyResponse(OK, response)
+
         Map optionalFieldMap = [
             fieldName   : 'Dynamic Profile Elem (Optional)',
             currentValue: 'abc'
@@ -2473,6 +2476,12 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         then: 'still 1 of these is for the Dynamic Profile Model'
         verifyResponse(OK, localResponse)
         localResponse.body().findAll{it.displayName == 'Dynamic Profile Model'}.size() == 1
+
+        when: 'get the finalised profile against the simple data model now there is a finalised and an unfinalised version of the profile'
+        GET("dataModels/$simpleModelId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic%20Profile%20Model", MAP_ARG)
+
+        then: 'the response is OK'
+        verifyResponse(OK, response)
 
         when: 'finalise the new branch model version'
         PUT("dataModels/$profileModelVersion2Id/finalise", [versionChangeType: 'Major', versionTag: 'Functional Test Second Version Tag'])

--- a/mdm-testing-functional/src/main/resources/InvalidProfile.json
+++ b/mdm-testing-functional/src/main/resources/InvalidProfile.json
@@ -1,0 +1,24 @@
+[
+  {
+    "sectionName": "Partially Invalid Section",
+    "sectionDescription": "Section with one valid and one invalid field",
+    "fields": [
+      {
+        "fieldName": "Valid Field",
+        "metadataPropertyName": "validField",
+        "description": "A field which is valid",
+        "minMultiplicity": 1,
+        "maxMultiplicity": 1,
+        "dataType": "text"
+      },
+      {
+        "fieldName": "Invalid Field with blank description",
+        "metadataPropertyName": "blankDescriptionField",
+        "description": "",
+        "minMultiplicity": 1,
+        "maxMultiplicity": 1,
+        "dataType": "int"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Treat custom datatypes in profiles as strings (resolves #213)
- Fix to loading date formats from ApiProperties (resolves #290)
- Use finalised dynamic profile as default version (resolves #292), restrict dynamic profiles to finalised only in profile providers endpoint, sort profile provider endpoints
- Show only latest versions (by metadata namespace) of unused profiles by default, add latest versions (by metadata namespace) param to unused and used profile endpoints