### PR TITLE
Feature/mc 9888

### DIFF
--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/hibernate/search/HibernateSearch.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/hibernate/search/HibernateSearch.groovy
@@ -19,7 +19,7 @@ package uk.ac.ox.softeng.maurodatamapper.hibernate.search
 
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiInternalException
 import uk.ac.ox.softeng.maurodatamapper.hibernate.search.engine.search.predicate.IdPathSecureFilterFactory
-import uk.ac.ox.softeng.maurodatamapper.path.PathNode
+import uk.ac.ox.softeng.maurodatamapper.path.Path
 
 import grails.plugins.hibernate.search.HibernateSearchApi
 import groovy.util.logging.Slf4j
@@ -35,7 +35,7 @@ class HibernateSearch {
     @SuppressWarnings('UnnecessaryQualifiedReference')
     static <T> PaginatedHibernateSearchResult<T> securedPaginatedList(Class<T> clazz,
                                                                       List<UUID> allowedIds,
-                                                                      List<PathNode> allowedPathNodes,
+                                                                      List<Path> allowedPaths,
                                                                       Map pagination,
                                                                       @DelegatesTo(HibernateSearchApi) Closure... closures) {
         if (!allowedIds) return new PaginatedHibernateSearchResult<T>([], 0)
@@ -47,7 +47,7 @@ class HibernateSearch {
                 closure.call()
             }
 
-            filter IdPathSecureFilterFactory.createFilterPredicate(searchPredicateFactory, allowedIds, allowedPathNodes)
+            filter IdPathSecureFilterFactory.createFilterPredicate(searchPredicateFactory, allowedIds, allowedPaths)
         }
     }
 

--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/hibernate/search/engine/search/predicate/IdPathSecureFilterFactory.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/hibernate/search/engine/search/predicate/IdPathSecureFilterFactory.groovy
@@ -37,20 +37,20 @@ import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory
 @CompileStatic
 class IdPathSecureFilterFactory extends FilterFactory {
 
-    static PredicateFinalStep createFilter(SearchPredicateFactory factory, Collection<UUID> allowedIds, Collection<PathNode> allowedPathNodes) {
+    static PredicateFinalStep createFilter(SearchPredicateFactory factory, Collection<UUID> allowedIds, Collection<Path> allowedPaths) {
 
         BooleanPredicateClausesStep step = startFilter(factory)
 
         allowedIds.each {id ->
             step = step.should(factory.id().matching(id))
         }
-        allowedPathNodes?.each {pn ->
-            step = step.should(factory.match().field('path').matching(Path.from(pn)))
+        allowedPaths?.each {p ->
+            step = step.should(factory.phrase().field('path').matching(p.toString()))
         }
         step
     }
 
-    static SearchPredicate createFilterPredicate(SearchPredicateFactory factory, Collection<UUID> allowedIds, Collection<PathNode> allowedPathNodes) {
-        createFilter(factory, allowedIds, allowedPathNodes).toPredicate()
+    static SearchPredicate createFilterPredicate(SearchPredicateFactory factory, Collection<UUID> allowedIds, Collection<Path> allowedPaths) {
+        createFilter(factory, allowedIds, allowedPaths).toPredicate()
     }
 }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItem.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItem.groovy
@@ -25,7 +25,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.EditHistoryAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.InformationAware
 import uk.ac.ox.softeng.maurodatamapper.hibernate.search.HibernateSearch
 import uk.ac.ox.softeng.maurodatamapper.hibernate.search.PaginatedHibernateSearchResult
-import uk.ac.ox.softeng.maurodatamapper.path.PathNode
+import uk.ac.ox.softeng.maurodatamapper.path.Path
 import uk.ac.ox.softeng.maurodatamapper.traits.domain.MdmDomain
 
 import grails.gorm.DetachedCriteria
@@ -101,11 +101,11 @@ trait CatalogueItem<D extends Diffable> implements MdmDomain, InformationAware, 
 
     static <T extends CatalogueItem> PaginatedHibernateSearchResult<T> standardHibernateSearch(Class<T> clazz, String searchTerm,
                                                                                                List<UUID> allowedIds,
-                                                                                               List<PathNode> allowedPathNodes, Map pagination,
+                                                                                               List<Path> allowedPaths, Map pagination,
                                                                                                @DelegatesTo(HibernateSearchApi)
                                                                                                    Closure additional = null) {
 
-        HibernateSearch.securedPaginatedList(clazz, allowedIds, allowedPathNodes, pagination) {
+        HibernateSearch.securedPaginatedList(clazz, allowedIds, allowedPaths, pagination) {
             if (searchTerm) {
                 simpleQueryString(searchTerm, 'label', 'description', 'aliasesString', 'metadata.key', 'metadata.value')
             }
@@ -118,23 +118,23 @@ trait CatalogueItem<D extends Diffable> implements MdmDomain, InformationAware, 
     }
 
     static <T extends CatalogueItem> PaginatedHibernateSearchResult<T> customHibernateSearch(Class<T> clazz, List<UUID> allowedIds,
-                                                                                             List<PathNode> allowedPathNodes, Map pagination,
+                                                                                             List<Path> allowedPaths, Map pagination,
                                                                                              @DelegatesTo(HibernateSearchApi)
                                                                                                  Closure... customSearches) {
-        HibernateSearch.securedPaginatedList(clazz, allowedIds, allowedPathNodes, pagination, customSearches)
+        HibernateSearch.securedPaginatedList(clazz, allowedIds, allowedPaths, pagination, customSearches)
     }
 
     static <T extends CatalogueItem> PaginatedHibernateSearchResult<T> labelHibernateSearch(Class<T> clazz, String searchTerm,
-                                                                                            List<UUID> allowedIds, List<PathNode> allowedPathNodes,
+                                                                                            List<UUID> allowedIds, List<Path> allowedPaths,
                                                                                             @DelegatesTo(HibernateSearchApi) Closure additional) {
-        labelHibernateSearch(clazz, searchTerm, allowedIds, allowedPathNodes, [:], additional)
+        labelHibernateSearch(clazz, searchTerm, allowedIds, allowedPaths, [:], additional)
     }
 
     static <T extends CatalogueItem> PaginatedHibernateSearchResult<T> labelHibernateSearch(Class<T> clazz, String searchTerm, List<UUID> allowedIds,
-                                                                                            List<PathNode> allowedPathNodes, Map pagination = [:],
+                                                                                            List<Path> allowedPaths, Map pagination = [:],
                                                                                             @DelegatesTo(HibernateSearchApi)
                                                                                                 Closure additional = null) {
-        HibernateSearch.securedPaginatedList(clazz, allowedIds, allowedPathNodes, pagination, additional) {
+        HibernateSearch.securedPaginatedList(clazz, allowedIds, allowedPaths, pagination, additional) {
             simpleQueryString searchTerm, 'label'
         }
     }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -285,8 +285,8 @@ abstract class ModelService<K extends Model>
         findAllReadableModels(constrainedIds, includeDeleted)
     }
 
-    List<PathNode> getAllReadablePathNodes(Collection<UUID> readableIds) {
-        getAll(readableIds).collect {it.path.last()}
+    List<Path> getAllReadablePaths(Collection<UUID> readableIds) {
+        getAll(readableIds).collect {it.path}
     }
 
     @Override

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/search/AbstractCatalogueItemSearchService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/search/AbstractCatalogueItemSearchService.groovy
@@ -23,7 +23,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.search.SearchParams
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.search.searchparamfilter.SearchParamFilter
 import uk.ac.ox.softeng.maurodatamapper.hibernate.search.HibernateSearch
 import uk.ac.ox.softeng.maurodatamapper.hibernate.search.PaginatedHibernateSearchResult
-import uk.ac.ox.softeng.maurodatamapper.path.PathNode
+import uk.ac.ox.softeng.maurodatamapper.path.Path
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
 import grails.plugins.hibernate.search.HibernateSearchApi
@@ -138,64 +138,64 @@ abstract class AbstractCatalogueItemSearchService<K extends CatalogueItem> {
                                                     Map pagination,
                                                     @DelegatesTo(HibernateSearchApi) Closure additional,
                                                     @DelegatesTo(HibernateSearchApi) Closure customSearch) {
-        List<PathNode> pathNodes = pathService.findAllPathsForIds(owningIds).collect {it.last()}
+        List<Path> paths = pathService.findAllPathsForIds(owningIds)
         if (customSearch) {
             log.debug('Performing hs custom search')
-            return performCustomSearch(filteredDomainToSearch, owningIds, pathNodes, pagination, additional, customSearch)
+            return performCustomSearch(filteredDomainToSearch, owningIds, paths, pagination, additional, customSearch)
         } else if (labelOnly) {
             log.debug('Performing hs label search')
-            return performLabelSearch(filteredDomainToSearch, owningIds, pathNodes, searchTerm, pagination, additional)
+            return performLabelSearch(filteredDomainToSearch, owningIds, paths, searchTerm, pagination, additional)
         }
 
         log.debug('Performing hs standard search')
-        performStandardSearch(filteredDomainToSearch, owningIds, pathNodes, searchTerm, pagination, additional)
+        performStandardSearch(filteredDomainToSearch, owningIds, paths, searchTerm, pagination, additional)
     }
 
     protected List<K> performLabelSearch(Set<Class<K>> filteredDomainsToSearch, List<UUID> owningIds, String searchTerm,
                                          @DelegatesTo(HibernateSearchApi) Closure additional = null) {
-        List<PathNode> pathNodes = pathService.findAllPathsForIds(owningIds).collect {it.last()}
+        List<Path> paths = pathService.findAllPathsForIds(owningIds)
         filteredDomainsToSearch.collect {domain ->
-            performLabelSearch(domain, owningIds, pathNodes, searchTerm, [:], additional).results
+            performLabelSearch(domain, owningIds, paths, searchTerm, [:], additional).results
         }.flatten().findAll() as List<K>
 
     }
 
     protected List<K> performStandardSearch(Set<Class<K>> filteredDomainsToSearch, List<UUID> owningIds, String searchTerm,
                                             @DelegatesTo(HibernateSearchApi) Closure additional = null) {
-        List<PathNode> pathNodes = pathService.findAllPathsForIds(owningIds).collect {it.last()}
+        List<Path> paths = pathService.findAllPathsForIds(owningIds)
         filteredDomainsToSearch.collect {domain ->
-            performStandardSearch(domain, owningIds, pathNodes, searchTerm, [:], additional).results
+            performStandardSearch(domain, owningIds, paths, searchTerm, [:], additional).results
         }.flatten().findAll() as List<K>
     }
 
     protected List<K> performCustomSearch(Set<Class<K>> filteredDomainsToSearch, List<UUID> owningIds,
                                           @DelegatesTo(HibernateSearchApi) Closure additional,
                                           @DelegatesTo(HibernateSearchApi) Closure customSearch) {
-        List<PathNode> pathNodes = pathService.findAllPathsForIds(owningIds).collect {it.last()}
+        List<Path> paths = pathService.findAllPathsForIds(owningIds)
         filteredDomainsToSearch.collect {domain ->
-            performCustomSearch(domain, owningIds, pathNodes, [:], additional, customSearch).results
+            performCustomSearch(domain, owningIds, paths, [:], additional, customSearch).results
         }.flatten().findAll() as List<K>
     }
 
-    protected PaginatedHibernateSearchResult<K> performLabelSearch(Class<K> domainToSearch, List<UUID> owningIds, List<PathNode> pathNodes, String searchTerm,
+    protected PaginatedHibernateSearchResult<K> performLabelSearch(Class<K> domainToSearch, List<UUID> owningIds, List<Path> paths, String searchTerm,
                                                                    Map pagination, @DelegatesTo(HibernateSearchApi) Closure additional) {
 
         log.debug('Domain searching {}', domainToSearch)
-        domainToSearch.labelHibernateSearch(domainToSearch, searchTerm, owningIds, pathNodes, pagination, additional)
+        domainToSearch.labelHibernateSearch(domainToSearch, searchTerm, owningIds, paths, pagination, additional)
 
     }
 
-    protected PaginatedHibernateSearchResult<K> performStandardSearch(Class<K> domainToSearch, List<UUID> owningIds, List<PathNode> pathNodes, String searchTerm,
+    protected PaginatedHibernateSearchResult<K> performStandardSearch(Class<K> domainToSearch, List<UUID> owningIds, List<Path> paths, String searchTerm,
                                                                       Map pagination, @DelegatesTo(HibernateSearchApi) Closure additional) {
         log.debug('Domain searching {}', domainToSearch)
-        domainToSearch.standardHibernateSearch(domainToSearch, searchTerm, owningIds, pathNodes, pagination, additional)
+        domainToSearch.standardHibernateSearch(domainToSearch, searchTerm, owningIds, paths, pagination, additional)
     }
 
-    protected PaginatedHibernateSearchResult<K> performCustomSearch(Class<K> domainToSearch, List<UUID> owningIds, List<PathNode> pathNodes, Map pagination,
+    protected PaginatedHibernateSearchResult<K> performCustomSearch(Class<K> domainToSearch, List<UUID> owningIds, List<Path> paths, Map pagination,
                                                                     @DelegatesTo(HibernateSearchApi) Closure additional,
                                                                     @DelegatesTo(HibernateSearchApi) Closure customSearch) {
         log.debug('Domain searching {}', domainToSearch)
-        domainToSearch.customHibernateSearch(domainToSearch, owningIds, pathNodes, pagination, additional, customSearch)
+        domainToSearch.customHibernateSearch(domainToSearch, owningIds, paths, pagination, additional, customSearch)
     }
 
     private static Integer removePaginationInteger(Map pagination, String field) {

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -944,7 +944,7 @@ WHERE
             long start = System.currentTimeMillis()
             results =
                 DataClass
-                    .labelHibernateSearch(DataClass, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds)).results
+                    .labelHibernateSearch(DataClass, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
 

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -203,7 +203,7 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
             long start = System.currentTimeMillis()
             results =
                 DataElement
-                    .labelHibernateSearch(DataElement, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds))
+                    .labelHibernateSearch(DataElement, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds))
                     .results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
@@ -469,7 +469,7 @@ WHERE (de.dataClass.id = :dataClassId OR idc.id = :dataClassId)''', 'de', filter
             .where {lsf ->
                 BooleanPredicateClausesStep boolStep = lsf
                     .bool()
-                    .filter(IdPathSecureFilterFactory.createFilter(lsf, [dataModelToSearch.id], [dataModelToSearch.path.last()]))
+                    .filter(IdPathSecureFilterFactory.createFilter(lsf, [dataModelToSearch.id], [dataModelToSearch.path]))
                     .filter(FilterFactory.mustNot(lsf, lsf.id().matching(dataElementToCompare.id)))
 
                 moreLikeThisQueries.each {mlt ->

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
@@ -218,7 +218,7 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
             long start = System.currentTimeMillis()
             results =
                 DataType
-                    .labelHibernateSearch(DataType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds)).results
+                    .labelHibernateSearch(DataType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
         results

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/EnumerationTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/EnumerationTypeService.groovy
@@ -141,7 +141,7 @@ class EnumerationTypeService extends ModelItemService<EnumerationType> implement
             long start = System.currentTimeMillis()
             results =
                 EnumerationType
-                    .labelHibernateSearch(EnumerationType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds))
+                    .labelHibernateSearch(EnumerationType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds))
                     .results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ModelDataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ModelDataTypeService.groovy
@@ -138,7 +138,7 @@ class ModelDataTypeService extends ModelItemService<ModelDataType> implements Su
         if (shouldPerformSearchForTreeTypeCatalogueItems(domainType)) {
             results =
                 ModelDataType
-                    .labelHibernateSearch(ModelDataType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds))
+                    .labelHibernateSearch(ModelDataType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds))
                     .results
         }
         log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/PrimitiveTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/PrimitiveTypeService.groovy
@@ -129,7 +129,7 @@ class PrimitiveTypeService extends ModelItemService<PrimitiveType> implements Su
         if (shouldPerformSearchForTreeTypeCatalogueItems(domainType)) {
             results =
                 PrimitiveType
-                    .labelHibernateSearch(PrimitiveType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds))
+                    .labelHibernateSearch(PrimitiveType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds))
                     .results
         }
         log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ReferenceTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ReferenceTypeService.groovy
@@ -164,7 +164,7 @@ class ReferenceTypeService extends ModelItemService<ReferenceType> implements Su
             long start = System.currentTimeMillis()
             results =
                 ReferenceType
-                    .labelHibernateSearch(ReferenceType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds))
+                    .labelHibernateSearch(ReferenceType, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds))
                     .results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueService.groovy
@@ -147,7 +147,7 @@ class EnumerationValueService extends ModelItemService<EnumerationValue> impleme
             long start = System.currentTimeMillis()
             results =
                 EnumerationValue
-                    .labelHibernateSearch(EnumerationValue, searchTerm, readableIds.toList(), dataModelService.getAllReadablePathNodes(readableIds))
+                    .labelHibernateSearch(EnumerationValue, searchTerm, readableIds.toList(), dataModelService.getAllReadablePaths(readableIds))
                     .results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataElementService.groovy
@@ -154,7 +154,7 @@ class ReferenceDataElementService extends ModelItemService<ReferenceDataElement>
             long start = System.currentTimeMillis()
             results =
                 ReferenceDataElement
-                    .labelHibernateSearch(ReferenceDataElement, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePathNodes(readableIds)).results
+                    .labelHibernateSearch(ReferenceDataElement, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
 
@@ -346,7 +346,7 @@ class ReferenceDataElementService extends ModelItemService<ReferenceDataElement>
             .where {lsf ->
                 BooleanPredicateClausesStep boolStep = lsf
                     .bool()
-                    .filter(IdPathSecureFilterFactory.createFilter(lsf, [referenceDataModelToSearch.id], [referenceDataModelToSearch.path.last()]))
+                    .filter(IdPathSecureFilterFactory.createFilter(lsf, [referenceDataModelToSearch.id], [referenceDataModelToSearch.path]))
                     .filter(FilterFactory.mustNot(lsf, lsf.id().matching(referenceDataElementToCompare.id)))
 
                 moreLikeThisQueries.each {mlt ->

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceDataTypeService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceDataTypeService.groovy
@@ -140,7 +140,7 @@ class ReferenceDataTypeService extends ModelItemService<ReferenceDataType> imple
             log.debug('Performing hs label search')
             long start = System.currentTimeMillis()
             results = ReferenceDataType.labelHibernateSearch(ReferenceDataType, searchTerm, readableIds.toList(),
-                                                             referenceDataModelService.getAllReadablePathNodes(readableIds)).results
+                                                             referenceDataModelService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
         results

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceEnumerationTypeService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferenceEnumerationTypeService.groovy
@@ -120,7 +120,7 @@ class ReferenceEnumerationTypeService extends ModelItemService<ReferenceEnumerat
             long start = System.currentTimeMillis()
             results =
                 ReferenceEnumerationType
-                    .labelHibernateSearch(ReferenceEnumerationType, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePathNodes(readableIds)).results
+                    .labelHibernateSearch(ReferenceEnumerationType, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
 

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferencePrimitiveTypeService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/ReferencePrimitiveTypeService.groovy
@@ -124,7 +124,7 @@ class ReferencePrimitiveTypeService extends ModelItemService<ReferencePrimitiveT
         if (shouldPerformSearchForTreeTypeCatalogueItems(domainType)) {
             results =
                 ReferencePrimitiveType
-                    .labelHibernateSearch(ReferencePrimitiveType, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePathNodes(readableIds)).results
+                    .labelHibernateSearch(ReferencePrimitiveType, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePaths(readableIds)).results
         }
         log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         results

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/item/datatype/enumeration/ReferenceEnumerationValueService.groovy
@@ -109,7 +109,7 @@ class ReferenceEnumerationValueService extends ModelItemService<ReferenceEnumera
             long start = System.currentTimeMillis()
             results =
                 ReferenceEnumerationValue
-                    .labelHibernateSearch(ReferenceEnumerationValue, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePathNodes(readableIds)).results
+                    .labelHibernateSearch(ReferenceEnumerationValue, searchTerm, readableIds.toList(), referenceDataModelService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
 

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermService.groovy
@@ -263,7 +263,7 @@ class TermService extends ModelItemService<Term> {
             log.debug('Performing hs label search')
             long start = System.currentTimeMillis()
             results = Term.labelHibernateSearch(Term, searchTerm, readableIds.toList(),
-                                                terminologyService.getAllReadablePathNodes(readableIds)).results
+                                                terminologyService.getAllReadablePaths(readableIds)).results
             log.debug("Search took: ${Utils.getTimeString(System.currentTimeMillis() - start)}. Found ${results.size()}")
         }
 


### PR DESCRIPTION
Fixes https://metadatacatalogue.myjetbrains.com/youtrack/issue/MC-9888

The endpoint `POST /api/dataClasses/{dataClassId}/profiles/{namespace}/{name}/search` was returning data elements which matched on search term but belonged to a data class other than the one specified in the route. This was because  `IdPathSecureFilterFactory.createFilter` was matching on the last node of the data class path, rather than the full path.

This PR changes the `IdPathSecureFilterFactory.createFilter` method to match by phrase on the full path of the specified data class. All uses of this method are updated. Test data replicating the failing case is added to the SearchFunctionalSpec.