### PR TITLE
Feature/mc 9861 - add intersectsMany endpoint

### DIFF
--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelController.groovy
@@ -225,6 +225,6 @@ class DataModelController extends ModelController<DataModel> {
         DataModel sourceModel = queryForResource params[alternateParamsIdKey]
         if (!sourceModel) return notFound(params[alternateParamsIdKey])
 
-        respond(intersectionMany: dataModelService.intersectsMany(sourceModel, intersects))
+        respond(intersectionMany: dataModelService.intersectsMany(currentUserSecurityPolicyManager, sourceModel, intersects))
     }
 }

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelController.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelController.groovy
@@ -27,6 +27,7 @@ import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataTypeService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.provider.exporter.DataModelExporterProviderService
 import uk.ac.ox.softeng.maurodatamapper.datamodel.provider.importer.DataModelImporterProviderService
+import uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport.Intersects
 import uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport.Subset
 import uk.ac.ox.softeng.maurodatamapper.hibernate.search.PaginatedHibernateSearchResult
 
@@ -219,5 +220,11 @@ class DataModelController extends ModelController<DataModel> {
         respond(intersection: dataModelService.intersects(sourceModel, targetModel))
     }
 
+    def intersectsMany(Intersects intersects) {
 
+        DataModel sourceModel = queryForResource params[alternateParamsIdKey]
+        if (!sourceModel) return notFound(params[alternateParamsIdKey])
+
+        respond(intersectionMany: dataModelService.intersectsMany(sourceModel, intersects))
+    }
 }

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelInterceptor.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelInterceptor.groovy
@@ -85,6 +85,13 @@ class DataModelInterceptor extends ModelInterceptor {
 
         boolean canReadId = currentUserSecurityPolicyManager.userCanReadSecuredResourceId(DataModel, getId())
 
+        if (actionName in ['intersectsMany']) {
+            if (!canReadId) {
+                return notFound(DataModel, getId())
+            }
+            return true
+        }
+
         if (actionName in ['suggestLinks', 'intersects']) {
             if (!canReadId) {
                 return notFound(DataModel, getId())

--- a/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/UrlMappings.groovy
+++ b/mdm-plugin-datamodel/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/datamodel/UrlMappings.groovy
@@ -59,6 +59,7 @@ class UrlMappings {
 
                 put "/subset/$otherDataModelId"(controller: 'dataModel', action: 'subset')
                 get "/intersects/$otherDataModelId"(controller: 'dataModel', action: 'intersects')
+                post '/intersectsMany'(controller: 'dataModel', action: 'intersectsMany')
 
                 get '/hierarchy'(controller: 'dataModel', action: 'hierarchy')
 

--- a/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElement.groovy
+++ b/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElement.groovy
@@ -254,6 +254,10 @@ class DataElement implements ModelItem<DataElement, DataModel>, MultiplicityAwar
         new DetachedCriteria<DataElement>(DataElement).in('dataClass', DataClass.byDataModelId(dataModelId).id())
     }
 
+    static DetachedCriteria<DataElement> byDataModelIdAndId(Serializable dataModelId, Serializable id) {
+        byDataModelId(dataModelId).eq('id', id)
+    }
+
     static DetachedCriteria<DataElement> byDataModelIdAndLabelIlike(Serializable dataModelId, String labelSearch) {
         byDataModelId(dataModelId).ilike('label', "%${labelSearch}%")
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -327,6 +327,10 @@ WHERE (de.dataClass.id = :dataClassId OR idc.id = :dataClassId)''', 'de', filter
         DataElement.byDataClassIdAndLabel(dataClassId, label).get()
     }
 
+    DataElement findByDataModelIdAndId(Serializable dataModelId, Serializable id) {
+        DataElement.byDataModelIdAndId(dataModelId, id).get()
+    }
+
     DataElement findOrCreateDataElementForDataClass(DataClass parentClass, String label, String description, User createdBy,
                                                     DataType dataType,
                                                     Integer minMultiplicity = 0, Integer maxMultiplicity = 1) {

--- a/mdm-plugin-datamodel/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/datamodel/rest/transport/Intersects.groovy
+++ b/mdm-plugin-datamodel/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/datamodel/rest/transport/Intersects.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport
+
+import grails.validation.Validateable
+
+/**
+ * @since 21/04/2022
+ */
+class Intersects implements Validateable {
+
+    List<String> targetDataModelIds
+    List<String> dataElementIds
+
+    static constraints = {
+        targetDataModelIds minSize: 1
+        targetDataModelIds nullable: false
+        dataElementIds minSize: 1
+        dataElementIds nullable: false
+    }
+}

--- a/mdm-plugin-datamodel/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/datamodel/rest/transport/SourceTargetIntersects.groovy
+++ b/mdm-plugin-datamodel/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/datamodel/rest/transport/SourceTargetIntersects.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport
+
+import grails.validation.Validateable
+
+/**
+ * @since 21/04/2022
+ */
+class SourceTargetIntersects implements Validateable {
+
+    String sourceDataModelId
+    String targetDataModelId
+
+    List<String> intersects
+}

--- a/mdm-plugin-datamodel/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/datamodel/rest/transport/SourceTargetIntersects.groovy
+++ b/mdm-plugin-datamodel/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/datamodel/rest/transport/SourceTargetIntersects.groovy
@@ -27,5 +27,5 @@ class SourceTargetIntersects implements Validateable {
     String sourceDataModelId
     String targetDataModelId
 
-    List<String> intersects
+    List<String> intersects = []
 }

--- a/mdm-plugin-datamodel/grails-app/views/dataModel/_sourceTargetIntersects.gson
+++ b/mdm-plugin-datamodel/grails-app/views/dataModel/_sourceTargetIntersects.gson
@@ -1,0 +1,11 @@
+import uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport.SourceTargetIntersects
+
+model {
+    SourceTargetIntersects sourceTargetIntersects
+}
+
+json {
+    sourceDataModelId sourceTargetIntersects.sourceDataModelId
+    targetDataModelId sourceTargetIntersects.targetDataModelId
+    intersects sourceTargetIntersects.intersects
+}

--- a/mdm-plugin-datamodel/grails-app/views/dataModel/intersectsMany.gson
+++ b/mdm-plugin-datamodel/grails-app/views/dataModel/intersectsMany.gson
@@ -1,9 +1,9 @@
 import uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport.SourceTargetIntersects
 
 model {
-    Collection<SourceTargetIntersects> manySourceTargetIntersects
+    Collection<SourceTargetIntersects> intersectionMany
 }
 
 json {
-    manySourceTargetIntersects
+    items tmpl.sourceTargetIntersects(intersectionMany ?: [])
 }

--- a/mdm-plugin-datamodel/grails-app/views/dataModel/intersectsMany.gson
+++ b/mdm-plugin-datamodel/grails-app/views/dataModel/intersectsMany.gson
@@ -1,0 +1,9 @@
+import uk.ac.ox.softeng.maurodatamapper.datamodel.rest.transport.SourceTargetIntersects
+
+model {
+    Collection<SourceTargetIntersects> manySourceTargetIntersects
+}
+
+json {
+    manySourceTargetIntersects
+}

--- a/mdm-plugin-datamodel/src/integration-test/resources/url-mappings/tracked_endpoints.txt
+++ b/mdm-plugin-datamodel/src/integration-test/resources/url-mappings/tracked_endpoints.txt
@@ -100,3 +100,4 @@
 | GET    | /api/${catalogueItemDomainType}/${catalogueItemId}/summaryMetadata/${summaryMetadataId}/summaryMetadataReports/${id} | show |
 | GET    | /api/dataModels/${dataModelId}/intersects/${otherDataModelId} | intersects |
 | PUT    | /api/dataModels/${dataModelId}/subset/${otherDataModelId} | subset |
+| POST   | /api/dataModels/${dataModelId}/intersectsMany | intersectsMany |


### PR DESCRIPTION
The endpoint ```GET /api/dataModels/${sourceDataModelId}/intersects/${targetDataModelId}`` iterates all data elements in the source model and determines which are present in the target model. When a user only wishes to check the existence of one (or a small number) of data elements in the target, this endpoint is slow. The slowness is compounded when the user wishes to check the existence of the data elements in many targets.

This PR adds a new and similar endpoint ```POST /api/dataModels/${sourceDataModelId}/intersectsMany``` which receives a payload like 
```
{
    "targetDataModelIds": ["d6fc69cc-7901-474c-b223-c2c88e42d41a", "0398c58c-5fa9-4ae8-8203-2b885000ed6a"],
    "dataElementIds": ["d0581d1d-9fda-4338-8380-835f40afafe2", "3de9ea4f-0178-4d96-94ff-4999e660c3ee"]
}
```
and for each targetDataModel, checks the intersection between source and target, but limiting the test to only those data elements provided. This should be faster when the user requires to check a small number of data elements across several target models, firstly because it is no longer necessary to iterate all data elements in the source model, and secondly because the user can now make a single API call to test against many target models.

Postman collection attached:
[mc-9861.postman_collection.json.zip](https://github.com/MauroDataMapper/mdm-core/files/8621033/mc-9861.postman_collection.json.zip)

