### PR TITLE
gh-329 test bulk edit of profiles for terms

### DIFF
--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
@@ -1315,52 +1315,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "profile functional model",
-  "domainType": "DataModel"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJson("profile functional model", "DataModel")
 
         cleanup:
         cleanupDataModelId(simpleModelId)
@@ -2025,53 +1980,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "first data element in profile functional class",
-  "domainType": "DataElement"
-}'''
-
+        verifyJsonResponse OK, getDynamicProfileExpectedJson("first data element in profile functional class", "DataElement")
 
         /**
          * 2. Use saveMany to update one of the previously saved dynamic profiles, and in the same
@@ -2184,52 +2093,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "first data element in profile functional class",
-  "domainType": "DataElement"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdate("first data element in profile functional class", "DataElement")
 
         when:
         localResponse = GET("dataElements/$secondModelSecondDataElementId/profiles/used", Argument.listOf(Map))
@@ -2768,53 +2632,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "first profile functional data type",
-  "domainType": "PrimitiveType"
-}'''
-
+        verifyJsonResponse OK, getDynamicProfileExpectedJson("first profile functional data type", "PrimitiveType")
 
         /**
          * 2. Use saveMany to update one of the previously saved dynamic profiles, and in the same
@@ -2928,52 +2746,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "first profile functional data type",
-  "domainType": "PrimitiveType"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdate("first profile functional data type", "PrimitiveType")
 
         when:
         localResponse = GET("dataTypes/$secondModelSecondModelItemId/profiles/used", Argument.listOf(Map))
@@ -3523,53 +3296,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "profile functional class",
-  "domainType": "DataClass"
-}'''
-
+        verifyJsonResponse OK, getDynamicProfileExpectedJson("profile functional class", "DataClass")
 
         /**
          * 2. Use saveMany to update one of the previously saved dynamic profiles, and in the same
@@ -3693,52 +3420,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "profile functional class",
-  "domainType": "DataClass"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdate("profile functional class", "DataClass")
 
         when:
         localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
@@ -4280,53 +3962,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "PT01: first term in profile functional class",
-  "domainType": "Term"
-}'''
-
+        verifyJsonResponse OK, getDynamicProfileExpectedJson("PT01: first term in profile functional class", "Term")
 
         /**
          * 2. Use saveMany to update one of the previously saved dynamic profiles, and in the same
@@ -4439,52 +4075,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "PT01: first term in profile functional class",
-  "domainType": "Term"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdate("PT01: first term in profile functional class", "Term")
 
         when:
         localResponse = GET("terms/$secondModelSecondTermId/profiles/used", Argument.listOf(Map))
@@ -5406,5 +4997,104 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         assert responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap2_1.fieldName}.currentValue == defaultOptionalFieldMap2_1.currentValue
         assert responseBody().profilesProvided[1].profile.id == secondModelItemId
         assert responseBody().profilesProvided[1].profile.domainType == modelItemDomainType
+    }
+
+    String getDynamicProfileExpectedJson(String label, String domainType) {
+        return '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "abc",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "def",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "''' + "${label}" + '''",
+  "domainType": "''' + "${domainType}" + '''"
+}'''
+    }
+
+
+    String getDynamicProfileExpectedJsonPostUpdate(String label, String domainType) {
+        return '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "abc updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "def updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "''' + "${label}" + '''",
+  "domainType": "''' + "${domainType}" + '''"
+}'''
     }
 }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
@@ -2109,52 +2109,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "second data element in profile functional class",
-  "domainType": "DataElement"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJson("second data element in profile functional class", "DataElement")
 
         /**
          * 3. Use saveMany to update the dynamic profiles that have previously been saved
@@ -2303,52 +2258,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "first data element in profile functional class",
-  "domainType": "DataElement"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdateAgain("first data element in profile functional class", "DataElement")
 
         when:
         localResponse = GET("dataElements/$secondModelSecondDataElementId/profiles/used", Argument.listOf(Map))
@@ -2364,52 +2274,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "second data element in profile functional class",
-  "domainType": "DataElement"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJsonPostUpdate("second data element in profile functional class", "DataElement")
 
         when:
         localResponse = GET("dataElements/$thirdModelFirstDataElementId/profiles/used", Argument.listOf(Map))
@@ -2442,32 +2307,15 @@ class ProfileFunctionalSpec extends FunctionalSpec {
          */
         when: 'request made against a MultiFacetAwareItem that is not a model'
         loginAuthor()
-        Map getManyMap = [
-            'multiFacetAwareItems'   : [
-                [
-                    'multiFacetAwareItemDomainType': 'dataElement',
-                    'multiFacetAwareItemId'        : secondModelFirstDataElementId
-                ],
-                [
-                    'multiFacetAwareItemDomainType': 'dataElement',
-                    'multiFacetAwareItemId'        : secondModelSecondDataElementId
-                ]
-            ],
-            'profileProviderServices': [
-                [
-                    'name'     : "Dynamic%20Profile%20Model",
-                    'namespace': "uk.ac.ox.softeng.maurodatamapper.profile.provider"
-                ]
-            ]
-        ]
+        Map manyMap = getManyMap('dataElement', secondModelFirstDataElementId, secondModelSecondDataElementId)
 
-        POST("dataElements/$secondModelFirstDataElementId/profile/getMany", getManyMap)
+        POST("dataElements/$secondModelFirstDataElementId/profile/getMany", manyMap)
 
         then:
         verifyResponse(BAD_REQUEST, response)
 
         when: 'correctly request against the second model'
-        POST("dataModels/$secondModelId/profile/getMany", getManyMap)
+        POST("dataModels/$secondModelId/profile/getMany", manyMap)
 
         then: 'the profiles are listed'
         verifyResponse(OK, response)
@@ -2475,7 +2323,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         responseBody().profilesProvided.size == 2
 
         when: 'incorrectly request against the third model'
-        POST("dataModels/$thirdModelId/profile/getMany", getManyMap)
+        POST("dataModels/$thirdModelId/profile/getMany", manyMap)
 
         then: 'the profiles are not listed'
         verifyResponse(OK, response)
@@ -2763,52 +2611,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "second profile functional data type",
-  "domainType": "PrimitiveType"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJson("second profile functional data type", "PrimitiveType")
 
         /**
          * 3. Use saveMany to update the dynamic profiles that have previously been saved
@@ -2958,52 +2761,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "first profile functional data type",
-  "domainType": "PrimitiveType"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdateAgain("first profile functional data type", "PrimitiveType")
 
         when:
         localResponse = GET("dataTypes/$secondModelSecondModelItemId/profiles/used", Argument.listOf(Map))
@@ -3020,52 +2778,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "second profile functional data type",
-  "domainType": "PrimitiveType"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJsonPostUpdate("second profile functional data type", "PrimitiveType")
 
         when:
         localResponse = GET("dataTypes/$thirdModelFirstModelItemId/profiles/used", Argument.listOf(Map))
@@ -3098,32 +2811,15 @@ class ProfileFunctionalSpec extends FunctionalSpec {
          */
         when: 'request made against a MultiFacetAwareItem that is not a model'
         loginAuthor()
-        Map getManyMap = [
-            'multiFacetAwareItems'   : [
-                [
-                    'multiFacetAwareItemDomainType': 'dataType',
-                    'multiFacetAwareItemId'        : secondModelFirstModelItemId
-                ],
-                [
-                    'multiFacetAwareItemDomainType': 'dataType',
-                    'multiFacetAwareItemId'        : secondModelSecondModelItemId
-                ]
-            ],
-            'profileProviderServices': [
-                [
-                    'name'     : "Dynamic%20Profile%20Model",
-                    'namespace': "uk.ac.ox.softeng.maurodatamapper.profile.provider"
-                ]
-            ]
-        ]
+        Map manyMap = getManyMap('dataType', secondModelFirstModelItemId, secondModelSecondModelItemId)
 
-        POST("dataTypes/$secondModelFirstModelItemId/profile/getMany", getManyMap)
+        POST("dataTypes/$secondModelFirstModelItemId/profile/getMany", manyMap)
 
         then:
         verifyResponse(BAD_REQUEST, response)
 
         when: 'correctly request against the second model'
-        POST("dataModels/$secondModelId/profile/getMany", getManyMap)
+        POST("dataModels/$secondModelId/profile/getMany", manyMap)
 
         then: 'the profiles are listed'
         verifyResponse(OK, response)
@@ -3131,7 +2827,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         responseBody().profilesProvided.size == 2
 
         when: 'incorrectly request against the third model'
-        POST("dataModels/$thirdModelId/profile/getMany", getManyMap)
+        POST("dataModels/$thirdModelId/profile/getMany", manyMap)
 
         then: 'the profiles are not listed'
         verifyResponse(OK, response)
@@ -3439,52 +3135,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "child profile functional class",
-  "domainType": "DataClass"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJson("child profile functional class", "DataClass")
 
         /**
          * 3. Use saveMany to update the dynamic profiles that have previously been saved
@@ -3632,52 +3283,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "profile functional class",
-  "domainType": "DataClass"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdateAgain("profile functional class", "DataClass")
 
         when:
         localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
@@ -3694,52 +3300,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "child profile functional class",
-  "domainType": "DataClass"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJsonPostUpdate("child profile functional class", "DataClass")
 
         when:
         localResponse = GET("dataClasses/$thirdModelDataClassId/profiles/used", Argument.listOf(Map))
@@ -3772,32 +3333,15 @@ class ProfileFunctionalSpec extends FunctionalSpec {
          */
         when: 'request made against a MultiFacetAwareItem that is not a model'
         loginAuthor()
-        Map getManyMap = [
-            'multiFacetAwareItems'   : [
-                [
-                    'multiFacetAwareItemDomainType': 'dataClass',
-                    'multiFacetAwareItemId'        : secondModelDataClassId
-                ],
-                [
-                    'multiFacetAwareItemDomainType': 'dataClass',
-                    'multiFacetAwareItemId'        : secondModelChildDataClassId
-                ]
-            ],
-            'profileProviderServices': [
-                [
-                    'name'     : "Dynamic%20Profile%20Model",
-                    'namespace': "uk.ac.ox.softeng.maurodatamapper.profile.provider"
-                ]
-            ]
-        ]
+        Map manyMap = getManyMap('dataClass', secondModelDataClassId, secondModelChildDataClassId)
 
-        POST("dataClasses/$secondModelDataClassId/profile/getMany", getManyMap)
+        POST("dataClasses/$secondModelDataClassId/profile/getMany", manyMap)
 
         then:
         verifyResponse(BAD_REQUEST, response)
 
         when: 'correctly request against the second model'
-        POST("dataModels/$secondModelId/profile/getMany", getManyMap)
+        POST("dataModels/$secondModelId/profile/getMany", manyMap)
 
         then: 'the profiles are listed'
         verifyResponse(OK, response)
@@ -3805,7 +3349,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         responseBody().profilesProvided.size == 2
 
         when: 'incorrectly request against the third model'
-        POST("dataModels/$thirdModelId/profile/getMany", getManyMap)
+        POST("dataModels/$thirdModelId/profile/getMany", manyMap)
 
         then: 'the profiles are not listed'
         verifyResponse(OK, response)
@@ -4091,52 +3635,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "PT02: second term in profile functional class",
-  "domainType": "Term"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJson("PT02: second term in profile functional class", "Term")
 
         /**
          * 3. Use saveMany to update the dynamic profiles that have previously been saved
@@ -4285,52 +3784,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "abc updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "def updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "updated again",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "PT01: first term in profile functional class",
-  "domainType": "Term"
-}'''
+        verifyJsonResponse OK, getDynamicProfileExpectedJsonPostUpdateAgain("PT01: first term in profile functional class", "Term")
 
         when:
         localResponse = GET("terms/$secondModelSecondTermId/profiles/used", Argument.listOf(Map))
@@ -4346,52 +3800,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
 
         then:
         verifyResponse(OK, jsonCapableResponse)
-        verifyJsonResponse OK, '''{
-  "sections": [
-    {
-      "name": "Profile Section Class",
-      "description": null,
-      "fields": [
-        {
-          "fieldName": "Dynamic Profile Elem (Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
-          "currentValue": "xyz updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Mandatory)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
-          "currentValue": "pqr updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 1,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        },
-        {
-          "fieldName": "Dynamic Profile Elem (Default Optional)",
-          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
-          "currentValue": "onm updated",
-          "dataType": "string",
-          "maxMultiplicity": 1,
-          "minMultiplicity": 0,
-          "uneditable": false,
-          "editableAfterFinalisation": false,
-          "derived": false
-        }
-      ]
-    }
-  ],
-  "id": "${json-unit.matches:id}",
-  "label": "PT02: second term in profile functional class",
-  "domainType": "Term"
-}'''
+        verifyJsonResponse OK, getOtherDynamicProfileExpectedJsonPostUpdate("PT02: second term in profile functional class", "Term")
 
         when:
         localResponse = GET("terms/$thirdModelFirstTermId/profiles/used", Argument.listOf(Map))
@@ -4424,32 +3833,15 @@ class ProfileFunctionalSpec extends FunctionalSpec {
          */
         when: 'request made against a MultiFacetAwareItem that is not a model'
         loginAuthor()
-        Map getManyMap = [
-            'multiFacetAwareItems'   : [
-                [
-                    'multiFacetAwareItemDomainType': 'term',
-                    'multiFacetAwareItemId'        : secondModelFirstTermId
-                ],
-                [
-                    'multiFacetAwareItemDomainType': 'term',
-                    'multiFacetAwareItemId'        : secondModelSecondTermId
-                ]
-            ],
-            'profileProviderServices': [
-                [
-                    'name'     : "Dynamic%20Profile%20Model",
-                    'namespace': "uk.ac.ox.softeng.maurodatamapper.profile.provider"
-                ]
-            ]
-        ]
+        Map manyMap = getManyMap('term', secondModelFirstTermId, secondModelSecondTermId)
 
-        POST("terms/$secondModelFirstTermId/profile/getMany", getManyMap)
+        POST("terms/$secondModelFirstTermId/profile/getMany", manyMap)
 
         then:
         verifyResponse(BAD_REQUEST, response)
 
         when: 'correctly request against the second model'
-        POST("terminologies/$secondModelId/profile/getMany", getManyMap)
+        POST("terminologies/$secondModelId/profile/getMany", manyMap)
 
         then: 'the profiles are listed'
         verifyResponse(OK, response)
@@ -4457,7 +3849,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         responseBody().profilesProvided.size == 2
 
         when: 'incorrectly request against the third model'
-        POST("terminologies/$thirdModelId/profile/getMany", getManyMap)
+        POST("terminologies/$thirdModelId/profile/getMany", manyMap)
 
         then: 'the profiles are not listed'
         verifyResponse(OK, response)
@@ -5097,4 +4489,173 @@ class ProfileFunctionalSpec extends FunctionalSpec {
   "domainType": "''' + "${domainType}" + '''"
 }'''
     }
+
+    String getDynamicProfileExpectedJsonPostUpdateAgain(String label, String domainType) {
+        return '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "abc updated again",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "def updated again",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "updated again",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "''' + "${label}" + '''",
+  "domainType": "''' + "${domainType}" + '''"
+}'''
+    }
+
+
+    String getOtherDynamicProfileExpectedJson(String label, String domainType) {
+        return '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "xyz",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "pqr",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "onm",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],  "id": "${json-unit.matches:id}",
+  "label": "''' + "${label}" + '''",
+  "domainType": "''' + "${domainType}" + '''"
+}'''
+    }
+
+    String getOtherDynamicProfileExpectedJsonPostUpdate(String label, String domainType) {
+        return '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "xyz updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "pqr updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "onm updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "''' + "${label}" + '''",
+  "domainType": "''' + "${domainType}" + '''"
+}'''
+    }
+
+    Map getManyMap(String modelItemDomainType, String firstModelElementId, String secondModelElementId) {
+        return [
+            'multiFacetAwareItems'   : [
+                [
+                    'multiFacetAwareItemDomainType': modelItemDomainType,
+                    'multiFacetAwareItemId'        : firstModelElementId
+                ],
+                [
+                    'multiFacetAwareItemDomainType': modelItemDomainType,
+                    'multiFacetAwareItemId'        : secondModelElementId
+                ]
+            ],
+            'profileProviderServices': [
+                [
+                    'name'     : "Dynamic%20Profile%20Model",
+                    'namespace': "uk.ac.ox.softeng.maurodatamapper.profile.provider"
+                ]
+            ]
+        ]
+    }
+
 }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/profile/ProfileFunctionalSpec.groovy
@@ -98,6 +98,11 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         verifyResponse(CREATED, response)
         String dataClassId = responseBody().id
 
+        // Add a Child Data Class
+        POST("dataModels/${id}/dataClasses/${dataClassId}/dataClasses", [label: 'child profile functional class'])
+        verifyResponse(CREATED, response)
+        String childDataClassId = responseBody().id
+
         // Add a Data Element
         POST("dataModels/${id}/dataClasses/${dataClassId}/dataElements", [label: 'first data element in profile functional class', dataType: [id:
                                                                                                                                                   firstDataTypeId]])
@@ -117,6 +122,7 @@ class ProfileFunctionalSpec extends FunctionalSpec {
             'firstDataTypeId': firstDataTypeId,
             'secondDataTypeId': secondDataTypeId,
             'dataClassId': dataClassId,
+            'childDataClassId': childDataClassId,
             'firstDataElementId': firstDataElementId,
             'secondDataElementId': secondDataElementId
         ]
@@ -1584,6 +1590,53 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         cleanupDataModelId(secondDynamicProfileModelId)
     }
 
+    void 'N12DMDC : test validating valid dynamic profiles using validateMany (as reader)'() {
+        given:
+        Map<String, String> secondIds = getSecondDataModelIds()
+        String secondModelId = secondIds['dataModelId']
+        String secondModelDataClassId = secondIds['dataClassId']
+        String secondModelChildDataClassId = secondIds['childDataClassId']
+        Map<String, String> thirdIds = getThirdDataModelIds()
+        String thirdModelId = thirdIds['dataModelId']
+        String dynamicProfileModelId = getDynamicProfileModelId()
+        String secondDynamicProfileModelId = getSecondDynamicProfileModelId()
+
+        when: 'use saveMany to save one profile on the first data class'
+        Map dynamicProfileMap = getDynamicProfileMapValid(
+            secondModelDataClassId,
+            'profile functional class',
+            secondModelChildDataClassId,
+            'child profile functional class',
+            'DataClass'
+        )
+
+        loginReader()
+        POST("dataModels/$secondModelId/profile/validateMany", dynamicProfileMap)
+
+        then: 'the profiles are validated successfully'
+        verifyResponseValidateManyValidProfile(response, secondModelDataClassId, secondModelChildDataClassId, 'DataClass')
+
+        when: 'used profiles are retrieved for the first data class'
+        HttpResponse<List<Map>> localResponse = GET("dataClasses/$secondModelDataClassId/profiles/used", Argument.listOf(Map))
+
+        then: 'there are not any'
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 0
+
+        when: 'used profiles are retrieved for the child data class'
+        localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
+
+        then: 'there are not any'
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 0
+
+        cleanup:
+        cleanupDataModelId(secondModelId)
+        cleanupDataModelId(thirdModelId)
+        cleanupDataModelId(dynamicProfileModelId)
+        cleanupDataModelId(secondDynamicProfileModelId)
+    }
+
     void 'N12T : test validating valid dynamic profiles for Terms on a Terminology using validateMany (as reader)'() {
         given:
         Map<String, String> secondIds = getSecondTerminologyIds()
@@ -1731,6 +1784,54 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         cleanupDataModelId(dynamicProfileModelId)
         cleanupDataModelId(secondDynamicProfileModelId)
     }
+
+    void 'N13DMDC : test validating invalid dynamic profiles using validateMany (as reader)'() {
+        given:
+        Map<String, String> secondIds = getSecondDataModelIds()
+        String secondModelId = secondIds['dataModelId']
+        String secondModelDataClassId = secondIds['dataClassId']
+        String secondModelChildDataClassId = secondIds['childDataClassId']
+        Map<String, String> thirdIds = getThirdDataModelIds()
+        String thirdModelId = thirdIds['dataModelId']
+        String dynamicProfileModelId = getDynamicProfileModelId()
+        String secondDynamicProfileModelId = getSecondDynamicProfileModelId()
+
+        when: 'use validateMany to save one profile on the first data element'
+        Map dynamicProfileMap = getDynamicProfileMapInvalid(
+            secondModelDataClassId,
+            'profile functional class',
+            secondModelChildDataClassId,
+            'child profile functional class',
+            'DataClass'
+        )
+
+        loginReader()
+        POST("dataModels/$secondModelId/profile/validateMany", dynamicProfileMap)
+
+        then: 'the first profile has an error'
+        verifyResponseValidateManyInvalidProfileError(response, secondModelDataClassId, secondModelChildDataClassId, 'DataClass')
+
+        when: 'used profiles are retrieved for the first data class'
+        HttpResponse<List<Map>> localResponse = GET("dataClasses/$secondModelDataClassId/profiles/used", Argument.listOf(Map))
+
+        then: 'there are not any'
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 0
+
+        when: 'used profiles are retrieved for the child data class'
+        localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
+
+        then: 'there are not any'
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 0
+
+        cleanup:
+        cleanupDataModelId(secondModelId)
+        cleanupDataModelId(thirdModelId)
+        cleanupDataModelId(dynamicProfileModelId)
+        cleanupDataModelId(secondDynamicProfileModelId)
+    }
+
 
     void 'N13T : test validating invalid dynamic profiles for Terms on a Terminology using validateMany (as reader)'() {
         given:
@@ -3244,6 +3345,771 @@ class ProfileFunctionalSpec extends FunctionalSpec {
         ]
 
         POST("dataTypes/$secondModelFirstModelItemId/profile/getMany", getManyMap)
+
+        then:
+        verifyResponse(BAD_REQUEST, response)
+
+        when: 'correctly request against the second model'
+        POST("dataModels/$secondModelId/profile/getMany", getManyMap)
+
+        then: 'the profiles are listed'
+        verifyResponse(OK, response)
+        responseBody().count == 2
+        responseBody().profilesProvided.size == 2
+
+        when: 'incorrectly request against the third model'
+        POST("dataModels/$thirdModelId/profile/getMany", getManyMap)
+
+        then: 'the profiles are not listed'
+        verifyResponse(OK, response)
+        responseBody().count == 0
+        !responseBody().profilesProvided
+
+
+        cleanup:
+        cleanupDataModelId(secondModelId)
+        cleanupDataModelId(thirdModelId)
+        cleanupDataModelId(dynamicProfileModelId)
+        cleanupDataModelId(secondDynamicProfileModelId)
+    }
+
+
+    /**
+     * 1. Save two profiles for one Data Class
+     * 2. Update one of the previously saved dynamic profiles, and in the same
+     * request save a dynamic profile against the second data class
+     * 3. Use saveMany to update the dynamic profiles that have previously been saved
+     * against the first and second data classes on the second data model, and also
+     * try to save a profile against the first data class of the third model, but using
+     * the endpoint of the second data model. The first two updates should work, and the
+     * third should fail silently.
+     * 4. Use getMany to retrieve the saved profiles
+     */
+    void 'N14DMDC : test saving and retrieving dynamic profiles using saveMany and getMany (as author and reader)'() {
+        given:
+        Map<String, String> secondIds = getSecondDataModelIds()
+        String secondModelId = secondIds['dataModelId']
+        String secondModelDataClassId = secondIds['dataClassId']
+        String secondModelChildDataClassId = secondIds['childDataClassId']
+        Map<String, String> thirdIds = getThirdDataModelIds()
+        String thirdModelId = thirdIds['dataModelId']
+        String thirdModelDataClassId = thirdIds['dataClassId']
+        String dynamicProfileModelId = getDynamicProfileModelId()
+        String secondDynamicProfileModelId = getSecondDynamicProfileModelId()
+
+
+        Map optionalFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: 'abc'
+        ]
+        Map mandatoryFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: 'def'
+        ]
+        Map defaultOptionalFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: ''
+        ]
+
+        Map optionalFieldMap2_1 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: '2_1 abc'
+        ]
+        Map mandatoryFieldMap2_1 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: '2_1 def'
+        ]
+        Map defaultOptionalFieldMap2_1 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: '2_1'
+        ]
+
+        Map dynamicProfileMap = [
+            profilesProvided: [
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap1,
+                                    mandatoryFieldMap1,
+                                    defaultOptionalFieldMap1
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : secondModelDataClassId,
+                        label     : 'profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Dynamic%20Profile%20Model'
+                    ]
+                ],
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap2_1,
+                                    mandatoryFieldMap2_1,
+                                    defaultOptionalFieldMap2_1
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : secondModelChildDataClassId,
+                        label     : 'child profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Second%20Dynamic%20Profile%20Model'
+                    ]
+                ]
+            ]
+        ]
+
+        /**
+         * 1. First save two dynamic profiles against the first data class
+         */
+
+        when: 'use saveMany on a MultiFacetAwareItem that is not a Model'
+        loginAuthor()
+        POST("dataClasses/$secondModelDataClassId/profile/saveMany", dynamicProfileMap)
+
+        then:
+        verifyResponse(BAD_REQUEST, response)
+
+        when: 'use saveMany to save one profile on the first data class'
+        POST("dataModels/$secondModelId/profile/saveMany", dynamicProfileMap)
+
+        then: 'the profile is saved for the first data class'
+        verifyResponse(OK, response)
+        responseBody().count == 2
+        responseBody().profilesProvided.size == 2
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == optionalFieldMap1.fieldName}.currentValue == optionalFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == mandatoryFieldMap1.fieldName}.currentValue == mandatoryFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap1.fieldName}.currentValue == defaultOptionalFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.id == secondModelDataClassId
+        responseBody().profilesProvided[0].profile.domainType == 'DataClass'
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == optionalFieldMap2_1.fieldName}.currentValue == optionalFieldMap2_1.currentValue
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == mandatoryFieldMap2_1.fieldName}.currentValue == mandatoryFieldMap2_1.currentValue
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap2_1.fieldName}.currentValue == defaultOptionalFieldMap2_1.currentValue
+        responseBody().profilesProvided[1].profile.id == secondModelChildDataClassId
+        responseBody().profilesProvided[1].profile.domainType == 'DataClass'
+
+        when: 'used profiles are retrieved for the first data class'
+        HttpResponse<List<Map>> localResponse = GET("dataClasses/$secondModelDataClassId/profiles/used", Argument.listOf(Map))
+
+        then: 'the saved profile is returned'
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 1
+        localResponse.body()[0].name == 'Dynamic%20Profile%20Model'
+        localResponse.body()[0].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when: 'used profiles are retrieved for the child data class'
+        HttpResponse<List<Map>> childLocalResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
+
+        then: 'the saved profile is returned'
+        verifyResponse(OK, childLocalResponse)
+        childLocalResponse.body().size() == 1
+        childLocalResponse.body()[0].name == 'Second%20Dynamic%20Profile%20Model'
+        childLocalResponse.body()[0].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when:
+        loginReader()
+        GET("dataClasses/$secondModelDataClassId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic%20Profile%20Model",
+            STRING_ARG)
+
+        then:
+        verifyResponse(OK, jsonCapableResponse)
+        verifyJsonResponse OK, '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "abc",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "def",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "profile functional class",
+  "domainType": "DataClass"
+}'''
+
+
+        /**
+         * 2. Use saveMany to update one of the previously saved dynamic profiles, and in the same
+         * request save a dynamic profile against the child data class
+         */
+        when:
+        loginAuthor()
+        optionalFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: 'abc updated'
+        ]
+        mandatoryFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: 'def updated'
+        ]
+        defaultOptionalFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: 'updated'
+        ]
+
+        Map optionalFieldMap2 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: 'xyz'
+        ]
+        Map mandatoryFieldMap2 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: 'pqr'
+        ]
+        Map defaultOptionalFieldMap2 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: 'onm'
+        ]
+
+        dynamicProfileMap = [
+            profilesProvided: [
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap1,
+                                    mandatoryFieldMap1,
+                                    defaultOptionalFieldMap1
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : secondModelDataClassId,
+                        label     : 'profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Dynamic%20Profile%20Model'
+                    ]
+                ],
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap2,
+                                    mandatoryFieldMap2,
+                                    defaultOptionalFieldMap2
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : secondModelChildDataClassId,
+                        label     : 'child profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Dynamic%20Profile%20Model'
+                    ]
+                ]
+            ]
+        ]
+
+        POST("dataModels/$secondModelId/profile/saveMany", dynamicProfileMap)
+
+        then:
+        verifyResponse(OK, response)
+        responseBody().count == 2
+        responseBody().profilesProvided.size == 2
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == optionalFieldMap1.fieldName}.currentValue == optionalFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == mandatoryFieldMap1.fieldName}.currentValue == mandatoryFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap1.fieldName}.currentValue == defaultOptionalFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.id == secondModelDataClassId
+        responseBody().profilesProvided[0].profile.domainType == 'DataClass'
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == optionalFieldMap2.fieldName}.currentValue == optionalFieldMap2.currentValue
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == mandatoryFieldMap2.fieldName}.currentValue == mandatoryFieldMap2.currentValue
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap2.fieldName}.currentValue == defaultOptionalFieldMap2.currentValue
+        responseBody().profilesProvided[1].profile.id == secondModelChildDataClassId
+        responseBody().profilesProvided[1].profile.domainType == 'DataClass'
+
+        when:
+        loginReader()
+        localResponse = GET("dataClasses/$secondModelDataClassId/profiles/used", Argument.listOf(Map))
+
+        then:
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 1
+        localResponse.body()[0].name == 'Dynamic%20Profile%20Model'
+        localResponse.body()[0].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when:
+        loginReader()
+        localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
+
+        then:
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 2
+        localResponse.body()[0].name == 'Dynamic%20Profile%20Model'
+        localResponse.body()[0].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+        localResponse.body()[1].name == 'Second%20Dynamic%20Profile%20Model'
+        localResponse.body()[1].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when:
+        GET("dataClasses/$secondModelDataClassId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic%20Profile%20Model",
+            STRING_ARG)
+
+        then:
+        verifyResponse(OK, jsonCapableResponse)
+        verifyJsonResponse OK, '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "abc updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "def updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "profile functional class",
+  "domainType": "DataClass"
+}'''
+
+        when:
+        localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
+
+        then:
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 2
+        localResponse.body()[0].name == 'Dynamic%20Profile%20Model'
+        localResponse.body()[0].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+        localResponse.body()[1].name == 'Second%20Dynamic%20Profile%20Model'
+        localResponse.body()[1].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when:
+        GET("dataClasses/$secondModelChildDataClassId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic%20Profile%20Model",
+            STRING_ARG)
+
+        then:
+        verifyResponse(OK, jsonCapableResponse)
+        verifyJsonResponse OK, '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "xyz",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "pqr",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "onm",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "child profile functional class",
+  "domainType": "DataClass"
+}'''
+
+        /**
+         * 3. Use saveMany to update the dynamic profiles that have previously been saved
+         * against the first and second data classes on the second data model, and also
+         * try to save a profile against the first data class of the third model, but using
+         * the endpoint of the second data model. The first two updates should work, and the
+         * third should fail silently.
+         */
+        when:
+        loginAuthor()
+        optionalFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: 'abc updated again'
+        ]
+        mandatoryFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: 'def updated again'
+        ]
+        defaultOptionalFieldMap1 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: 'updated again'
+        ]
+
+        optionalFieldMap2 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: 'xyz updated'
+        ]
+        mandatoryFieldMap2 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: 'pqr updated'
+        ]
+        defaultOptionalFieldMap2 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: 'onm updated'
+        ]
+
+        Map optionalFieldMap3 = [
+            fieldName   : 'Dynamic Profile Elem (Optional)',
+            currentValue: 'hij'
+        ]
+        Map mandatoryFieldMap3 = [
+            fieldName   : 'Dynamic Profile Elem (Mandatory)',
+            currentValue: 'klm'
+        ]
+        Map defaultOptionalFieldMap3 = [
+            fieldName   : 'Dynamic Profile Elem (Default Optional)',
+            currentValue: ''
+        ]
+
+        dynamicProfileMap = [
+            profilesProvided: [
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap1,
+                                    mandatoryFieldMap1,
+                                    defaultOptionalFieldMap1
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : secondModelDataClassId,
+                        label     : 'profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Dynamic%20Profile%20Model'
+                    ]
+                ],
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap2,
+                                    mandatoryFieldMap2,
+                                    defaultOptionalFieldMap2
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : secondModelChildDataClassId,
+                        label     : 'child profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Dynamic%20Profile%20Model'
+                    ]
+                ],
+                [
+                    profile: [
+                        sections  : [
+                            [
+                                fields: [
+                                    optionalFieldMap3,
+                                    mandatoryFieldMap3,
+                                    defaultOptionalFieldMap3
+                                ],
+                                name  : 'Profile Section Class'
+                            ]
+                        ],
+                        id        : thirdModelDataClassId,
+                        label     : 'profile functional class',
+                        domainType: 'DataClass'],
+                    profileProviderService: [
+                        namespace : 'uk.ac.ox.softeng.maurodatamapper.profile.provider',
+                        name: 'Second%20Dynamic%20Profile%20Model'
+                    ]
+                ]
+            ]
+        ]
+
+        POST("dataModels/$secondModelId/profile/saveMany", dynamicProfileMap)
+
+        then:
+        verifyResponse(OK, response)
+        responseBody().count == 2
+        responseBody().profilesProvided.size == 2
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == optionalFieldMap1.fieldName}.currentValue == optionalFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == mandatoryFieldMap1.fieldName}.currentValue == mandatoryFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap1.fieldName}.currentValue == defaultOptionalFieldMap1.currentValue
+        responseBody().profilesProvided[0].profile.id == secondModelDataClassId
+        responseBody().profilesProvided[0].profile.domainType == 'DataClass'
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == optionalFieldMap2.fieldName}.currentValue == optionalFieldMap2.currentValue
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == mandatoryFieldMap2.fieldName}.currentValue == mandatoryFieldMap2.currentValue
+        responseBody().profilesProvided[1].profile.sections.first().fields.find {it.fieldName == defaultOptionalFieldMap2.fieldName}.currentValue == defaultOptionalFieldMap2.currentValue
+        responseBody().profilesProvided[1].profile.id == secondModelChildDataClassId
+        responseBody().profilesProvided[1].profile.domainType == 'DataClass'
+
+        when:
+        loginReader()
+        localResponse = GET("dataClasses/$secondModelDataClassId/profiles/used", Argument.listOf(Map))
+
+        then:
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 1
+        localResponse.body()[0].name == 'Dynamic%20Profile%20Model'
+        localResponse.body()[0].namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when:
+        GET("dataClasses/$secondModelDataClassId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic%20Profile%20Model",
+            STRING_ARG)
+
+        then:
+        verifyResponse(OK, jsonCapableResponse)
+        verifyJsonResponse OK, '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "abc updated again",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "def updated again",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "updated again",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "profile functional class",
+  "domainType": "DataClass"
+}'''
+
+        when:
+        localResponse = GET("dataClasses/$secondModelChildDataClassId/profiles/used", Argument.listOf(Map))
+
+        then:
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 2
+        localResponse.body().first().name == 'Dynamic%20Profile%20Model'
+        localResponse.body().first().namespace == 'uk.ac.ox.softeng.maurodatamapper.profile.provider'
+
+        when:
+        GET("dataClasses/$secondModelChildDataClassId/profile/uk.ac.ox.softeng.maurodatamapper.profile.provider/Dynamic%20Profile%20Model",
+            STRING_ARG)
+
+        then:
+        verifyResponse(OK, jsonCapableResponse)
+        verifyJsonResponse OK, '''{
+  "sections": [
+    {
+      "name": "Profile Section Class",
+      "description": null,
+      "fields": [
+        {
+          "fieldName": "Dynamic Profile Elem (Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Optional)",
+          "currentValue": "xyz updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Mandatory)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Mandatory)",
+          "currentValue": "pqr updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 1,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        },
+        {
+          "fieldName": "Dynamic Profile Elem (Default Optional)",
+          "metadataPropertyName": "Profile Section Class/Dynamic Profile Elem (Default Optional)",
+          "currentValue": "onm updated",
+          "dataType": "string",
+          "maxMultiplicity": 1,
+          "minMultiplicity": 0,
+          "uneditable": false,
+          "editableAfterFinalisation": false,
+          "derived": false
+        }
+      ]
+    }
+  ],
+  "id": "${json-unit.matches:id}",
+  "label": "child profile functional class",
+  "domainType": "DataClass"
+}'''
+
+        when:
+        localResponse = GET("dataClasses/$thirdModelDataClassId/profiles/used", Argument.listOf(Map))
+
+        then:
+        verifyResponse(OK, localResponse)
+        localResponse.body().size() == 0
+
+        when: 'do the same POST again, but after finalising the data models'
+        finaliseDataModelId(secondModelId)
+        finaliseDataModelId(thirdModelId)
+        loginEditor()
+        POST("dataModels/$secondModelId/profile/saveMany", dynamicProfileMap)
+
+        then: 'no changes are made'
+        verifyResponse(OK, response)
+        responseBody().count == 0
+        responseBody().profilesProvided.size == 0
+
+        when: 'make the same POST again, but this time to thirdDataModel'
+        POST("dataModels/$thirdModelId/profile/saveMany", dynamicProfileMap)
+
+        then: 'the change to the first data element on the third model is made'
+        verifyResponse(OK, response)
+        responseBody().count == 1
+        responseBody().profilesProvided.size == 1
+
+        /**
+         * 4. Get many profiles for many elements
+         */
+        when: 'request made against a MultiFacetAwareItem that is not a model'
+        loginAuthor()
+        Map getManyMap = [
+            'multiFacetAwareItems'   : [
+                [
+                    'multiFacetAwareItemDomainType': 'dataClass',
+                    'multiFacetAwareItemId'        : secondModelDataClassId
+                ],
+                [
+                    'multiFacetAwareItemDomainType': 'dataClass',
+                    'multiFacetAwareItemId'        : secondModelChildDataClassId
+                ]
+            ],
+            'profileProviderServices': [
+                [
+                    'name'     : "Dynamic%20Profile%20Model",
+                    'namespace': "uk.ac.ox.softeng.maurodatamapper.profile.provider"
+                ]
+            ]
+        ]
+
+        POST("dataClasses/$secondModelDataClassId/profile/getMany", getManyMap)
 
         then:
         verifyResponse(BAD_REQUEST, response)


### PR DESCRIPTION
No functional changes.

Adds tests to verify that the existing endpoints for bulk editing of profiles on data elements work for:
- terms of a terminology
- data types of a data model
- data class and child data class of a data model
