### PR TITLE
gh-256 use the securableResourceId

### DIFF
--- a/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/UserGroupInterceptor.groovy
+++ b/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/UserGroupInterceptor.groovy
@@ -40,7 +40,12 @@ class UserGroupInterceptor extends TieredAccessSecurableResourceInterceptor {
 
     @Override
     UUID getId() {
-        params.userGroupId ?: params.id ?: params.securableResourceId
+        params.userGroupId ?: params.id
+    }
+
+    @Override
+    UUID getSecuredId() {
+        getId() ?: params.securableResourceId
     }
 
     boolean before() {

--- a/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/UserGroupInterceptor.groovy
+++ b/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/UserGroupInterceptor.groovy
@@ -40,7 +40,7 @@ class UserGroupInterceptor extends TieredAccessSecurableResourceInterceptor {
 
     @Override
     UUID getId() {
-        params.userGroupId ?: params.id
+        params.userGroupId ?: params.id ?: params.securableResourceId
     }
 
     boolean before() {

--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessAndPermissionChangingFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessAndPermissionChangingFunctionalSpec.groovy
@@ -319,9 +319,7 @@ abstract class UserAccessAndPermissionChangingFunctionalSpec extends UserAccessF
 
         then:
         verifyResponse OK, response
-        responseBody().count == 1
-        responseBody().items[0].id == groupId
-        responseBody().items[0].name == "extraGroup"
+        responseBody().items.find{it.id == groupId && it.name == "extraGroup"}
 
         when: 'getting item as new reader'
         loginAuthenticated2()

--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessAndPermissionChangingFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessAndPermissionChangingFunctionalSpec.groovy
@@ -313,6 +313,16 @@ abstract class UserAccessAndPermissionChangingFunctionalSpec extends UserAccessF
         responseBody().userGroup.id == groupId
         responseBody().groupRole.id == groupRoleId
 
+        when: 'list user groups'
+        loginAdmin()
+        GET("$id/groupRoles/$groupRoleId/userGroups")
+
+        then:
+        verifyResponse OK, response
+        responseBody().count == 1
+        responseBody().items[0].id == groupId
+        responseBody().items[0].name == "extraGroup"
+
         when: 'getting item as new reader'
         loginAuthenticated2()
         GET(id)


### PR DESCRIPTION
Closes #256 

Fall back to using `securableResourceId` and add a test for the endpoint `GET /{securableResourceDomainType}/{securableResourceId}/groupRoles/{groupRoleId}/userGroups`