### PR TITLE
Feature/gh 330 Delete version links when deleting a versioned folder

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -393,6 +393,13 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
     void delete(VersionedFolder folder, boolean permanent, boolean flush = true) {
         folderService.delete(folder, permanent, flush)
+
+        if (permanent) {
+            // delete version links which point to this VF
+            versionLinkService.findAllByTargetModelId(folder.id).each{
+                versionLinkService.delete(it, flush)
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes #330 

- add a failing test scenario to replicate the issue described in the ticket, i.e.
  - create and finalise a VF at 1.0.0
  - create and finalise a new version of the VF at 1.1.0
  - create a new version of the VF
  - delete version 1.0.0
  - see that when selecting the main branch in the UI, the endpoint `${main version Id}/simpleModelVersionTree?branchesOnly=undefined` responds with a 500 internal server error

- fix the failing scenario by deleting version links which point to the deleted VF