### PR TITLE
Import Data Elements into Data Classes within the same VF

### DIFF
--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -1185,7 +1185,7 @@ abstract class ModelService<K extends Model>
         if (!versionedFolderService.isVersionedFolderFamily(model.folder) || !versionedFolderService.isVersionedFolderFamily(otherModel.folder)) return false
         Path modelPath = getFullPathForModel(model)
         Path otherModelPath = getFullPathForModel(otherModel)
-        modelPath.getParent() == otherModelPath.getParent()
+        modelPath.first() == otherModelPath.first()
 
     }
 


### PR DESCRIPTION
Check against the top-level path item, rather than the immediate parent.  Solves #278 where the models are in different folders inside the VF