### PR TITLE
gh-253 fix the availableApplicationAccess endpoint and allow admin ac…

### DIFF
--- a/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/role/GroupRoleController.groovy
+++ b/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/role/GroupRoleController.groovy
@@ -40,7 +40,7 @@ class GroupRoleController extends EditLoggingController<GroupRole> {
 
     def listApplicationAccess() {
         List<GroupRole> applicationGroupRoles = (currentUserSecurityPolicyManager as GroupBasedUserSecurityPolicyManager)
-            .applicationPermittedRoles
+            .userPolicy.applicationPermittedRoles
             .toList()
         respond applicationGroupRoles, view: 'index', model: [userSecurityPolicyManager: currentUserSecurityPolicyManager]
     }

--- a/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/role/GroupRoleInterceptor.groovy
+++ b/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/role/GroupRoleInterceptor.groovy
@@ -60,6 +60,6 @@ class GroupRoleInterceptor extends SecurableResourceInterceptor {
             return currentUserSecurityPolicyManager.isApplicationAdministrator() ?: forbiddenDueToNotApplicationAdministrator()
         }
 
-        checkActionAuthorisationOnSecuredResource(GroupRole, getId())
+        checkActionAuthorisationOnSecuredResource(GroupRole, getId(), currentUserSecurityPolicyManager.isApplicationAdministrator())
     }
 }

--- a/mdm-security/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/security/policy/GroupBasedUserSecurityPolicyManager.groovy
+++ b/mdm-security/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/security/policy/GroupBasedUserSecurityPolicyManager.groovy
@@ -360,6 +360,10 @@ class GroupBasedUserSecurityPolicyManager implements UserSecurityPolicyManager {
             // Anyone who's logged in can index or read an authority
             return isAuthenticated()
         }
+        if (Utils.parentClassIsAssignableFromChild(GroupRole, securableResourceClass)) {
+            // Group admin can index and get GroupRoles
+            return hasApplicationLevelRole(GROUP_ADMIN_ROLE_NAME)
+        }
         hasAnyAccessToSecuredResource(securableResourceClass, id)
     }
 


### PR DESCRIPTION
…cess to groupRole endpoint

Closes #253 

- Fix the method `listApplicationAccess`
- Change the GroupRoleInterceptor and GroupBasedSecurityPolicyManager to allow read access to groupRoles for administrator

Test failures on the branch build not related.