### PR TITLE
gh-347 add a database constraint to prevent duplicate SecurableResourceGroupRole

### DIFF
--- a/mdm-security/grails-app/conf/db/migration/security/V5_2_0__add_securableresourcegrouprole_constraint.sql
+++ b/mdm-security/grails-app/conf/db/migration/security/V5_2_0__add_securableresourcegrouprole_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS  security.securable_resource_group_role
+    ADD CONSTRAINT UKfa251ce1f3b24cad8cccd15394d1 UNIQUE (securable_resource_id, user_group_id);


### PR DESCRIPTION
Closes #347 

To reproduce the problem described in the ticket I placed a debug breakpoint in the backend code; this gave me plenty of time to press the green tick and verify that indeed multiple request to create a SecurableResourceGroupRole do succeed.

After adding the database constraint I did the same again, and received a response of
```{"status":500,"reason":"Internal Server Error","errorCode":"UEX--","message":"ERROR: duplicate key value violates unique constraint \"ukfa251ce1f3b24cad8cccd15394d1\"\n  Detail: Key (securable_resource_id, user_group_id)=(77c43d51-9060-44e9-a987-6a8b2bdfaeb2, 0721a5da-812b-4cf6-828d-3078619ce667) already exists.","path":"/api/Folder/77c43d51-9060-44e9-a987-6a8b2bdfaeb2/groupRoles/83ab3977-841e-4307-b4d3-b16fe0a51511/userGroups/0721a5da-812b-4cf6-828d-3078619ce667","environment":"DEVELOPMENT","version":"5.2.0-SNAPSHOT","exception":{"type":"PSQLException","message":"ERROR: duplicate key value violates unique constraint \"ukfa251ce1f3b24cad8cccd15394d1\" >>   Detail: Key (securable_resource_id, user_group_id)=(77c43d51-9060-44e9-a987-6a8b2bdfaeb2, 0721a5da-812b-4cf6-828d-3078619ce667) already exists.","stacktrace":["org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)","org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)","org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:559)","org.postgresql.jdbc.PgStatement.internalExecuteBatch(PgStatement.java:887)","org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:910)","org.postgresql.jdbc.PgPreparedStatement.executeBatch(PgPreparedStatement.java:1649)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","org.hibernate.engine.jdbc.batch.internal.BatchingBatch.performExecution(BatchingBatch.java:125)","org.hibernate.engine.jdbc.batch.internal.BatchingBatch.doExecuteBatch(BatchingBatch.java:110)","org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl.execute(AbstractBatchImpl.java:153)","org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.executeBatch(JdbcCoordinatorImpl.java:198)","org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:633)","org.hibernate.engine.spi.ActionQueue.lambda$executeActions$1(ActionQueue.java:478)","java.util.LinkedHashMap.forEach(LinkedHashMap.java:721)","org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:475)","org.hibernate.event.internal.AbstractFlushingEventListener.performExecutions(AbstractFlushingEventListener.java:344)","org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:40)","org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)","org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1407)","org.hibernate.internal.SessionImpl.flush(SessionImpl.java:1394)","org.grails.orm.hibernate.AbstractHibernateGormInstanceApi.flushSession(AbstractHibernateGormInstanceApi.groovy:285)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","org.grails.orm.hibernate.AbstractHibernateGormInstanceApi$_performSave_closure3.doCall(AbstractHibernateGormInstanceApi.groovy:250)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","org.grails.orm.hibernate.GrailsHibernateTemplate.doExecute(GrailsHibernateTemplate.java:297)","org.grails.orm.hibernate.GrailsHibernateTemplate.execute(GrailsHibernateTemplate.java:241)","org.grails.orm.hibernate.GrailsHibernateTemplate.execute(GrailsHibernateTemplate.java:120)","org.grails.orm.hibernate.AbstractHibernateGormInstanceApi.performSave(AbstractHibernateGormInstanceApi.groovy:247)","org.grails.orm.hibernate.AbstractHibernateGormInstanceApi.save(AbstractHibernateGormInstanceApi.groovy:164)","org.grails.datastore.gorm.GormEntity$Trait$Helper.save(GormEntity.groovy:153)","uk.ac.ox.softeng.maurodatamapper.core.controller.EditLoggingController.saveResource(EditLoggingController.groovy:161)","jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","uk.ac.ox.softeng.maurodatamapper.security.role.SecurableResourceGroupRoleController.saveResource(SecurableResourceGroupRoleController.groovy:88)","jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","uk.ac.ox.softeng.maurodatamapper.core.controller.EditLoggingController.$tt__editLoggingController_save(EditLoggingController.groovy:86)","jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","grails.gorm.transactions.GrailsTransactionTemplate$2.doInTransaction(GrailsTransactionTemplate.groovy:94)","org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140)","grails.gorm.transactions.GrailsTransactionTemplate.execute(GrailsTransactionTemplate.groovy:91)","jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)","jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","org.grails.core.DefaultGrailsControllerClass$ReflectionInvoker.invoke(DefaultGrailsControllerClass.java:211)","org.grails.core.DefaultGrailsControllerClass.invoke(DefaultGrailsControllerClass.java:188)","org.grails.web.mapping.mvc.UrlMappingsInfoHandlerAdapter.handle(UrlMappingsInfoHandlerAdapter.groovy:90)","org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067)","org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)","org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)","org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909)","org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)","org.grails.web.servlet.mvc.GrailsWebRequestFilter.doFilterInternal(GrailsWebRequestFilter.java:77)","org.grails.web.filters.HiddenHttpMethodFilter.doFilterInternal(HiddenHttpMethodFilter.java:67)","java.lang.Thread.run(Thread.java:833)"]}}```

which is what I expected and seems reasonable.