### PR TITLE
Allow one ReferenceDataValue per ReferenceDataModel row and column

### DIFF
--- a/mdm-plugin-referencedata/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValue.groovy
+++ b/mdm-plugin-referencedata/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValue.groovy
@@ -44,7 +44,8 @@ class ReferenceDataValue implements MdmDomain, Diffable<ReferenceDataValue> {
     static belongsTo = [ReferenceDataModel, ReferenceDataElement]
 
     static constraints = {
-        value blank: true, nullable: true, unique: ['rowNumber', 'referenceDataElement']
+        value blank: true, nullable: true
+        rowNumber unique: 'referenceDataElement'
     }
 
     static mapping = {

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
@@ -158,6 +158,12 @@ class ReferenceDataValueFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
             referenceDataElement: referenceDataElementId,
         ]
 
+        Map value3 = [
+            rowNumber           : 2,
+            value               : 'Second Value',
+            referenceDataElement: referenceDataElementId,
+        ]
+
         when: 'The save action is executed with valid data'
         POST(getSavePath(), value1, MAP_ARG, true)
 
@@ -184,8 +190,17 @@ class ReferenceDataValueFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         then: 'We still the same one reference data value'
         verifyR3IndexResponse(id)
 
+        when: 'The save action is executed with the same row number and data element'
+        POST(getSavePath(), value3, MAP_ARG, true)
+
+        then: 'The response is CREATED'
+        response.status == HttpStatus.CREATED
+        String id3 = response.body().id
+
         cleanup:
         DELETE(getDeleteEndpoint(id))
+        assert response.status() == HttpStatus.NO_CONTENT
+        DELETE(getDeleteEndpoint(id3))
         assert response.status() == HttpStatus.NO_CONTENT
     }
 }

--- a/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-plugin-referencedata/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/referencedata/item/ReferenceDataValueFunctionalSpec.groovy
@@ -27,6 +27,7 @@ import grails.gorm.transactions.Transactional
 import grails.testing.mixin.integration.Integration
 import grails.testing.spock.RunOnce
 import groovy.util.logging.Slf4j
+import io.micronaut.http.HttpStatus
 import spock.lang.Shared
 
 import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.FUNCTIONAL_TEST
@@ -142,5 +143,49 @@ class ReferenceDataValueFunctionalSpec extends ResourceFunctionalSpec<ReferenceD
         "maxMultiplicity": 1
     }
 }'''
+    }
+
+    void 'R3A: Test the row and column number constraint'() {
+        Map value1 = [
+            rowNumber           : 1,
+            value               : 'First Value',
+            referenceDataElement: referenceDataElementId,
+        ]
+
+        Map value2 = [
+            rowNumber           : 1,
+            value               : 'Second Value',
+            referenceDataElement: referenceDataElementId,
+        ]
+
+        when: 'The save action is executed with valid data'
+        POST(getSavePath(), value1, MAP_ARG, true)
+
+        then: 'The response is correct'
+        response.status == HttpStatus.CREATED
+        response.body().id
+
+        when: 'List is called'
+        String id = response.body().id
+        GET('')
+
+        then: 'We now list one value'
+        verifyR3IndexResponse(id)
+
+        when: 'The save action is executed with the same row number and data element'
+        POST(getSavePath(), value2, MAP_ARG, true)
+
+        then: 'The response is unprocessable'
+        response.status == HttpStatus.UNPROCESSABLE_ENTITY
+
+        when: 'List is called'
+        GET('')
+
+        then: 'We still the same one reference data value'
+        verifyR3IndexResponse(id)
+
+        cleanup:
+        DELETE(getDeleteEndpoint(id))
+        assert response.status() == HttpStatus.NO_CONTENT
     }
 }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataValueFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/referencedata/ReferenceDataValueFunctionalSpec.groovy
@@ -52,6 +52,9 @@ import java.util.regex.Pattern
 class ReferenceDataValueFunctionalSpec extends UserAccessFunctionalSpec {
 
     @Shared
+    int rowNumber = 100
+
+    @Shared
     Path resourcesPath
 
     @RunOnce
@@ -110,8 +113,10 @@ class ReferenceDataValueFunctionalSpec extends UserAccessFunctionalSpec {
 
     @Override
     Map getValidJson() {
+        // increment the rowNumber so that we don't try to break the unique constraint
+        rowNumber = rowNumber + 1
         [
-            rowNumber           : 1,
+            rowNumber           : rowNumber,
             value               : 'Functional Test ReferenceDataValue',
             referenceDataElement: referenceDataElementId
         ]


### PR DESCRIPTION
Closes #334  

Fix the constraint on ReferenceDataValue.

The existing constraint `value blank: true, nullable: true, unique: ['rowNumber', 'referenceDataElement']` meant 'value must be unique within rowNumber and referenceDataElement'

This has been changed to `rowNumber unique: 'referenceDataElement'`.

Modify and add tests accordingly.