### PR TITLE
gh-257 handle unknown IDs

### DIFF
--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -234,9 +234,14 @@ abstract class ModelService<K extends Model>
 
     List<K> deleteAll(List<Serializable> idsToDelete, Boolean permanent) {
         if (!permanent) {
-            List<K> updated = idsToDelete.collect {
+            // Use findResults rather than collect so that we don't add
+            // null values, which would happen if an unknown ID has been provided,
+            // to the updated list
+            List<K> updated = idsToDelete.findResults {
                 K dm = get(it)
-                delete(dm, permanent, false)
+                if (dm) {
+                    delete(dm, permanent, false)
+                }
                 dm
             }
             return updated

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelFunctionalSpec.groovy
@@ -3909,6 +3909,10 @@ class DataModelFunctionalSpec extends ResourceFunctionalSpec<DataModel> implemen
             ])
         }
 
+        // To check that deleting an unknown ID does not cause an exception
+        // See https://github.com/MauroDataMapper/mdm-core/issues/257
+        idstoDelete << UUID.randomUUID().toString()
+
         when:
         DELETE('', [
             ids      : idstoDelete,

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelFunctionalSpec.groovy
@@ -2165,6 +2165,10 @@ class ReferenceDataModelFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
             ])
         }
 
+        // To check that deleting an unknown ID does not cause an exception
+        // See https://github.com/MauroDataMapper/mdm-core/issues/257
+        idstoDelete << UUID.randomUUID().toString()
+
         when:
         DELETE('', [
             ids      : idstoDelete,

--- a/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetFunctionalSpec.groovy
+++ b/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetFunctionalSpec.groovy
@@ -1160,6 +1160,10 @@ class CodeSetFunctionalSpec extends ResourceFunctionalSpec<CodeSet> implements X
             ])
         }
 
+        // To check that deleting an unknown ID does not cause an exception
+        // See https://github.com/MauroDataMapper/mdm-core/issues/257
+        idstoDelete << UUID.randomUUID().toString()
+
         when:
         DELETE('', [
             ids      : idstoDelete,

--- a/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyFunctionalSpec.groovy
+++ b/mdm-plugin-terminology/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyFunctionalSpec.groovy
@@ -1271,6 +1271,10 @@ class TerminologyFunctionalSpec extends ResourceFunctionalSpec<Terminology> impl
             ])
         }
 
+        // To check that deleting an unknown ID does not cause an exception
+        // See https://github.com/MauroDataMapper/mdm-core/issues/257
+        idstoDelete << UUID.randomUUID().toString()
+
         when:
         DELETE('', [
             ids      : idstoDelete,


### PR DESCRIPTION
Handle the possibility that an unknown ID may be passed to the deletion endpoint.

Closes #257 

(Test failure on the branch not related)