### PR TITLE
Feature/gh 254 Fix creation of SecurableResourceGroupRole on UserGroup endpoint

### DIFF
--- a/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleController.groovy
+++ b/mdm-security/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleController.groovy
@@ -17,8 +17,8 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.security.role
 
-
 import uk.ac.ox.softeng.maurodatamapper.core.controller.EditLoggingController
+import uk.ac.ox.softeng.maurodatamapper.security.SecurableResource
 import uk.ac.ox.softeng.maurodatamapper.security.UserGroupService
 import uk.ac.ox.softeng.maurodatamapper.security.policy.GroupBasedSecurityPolicyManagerService
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
@@ -65,10 +65,18 @@ class SecurableResourceGroupRoleController extends EditLoggingController<Securab
             securableResourceGroupRole.groupRole = groupRoleService.get(params.groupRoleId)
         }
         if (params.containsKey('securableResourceId')) {
-            securableResourceGroupRole.securableResource = securableResourceGroupRoleService.findSecurableResource(
-                params.securableResourceClass as Class, params.securableResourceId)
+            // If the endpoint is POST /userGroups/{userGroupId}/securableResourceGroupRoles
+            // with a body containing the securableResourceDomainType, securableResourceId and groupRole,
+            // then at this point params.securableResourceClass will be set to 'UserGroup'. So, silence the
+            // exception that would otherwise be raised, and drop into the block following this one.
+            SecurableResource r = securableResourceGroupRoleService.findSecurableResource(
+                params.securableResourceClass as Class, params.securableResourceId, true)
+            if (r) {
+                securableResourceGroupRole.securableResource = r
+            }
         }
-        // If the securable resource hasnt been loaded then try and load from whats saved in the domain
+
+        // If the securable resource hasn't been loaded then try and load from what's saved in the domain
         if (!securableResourceGroupRole.securableResource &&
             securableResourceGroupRole.securableResourceId &&
             securableResourceGroupRole.securableResourceDomainType) {

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
@@ -153,17 +153,25 @@ class SecurableResourceGroupRoleService implements MdmDomainService<SecurableRes
                                                                      groupRoleId).list(pagination)
     }
 
-    def <R extends SecurableResource> R findSecurableResource(Class<R> clazz, UUID id) {
+    // There are valid situations in which there may be no securable resource service found, so let the caller
+    // of this method decide whether an exception should be thrown, or a null value returned
+    def <R extends SecurableResource> R findSecurableResource(Class<R> clazz, UUID id, boolean silenceException = false) {
         SecurableResourceService service = securableResourceServices.find { it.handles(clazz) }
-        if (!service) throw new ApiBadRequestException('SRGRS01',
-                                                       "SecurableResourceGroupRole retrieval for securable resource [${clazz.simpleName}] with no " +
-                                                       'supporting service')
+        if (!service) {
+            if (silenceException) {
+                return null
+            } else {
+                throw new ApiBadRequestException('SRGRS01',
+                                             "SecurableResourceGroupRole retrieval for securable resource [${clazz.simpleName}] with no " +
+                                             'supporting service')
+            }
+        }
         service.get(id)
     }
 
     def <R extends SecurableResource> R findSecurableResource(String domainType, UUID id) {
         SecurableResourceService service = securableResourceServices.find { it.handles(domainType) }
-        if (!service) throw new ApiBadRequestException('SRGRS01',
+        if (!service) throw new ApiBadRequestException('SRGRS02',
                                                        "SecurableResourceGroupRole retrieval for securable resource [${domainType}] with no " +
                                                        'supporting service')
         service.get(id)

--- a/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleControllerSpec.groovy
+++ b/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleControllerSpec.groovy
@@ -98,7 +98,7 @@ class SecurableResourceGroupRoleControllerSpec extends ResourceControllerSpec<Se
                 }
                 []
             }
-            findSecurableResource(_, _) >> {clazz, id ->
+            findSecurableResource(_, _, _) >> {clazz, id, silenceException ->
                 id == folder.id ? folder : null
             }
         }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/security/role/SecurableResourceGroupRoleFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/security/role/SecurableResourceGroupRoleFunctionalSpec.groovy
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.testing.functional.security.role
+
+import uk.ac.ox.softeng.maurodatamapper.core.container.Folder
+import uk.ac.ox.softeng.maurodatamapper.security.CatalogueUser
+import uk.ac.ox.softeng.maurodatamapper.security.UserGroup
+import uk.ac.ox.softeng.maurodatamapper.security.role.GroupRole
+import uk.ac.ox.softeng.maurodatamapper.security.role.GroupRoleService
+import uk.ac.ox.softeng.maurodatamapper.testing.functional.UserAccessFunctionalSpec
+import uk.ac.ox.softeng.maurodatamapper.testing.functional.expectation.Expectations
+
+import grails.gorm.transactions.Transactional
+import grails.testing.mixin.integration.Integration
+import grails.testing.spock.RunOnce
+import groovy.util.logging.Slf4j
+import io.micronaut.http.HttpResponse
+import spock.lang.Shared
+
+import java.util.regex.Pattern
+
+import static uk.ac.ox.softeng.maurodatamapper.util.GormUtils.checkAndSave
+
+import static io.micronaut.http.HttpStatus.OK
+
+/**
+ * <pre>
+ * Controller: securableResourceGroupRole
+ *  |  POST    | /api/userGroups/{id}/securableResourceGroupRoles         | Action: save
+ *  |  GET     | /api/userGroups/{id}/securableResourceGroupRoles         | Action: index
+ *  |  GET     | /api/userGroups/{id}/securableResourceGroupRoles/{id}    | Action: show
+ *  |  DELETE  | /api/userGroups/{id}/securableResourceGroupRoles/{id}    | Action: delete
+ *  |  PUT     | /api/userGroups/{id}/securableResourceGroupRoles/{id}    | Action: update
+ *  </pre>
+ * @see uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRoleController
+ */
+@Integration
+@Slf4j
+class SecurableResourceGroupRoleFunctionalSpec extends UserAccessFunctionalSpec {
+
+    GroupRoleService groupRoleService
+
+    @Shared
+    String groupAdminId
+
+    @Shared
+    String folderId
+
+    @Shared
+    authorGroupRoleId
+
+    @Shared
+    reviewerGroupRoleId
+
+    @Shared
+    applicationAdminGroupRoleId
+
+    @RunOnce
+    @Transactional
+    def setup() {
+        log.debug('Check and setup test data')
+
+        // For now to allow existing permissions tests the editor user needs to be group admin role level
+        // This will give editor the "editing" rights to usergroups
+        UserGroup groupAdmin = new UserGroup(
+            createdBy: userEmailAddresses.functionalTest,
+            name: 'groupAdmins',
+            applicationGroupRole: groupRoleService.getFromCache(GroupRole.GROUP_ADMIN_ROLE_NAME).groupRole)
+            .addToGroupMembers(CatalogueUser.findByEmailAddress(userEmailAddresses.containerAdmin))
+            .addToGroupMembers(CatalogueUser.findByEmailAddress(userEmailAddresses.editor))
+        checkAndSave(messageSource, groupAdmin)
+
+        groupAdminId = groupAdmin.id
+
+        // For now to allow existing permissions tests the reader user needs to be container group admin role level
+        // This will give editor the "reader" rights to usergroups
+        UserGroup containerGroupAdmin = new UserGroup(
+            createdBy: userEmailAddresses.functionalTest,
+            name: 'containerGroupAdmins',
+            applicationGroupRole: groupRoleService.getFromCache(GroupRole.CONTAINER_GROUP_ADMIN_ROLE_NAME).groupRole)
+            .addToGroupMembers(CatalogueUser.findByEmailAddress(userEmailAddresses.reader))
+            .addToGroupMembers(CatalogueUser.findByEmailAddress(userEmailAddresses.reviewer))
+            .addToGroupMembers(CatalogueUser.findByEmailAddress(userEmailAddresses.author))
+        checkAndSave(messageSource, containerGroupAdmin)
+
+        Folder folder = new Folder(label: 'Functional Test Folder', createdBy: userEmailAddresses.functionalTest);
+        checkAndSave(messageSource, folder)
+        folderId = folder.id
+
+        authorGroupRoleId = groupRoleService.getFromCache(GroupRole.AUTHOR_ROLE_NAME).groupRole.id
+        reviewerGroupRoleId = groupRoleService.getFromCache(GroupRole.REVIEWER_ROLE_NAME).groupRole.id
+        applicationAdminGroupRoleId = groupRoleService.getFromCache(GroupRole.APPLICATION_ADMIN_ROLE_NAME).groupRole.id
+    }
+
+    @Transactional
+    def cleanupSpec() {
+        // Remove all installed required domains here
+        UserGroup.findByName('groupAdmins').delete(flush: true)
+        UserGroup.findByName('containerGroupAdmins').delete(flush: true)
+        Folder.findById(folderId).delete(flush: true)
+    }
+
+    @Transactional
+    String getUserGroupId(String userGroupName) {
+        UserGroup userGroup = UserGroup.findByName(userGroupName)
+        userGroup.id
+    }
+
+    @Override
+    Expectations getExpectations() {
+        Expectations.builder()
+            .withDefaultExpectations()
+            .withoutEdits() //TODO Fix the edits endpoint
+            .withInheritedAccessPermissions()
+            .whereTestingUnsecuredResource()
+            .whereEditorsCannotChangePermissions()
+            .whereReaders {
+                canCreate()
+            }
+            .whereReviewers {
+                canCreate()
+            }
+            .whereAuthors {
+                canCreate()
+                canSee()
+                canIndex()
+                cannotEditDescription()
+                cannotUpdate()
+            }
+            .whereContainerAdminsCanAction('comment', 'delete', 'editDescription', 'save', 'show', 'softDelete', 'update')
+            .whereEditorsCanAction('show')
+    }
+
+    @Override
+    void verify03ValidResponseBody(HttpResponse<Map> response) {
+        assert response.body().id
+    }
+
+    @Override
+    void verifyValidDataUpdateResponse(HttpResponse<Map> response, String id, Map update) {
+        verifyResponse OK, response
+    }
+
+    @Override
+    String getResourcePath() {
+        "userGroups/${groupAdminId}/securableResourceGroupRoles"
+    }
+
+    // Note, this edits path does not work
+    @Override
+    String getEditsPath() {
+        "folders/${folderId}"
+    }
+
+    @Override
+    List<String> getPermanentGroupNames() {
+        super.permanentGroupNames + ['groupAdmins', 'containerGroupAdmins']
+    }
+
+    Pattern getExpectedUpdateEditRegex() {
+        ~/\[\w+( \w+)*:.+?] changed properties \[path, name]/
+    }
+
+    @Override
+    Map getValidJson() {
+        [
+            "securableResourceDomainType": "Folder",
+            "securableResourceId": folderId,
+            "groupRole": [
+                "id": authorGroupRoleId
+            ]
+        ]
+    }
+
+    // This is invalid because it is not allowed to set an application level group role
+    @Override
+    Map getInvalidJson() {
+        [
+            "securableResourceDomainType": "Folder",
+            "securableResourceId": folderId,
+            "groupRole": [
+                "id": applicationAdminGroupRoleId
+            ]
+        ]
+    }
+
+    Map getValidNonDescriptionUpdateJson() {
+        [
+            "securableResourceDomainType": "Folder",
+            "securableResourceId": folderId,
+            "groupRole": [
+                "id": reviewerGroupRoleId
+            ]
+        ]
+    }
+
+    @Override
+    String getEditorIndexJson() {
+        '''{
+  "count": 0,
+  "items": []
+}'''
+    }
+
+    @Override
+    String getReaderIndexJson() {
+        '''{
+  "count": 0,
+  "items": []
+}'''
+    }
+
+    @Override
+    String getShowJson() {
+        '''{
+   "availableActions": ["show"],
+   "createdBy": "creator@test.com",
+   "groupRole": {
+       "displayName": "Author",
+       "id": "${json-unit.matches:id}",
+       "name": "author"
+   },
+   "id": "${json-unit.matches:id}",
+   "securableResourceDomainType": "Folder",
+   "securableResourceId": "${json-unit.matches:id}",
+   "userGroup": {
+       "id": "${json-unit.matches:id}",
+       "name": "groupAdmins"
+   }
+ }'''
+    }
+}

--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/expectation/Expectations.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/expectation/Expectations.groovy
@@ -39,6 +39,7 @@ class Expectations {
     private boolean availableActionsProvided
     private boolean editorCanChangePermissions
     private boolean isSecuredResource
+    private boolean hasEditsEndpoint
 
     private Expectations() {
 
@@ -66,6 +67,10 @@ class Expectations {
 
     boolean getMergingIsAvailable() {
         mergingIsAvailable
+    }
+
+    boolean getHasEditsEndpoint() {
+        hasEditsEndpoint
     }
 
     List<String> getContainerAdminAvailableActions() {
@@ -232,6 +237,16 @@ class Expectations {
         this
     }
 
+    Expectations withEdits() {
+        this.hasEditsEndpoint = true
+        this
+    }
+
+    Expectations withoutEdits() {
+        this.hasEditsEndpoint = false
+        this
+    }
+
     Expectations whereAdmins(@DelegatesTo(UserExpectation) Closure closure) {
         closure.setDelegate(admin)
         closure.call()
@@ -335,6 +350,7 @@ class Expectations {
         withMergingAvailable()
         whereTestingSecuredResource()
         whereEditorsCanChangePermissions()
+        withEdits()
         admin.canUpdate().canDelete().canCreate().canSee().canIndex().withDefaultActions()
         containerAdmin.canUpdate().canDelete().canCreate().canSee().canIndex().withDefaultActions()
         editor.canUpdate().canDelete().canCreate().canSee().canIndex().withDefaultActions()


### PR DESCRIPTION
Closes #254 

- Make a small fix to the SecurableResourceGroupRoleController and SecurableResourceGroupRoleService to allow the findSecurableResource method to return a null value rather than throw an exception. This fixes the original bug.
- As required by the ticket, also add E2E tests for SecurableResourceGroupRole. As I am not certain what the requirements are, the test expectations are set up to pass given the current implementation in code.
- One problem I did notice is that there seems to be no `/edits`endpoint for SecurableResourceGroupRole. To ensure that the test suite passes I've added a test expectation `hasEditsEndpoint` and used this to skip testing of edits for SecurableResourceGroupRole. If it is required to add an endpoint for retrieving edits then this could be raised as a separate ticket, and the change to test expectations could then be reverted.