### PR TITLE
gh-274 set referenceDataModel from URL

### DIFF
--- a/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueController.groovy
+++ b/mdm-plugin-referencedata/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueController.groovy
@@ -20,6 +20,7 @@ package uk.ac.ox.softeng.maurodatamapper.referencedata.item
 import uk.ac.ox.softeng.maurodatamapper.core.controller.EditLoggingController
 import uk.ac.ox.softeng.maurodatamapper.core.facet.EditTitle
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.search.SearchParams
+import uk.ac.ox.softeng.maurodatamapper.referencedata.ReferenceDataModelService
 
 import groovy.util.logging.Slf4j
 
@@ -27,6 +28,7 @@ import groovy.util.logging.Slf4j
 class ReferenceDataValueController extends EditLoggingController<ReferenceDataValue> {
     static responseFormats = ['json', 'xml']
 
+    ReferenceDataModelService referenceDataModelService
     ReferenceDataValueService referenceDataValueService
 
     ReferenceDataValueController() {
@@ -136,6 +138,15 @@ class ReferenceDataValueController extends EditLoggingController<ReferenceDataVa
             return rowify(referenceDataValues)
         }
         referenceDataValueService.findAllByReferenceDataModelId(params.referenceDataModelId, params)
+    }
+
+    @Override
+    protected ReferenceDataValue createResource(Map includesExcludes = Collections.EMPTY_MAP) {
+        ReferenceDataValue instance = super.createResource(includesExcludes)
+
+        instance.referenceDataModel = referenceDataModelService.get(params.referenceDataModelId)
+
+        instance
     }
 
     @Override

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
@@ -91,7 +91,6 @@ class ReferenceDataValueFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         [
             rowNumber           : 1,
             value               : 'Functional Test ReferenceDataValue',
-            referenceDataModel  : referenceDataModelId,
             referenceDataElement: referenceDataElementId,
         ]
     }
@@ -101,7 +100,6 @@ class ReferenceDataValueFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         [
             rowNumber           : -1,
             value               : null,
-            referenceDataModel  : null,
             referenceDataElement: null,
         ]
     }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataValueFunctionalSpec.groovy
@@ -113,7 +113,6 @@ class ReferenceDataValueFunctionalSpec extends UserAccessFunctionalSpec {
         [
             rowNumber           : 1,
             value               : 'Functional Test ReferenceDataValue',
-            referenceDataModel  : simpleReferenceDataModelId,
             referenceDataElement: referenceDataElementId
         ]
     }
@@ -123,7 +122,6 @@ class ReferenceDataValueFunctionalSpec extends UserAccessFunctionalSpec {
         [
             rowNumber           : -1,
             value               : null,
-            referenceDataModel  : null,
             referenceDataElement: null,
         ]
     }


### PR DESCRIPTION
Closes #274

- Update functional tests, removing `referenceDataModel` from the body of each test, which has the effect of creating a failing test for the scenario described in the ticket
- Override the `createResource`method so that we can set the referenceDataModel using the ID from the URL, rather than wrongly expecting it to be in the body of the request
