### PR TITLE
Clean up unused endpoints

### DIFF
--- a/mdm-core/README.md
+++ b/mdm-core/README.md
@@ -110,7 +110,6 @@ Controller: semanticLink
  |   GET    | /api/${catalogueItemDomainType}/${catalogueItemId}/semanticLinks/${id}                                | Action: show
 
 Controller: session
- |   GET    | /api/session/keepAlive                                                                                | Action: keepAlive
  |   GET    | /api/admin/activeSessions                                                                             | Action: activeSessions
  |   GET    | /api/session/isAuthenticated/${sessionId}?                                                           | Action: isAuthenticatedSession
 

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/UrlMappings.groovy
@@ -62,7 +62,6 @@ class UrlMappings {
             // Open access url
             get "/session/isAuthenticated/$sessionId?"(controller: 'session', action: 'isAuthenticatedSession') // New Url
             get '/session/isApplicationAdministration'(controller: 'session', action: 'isApplicationAdministrationSession') // New Url
-            get '/session/keepAlive'(controller: 'session', action: 'keepAlive') // New Url
             get '/properties'(controller: 'apiProperty', action: 'index') {
                 openAccess = true
             }

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/session/SessionController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/session/SessionController.groovy
@@ -19,8 +19,6 @@ package uk.ac.ox.softeng.maurodatamapper.core.session
 
 import uk.ac.ox.softeng.maurodatamapper.core.traits.controller.ResourcelessMdmController
 
-import io.micronaut.http.HttpStatus
-
 class SessionController implements ResourcelessMdmController {
 
     SessionService sessionService
@@ -38,9 +36,5 @@ class SessionController implements ResourcelessMdmController {
 
     def isApplicationAdministrationSession() {
         respond applicationAdministrationSession: currentUserSecurityPolicyManager.isApplicationAdministrator()
-    }
-
-    def keepAlive() {
-        render status: HttpStatus.CONTINUE
     }
 }

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/provider/MauroDataMapperServiceProviderServiceSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/provider/MauroDataMapperServiceProviderServiceSpec.groovy
@@ -43,7 +43,7 @@ class MauroDataMapperServiceProviderServiceSpec extends MdmSpecification {
         map.values().flatten().size() == mauroDataMapperServiceProviderService.providerServices.size()
 
         and:
-        map.values().flatten().each {p ->
+        map.values().flatten().every {p ->
             mauroDataMapperServiceProviderService.providerServices.any {it == p}
         }
     }

--- a/mdm-core/src/integration-test/resources/url-mappings/tracked_endpoints.txt
+++ b/mdm-core/src/integration-test/resources/url-mappings/tracked_endpoints.txt
@@ -137,7 +137,6 @@
 | DELETE | /api/${catalogueItemDomainType}/${catalogueItemId}/semanticLinks/${id} | delete |
 | PUT    | /api/${catalogueItemDomainType}/${catalogueItemId}/semanticLinks/${id} | update |
 | GET    | /api/${catalogueItemDomainType}/${catalogueItemId}/semanticLinks/${id} | show |
-| GET    | /api/session/keepAlive | keepAlive |
 | GET    | /api/session/isApplicationAdministration | isApplicationAdministrationSession |
 | GET    | /api/admin/activeSessions | activeSessions |
 | GET    | /api/session/isAuthenticated/${sessionId}? | isAuthenticatedSession |

--- a/mdm-plugin-datamodel/README.md
+++ b/mdm-plugin-datamodel/README.md
@@ -41,8 +41,6 @@ Controller: dataModel
  |   GET    | /api/dataModels/types                                                                                                                | Action: types
  |   POST   | /api/dataModels/import/${importerNamespace}/${importerName}/${importerVersion}                                                       | Action: importModels
  |   POST   | /api/dataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion}                                                       | Action: exportModels
- |  DELETE  | /api/dataModels/${dataModelId}/dataClasses/clean                                                                                     | Action: deleteAllUnusedDataClasses
- |  DELETE  | /api/dataModels/${dataModelId}/dataTypes/clean                                                                                       | Action: deleteAllUnusedDataTypes
  |   GET    | /api/folders/${folderId}/dataModels                                                                                                  | Action: index
  |  DELETE  | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                   | Action: readByAuthenticated
  |   PUT    | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                   | Action: readByAuthenticated

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelController.groovy
@@ -84,36 +84,6 @@ class DataModelController extends ModelController<DataModel> {
         dataModelService
     }
 
-    @Transactional
-    def deleteAllUnusedDataClasses() {
-        if (handleReadOnly()) {
-            return
-        }
-
-        DataModel dataModel = queryForResource params.dataModelId
-
-        if (!dataModel) return notFound(params.dataModelId)
-
-        dataModelService.deleteAllUnusedDataClasses(dataModel)
-
-        render status: NO_CONTENT // NO CONTENT STATUS CODE
-    }
-
-    @Transactional
-    def deleteAllUnusedDataTypes() {
-        if (handleReadOnly()) {
-            return
-        }
-
-        DataModel dataModel = queryForResource params.dataModelId
-
-        if (!dataModel) return notFound(params.dataModelId)
-
-        dataModelService.deleteAllUnusedDataTypes(dataModel)
-
-        render status: NO_CONTENT // NO CONTENT STATUS CODE
-    }
-
     def search(SearchParams searchParams) {
 
         if (searchParams.hasErrors()) {

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/UrlMappings.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/UrlMappings.groovy
@@ -60,9 +60,6 @@ class UrlMappings {
                 put "/subset/$otherDataModelId"(controller: 'dataModel', action: 'subset')
                 get "/intersects/$otherDataModelId"(controller: 'dataModel', action: 'intersects')
 
-                delete '/dataTypes/clean'(controller: 'dataModel', action: 'deleteAllUnusedDataTypes')
-                delete '/dataClasses/clean'(controller: 'dataModel', action: 'deleteAllUnusedDataClasses')
-
                 get '/hierarchy'(controller: 'dataModel', action: 'hierarchy')
 
                 post '/search'(controller: 'dataModel', action: 'search')

--- a/mdm-plugin-datamodel/src/integration-test/resources/url-mappings/tracked_endpoints.txt
+++ b/mdm-plugin-datamodel/src/integration-test/resources/url-mappings/tracked_endpoints.txt
@@ -36,8 +36,6 @@
 | GET    | /api/dataModels/types | types |
 | POST   | /api/dataModels/import/${importerNamespace}/${importerName}/${importerVersion} | importModels |
 | POST   | /api/dataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion} | exportModels |
-| DELETE | /api/dataModels/${dataModelId}/dataClasses/clean | deleteAllUnusedDataClasses |
-| DELETE | /api/dataModels/${dataModelId}/dataTypes/clean | deleteAllUnusedDataTypes |
 | GET    | /api/folders/${folderId}/dataModels | index |
 | DELETE | /api/dataModels/${dataModelId}/readByAuthenticated | readByAuthenticated |
 | PUT    | /api/dataModels/${dataModelId}/readByAuthenticated | readByAuthenticated |

--- a/mdm-plugin-referencedata/README.md
+++ b/mdm-plugin-referencedata/README.md
@@ -41,8 +41,6 @@ Controller: dataModel
  |   GET    | /api/dataModels/types                                                                                                                | Action: types
  |   POST   | /api/dataModels/import/${importerNamespace}/${importerName}/${importerVersion}                                                       | Action: importModels
  |   POST   | /api/dataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion}                                                       | Action: exportModels
- |  DELETE  | /api/dataModels/${dataModelId}/dataClasses/clean                                                                                     | Action: deleteAllUnusedDataClasses
- |  DELETE  | /api/dataModels/${dataModelId}/dataTypes/clean                                                                                       | Action: deleteAllUnusedDataTypes
  |   GET    | /api/folders/${folderId}/dataModels                                                                                                  | Action: index
  |  DELETE  | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                   | Action: readByAuthenticated
  |   PUT    | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                   | Action: readByAuthenticated

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelController.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelController.groovy
@@ -72,36 +72,6 @@ class ReferenceDataModelController extends ModelController<ReferenceDataModel> {
         resource ? respond(resource, [model: [userSecurityPolicyManager: currentUserSecurityPolicyManager], view: 'hierarchy']) : notFound(params.id)
     }
 
-    @Transactional
-    def deleteAllUnusedDataClasses() {
-        if (handleReadOnly()) {
-            return
-        }
-
-        ReferenceDataModel referenceDataModel = queryForResource params.referenceDataModelId
-
-        if (!referenceDataModel) return notFound(params.referenceDataModelId)
-
-        referenceDataModelService.deleteAllUnusedDataClasses(referenceDataModel)
-
-        render status: NO_CONTENT // NO CONTENT STATUS CODE
-    }
-
-    @Transactional
-    def deleteAllUnusedDataTypes() {
-        if (handleReadOnly()) {
-            return
-        }
-
-        ReferenceDataModel referenceDataModel = queryForResource params.referenceDataModelId
-
-        if (!referenceDataModel) return notFound(params.referenceDataModelId)
-
-        referenceDataModelService.deleteAllUnusedDataTypes(referenceDataModel)
-
-        render status: NO_CONTENT // NO CONTENT STATUS CODE
-    }
-
     def search(SearchParams searchParams) {
 
         if (searchParams.hasErrors()) {

--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/UrlMappings.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/UrlMappings.groovy
@@ -57,8 +57,6 @@ class UrlMappings {
                 put "/folder/$folderId"(controller: 'referenceDataModel', action: 'changeFolder')
                 get "/export/$exporterNamespace/$exporterName/$exporterVersion"(controller: 'referenceDataModel', action: 'exportModel')
 
-                delete '/referenceDataTypes/clean'(controller: 'referenceDataModel', action: 'deleteAllUnusedReferenceDataTypes')
-
                 get '/hierarchy'(controller: 'referenceDataModel', action: 'hierarchy')
 
                 post '/search'(controller: 'referenceDataModel', action: 'search')

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelServiceIntegrationSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelServiceIntegrationSpec.groovy
@@ -682,8 +682,8 @@ class ReferenceDataModelServiceIntegrationSpec extends BaseReferenceDataModelInt
 
         then:
         availableBranches.size() == 2
-        availableBranches.each { it.id in [draftModel.id, testModel.id] }
-        availableBranches.each { it.label == dataModel.label }
+        availableBranches.every {it.id in [draftModel.id, testModel.id]}
+        availableBranches.every {it.label == dataModel.label}
     }
 
     void 'DMSV01 : test validation on valid model'() {

--- a/mdm-plugin-referencedata/src/integration-test/resources/url-mappings/tracked_endpoints.txt
+++ b/mdm-plugin-referencedata/src/integration-test/resources/url-mappings/tracked_endpoints.txt
@@ -14,7 +14,6 @@
 | PUT    | /api/admin/referenceDataModels/${id}/undoSoftDelete | undoSoftDelete |
 | POST   | /api/referenceDataModels/import/${importerNamespace}/${importerName}/${importerVersion} | importModels |
 | POST   | /api/referenceDataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion} | exportModels |
-| DELETE | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes/clean | deleteAllUnusedReferenceDataTypes |
 | GET    | /api/folders/${folderId}/referenceDataModels | index |
 | DELETE | /api/referenceDataModels/${referenceDataModelId}/readByAuthenticated | readByAuthenticated |
 | PUT    | /api/referenceDataModels/${referenceDataModelId}/readByAuthenticated | readByAuthenticated |

--- a/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyServiceIntegrationSpec.groovy
+++ b/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyServiceIntegrationSpec.groovy
@@ -333,8 +333,8 @@ class TerminologyServiceIntegrationSpec extends BaseTerminologyIntegrationSpec {
 
         then:
         availableBranches.size() == 2
-        availableBranches.each {it.id in [draftModel.id, testModel.id]}
-        availableBranches.each {it.label == terminology.label}
+        availableBranches.every {it.id in [draftModel.id, testModel.id]}
+        availableBranches.every {it.label == terminology.label}
     }
 
     void 'TSM01 : test finding merge difference between two terminologies'() {

--- a/mdm-testing-functional/README.md
+++ b/mdm-testing-functional/README.md
@@ -236,8 +236,6 @@ Controller: dataModel
 |   GET    | /api/dataModels/types                                                                                                                                                            | Action: types
 |   POST   | /api/dataModels/import/${importerNamespace}/${importerName}/${importerVersion}                                                                                                   | Action: importModels
 |   POST   | /api/dataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion}                                                                                                   | Action: exportModels
-|  DELETE  | /api/dataModels/${dataModelId}/dataClasses/clean                                                                                                                                 | Action: deleteAllUnusedDataClasses
-|  DELETE  | /api/dataModels/${dataModelId}/dataTypes/clean                                                                                                                                   | Action: deleteAllUnusedDataTypes
 |   GET    | /api/folders/${folderId}/dataModels                                                                                                                                              | Action: index
 |  DELETE  | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                                                               | Action: readByAuthenticated
 |   PUT    | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                                                               | Action: readByAuthenticated
@@ -418,7 +416,6 @@ Controller: referenceDataModel
 |   PUT    | /api/admin/referenceDataModels/${id}/undoSoftDelete                                                                                                                              | Action: undoSoftDelete
 |   POST   | /api/referenceDataModels/import/${importerNamespace}/${importerName}/${importerVersion}                                                                                          | Action: importModels
 |   POST   | /api/referenceDataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion}                                                                                          | Action: exportModels
-|  DELETE  | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes/clean                                                                                                        | Action: deleteAllUnusedReferenceDataTypes
 |   GET    | /api/folders/${folderId}/referenceDataModels                                                                                                                                     | Action: index
 |  DELETE  | /api/referenceDataModels/${referenceDataModelId}/readByAuthenticated                                                                                                             | Action: readByAuthenticated
 |   PUT    | /api/referenceDataModels/${referenceDataModelId}/readByAuthenticated                                                                                                             | Action: readByAuthenticated

--- a/mdm-testing-functional/README.md
+++ b/mdm-testing-functional/README.md
@@ -562,7 +562,6 @@ Controller: semanticLink
 |   GET    | /api/${catalogueItemDomainType}/${catalogueItemId}/semanticLinks/${id}                                                                                                           | Action: show
 
 Controller: session
-|   GET    | /api/session/keepAlive                                                                                                                                                           | Action: keepAlive
 |   GET    | /api/session/isApplicationAdministration                                                                                                                                         | Action: isApplicationAdministrationSession
 |   GET    | /api/admin/activeSessions                                                                                                                                                        | Action: activeSessions
 |   GET    | /api/session/isAuthenticated/${sessionId}?                                                                                                                                       | Action: isAuthenticatedSession

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/versionedfolder/container/VersionedFolderFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/versionedfolder/container/VersionedFolderFunctionalSpec.groovy
@@ -1887,8 +1887,8 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         then:
         verifyResponse OK, response
         responseBody().count == 5
-        responseBody().items.each {it.id in expectedBrancheIds}
-        responseBody().items.each {it.label == validJson.label}
+        responseBody().items.every {it.id in expectedBrancheIds}
+        responseBody().items.every {it.label == validJson.label}
 
         when:
         GET("$data.v2/availableBranches")
@@ -1896,8 +1896,8 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         then:
         verifyResponse OK, response
         responseBody().count == 5
-        responseBody().items.each {it.id in expectedBrancheIds}
-        responseBody().items.each {it.label == validJson.label}
+        responseBody().items.every {it.id in expectedBrancheIds}
+        responseBody().items.every {it.label == validJson.label}
 
         when:
         GET("$data.v1/availableBranches")
@@ -1905,8 +1905,8 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         then:
         verifyResponse OK, response
         responseBody().count == 5
-        responseBody().items.each {it.id in expectedBrancheIds}
-        responseBody().items.each {it.label == validJson.label}
+        responseBody().items.every {it.id in expectedBrancheIds}
+        responseBody().items.every {it.label == validJson.label}
 
         when:
         GET("$data.main/availableBranches")
@@ -1914,8 +1914,8 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         then:
         verifyResponse OK, response
         responseBody().count == 5
-        responseBody().items.each {it.id in expectedBrancheIds}
-        responseBody().items.each {it.label == validJson.label}
+        responseBody().items.every {it.id in expectedBrancheIds}
+        responseBody().items.every {it.label == validJson.label}
 
         cleanup:
         cleanupModelVersionTree(data)

--- a/mdm-testing-functional/untested_endpoints.md
+++ b/mdm-testing-functional/untested_endpoints.md
@@ -228,8 +228,6 @@ Controller: dataModel
 |   GET    | /api/dataModels/types                                                                                                                                                            | Action: types
 |   POST   | /api/dataModels/import/${importerNamespace}/${importerName}/${importerVersion}                                                                                                   | Action: importModels
 |   POST   | /api/dataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion}                                                                                                   | Action: exportModels
-|  DELETE  | /api/dataModels/${dataModelId}/dataClasses/clean                                                                                                                                 | Action: deleteAllUnusedDataClasses
-|  DELETE  | /api/dataModels/${dataModelId}/dataTypes/clean                                                                                                                                   | Action: deleteAllUnusedDataTypes
 |   GET    | /api/folders/${folderId}/dataModels                                                                                                                                              | Action: index
 |  DELETE  | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                                                               | Action: readByAuthenticated
 |   PUT    | /api/dataModels/${dataModelId}/readByAuthenticated                                                                                                                               | Action: readByAuthenticated
@@ -410,7 +408,6 @@ Controller: referenceDataModel
 |   PUT    | /api/admin/referenceDataModels/${id}/undoSoftDelete                                                                                                                              | Action: undoSoftDelete
 |   POST   | /api/referenceDataModels/import/${importerNamespace}/${importerName}/${importerVersion}                                                                                          | Action: importModels
 |   POST   | /api/referenceDataModels/export/${exporterNamespace}/${exporterName}/${exporterVersion}                                                                                          | Action: exportModels
-|  DELETE  | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes/clean                                                                                                        | Action: deleteAllUnusedReferenceDataTypes
 |   GET    | /api/folders/${folderId}/referenceDataModels                                                                                                                                     | Action: index
 |  DELETE  | /api/referenceDataModels/${referenceDataModelId}/readByAuthenticated                                                                                                             | Action: readByAuthenticated
 |   PUT    | /api/referenceDataModels/${referenceDataModelId}/readByAuthenticated                                                                                                             | Action: readByAuthenticated

--- a/mdm-testing-functional/untested_endpoints.md
+++ b/mdm-testing-functional/untested_endpoints.md
@@ -554,7 +554,6 @@ Controller: semanticLink
 |   GET    | /api/${catalogueItemDomainType}/${catalogueItemId}/semanticLinks/${id}                                                                                                           | Action: show
 
 Controller: session
-|   GET    | /api/session/keepAlive                                                                                                                                                           | Action: keepAlive
 |   GET    | /api/session/isApplicationAdministration                                                                                                                                         | Action: isApplicationAdministrationSession
 |   GET    | /api/admin/activeSessions                                                                                                                                                        | Action: activeSessions
 |   GET    | /api/session/isAuthenticated/${sessionId}?                                                                                                                                       | Action: isAuthenticatedSession


### PR DESCRIPTION
- Remove unused clean datatypes/dataclasses endpoints from datamodel and referencedata plugins (resolves #272)
- Remove unused keep alive endpoint (resolves #259)

Also:
- Ensure tests use assertions where needed