### PR TITLE
gh-288 Update tree endpoints to filter superseded Versioned Folders

### DIFF
--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemController.groovy
@@ -62,11 +62,11 @@ class TreeItemController extends RestfulController<TreeItem> implements MdmContr
             Container container = treeItemService.findTreeCapableContainer(params.containerClass, params.containerId)
             if (!container) return notFound(Container, params.containerId)
             respond treeItemList: treeItemService.buildDirectChildrenContainerTree(params.containerClass,
-                                                                          container,
-                                                                          currentUserSecurityPolicyManager,
-                                                                          shouldIncludeDocumentSupersededItems(),
-                                                                          shouldIncludeModelSupersededItems(),
-                                                                          shouldIncludeDeletedItems())
+                                                                                   container,
+                                                                                   currentUserSecurityPolicyManager,
+                                                                                   shouldIncludeDocumentSupersededItems(),
+                                                                                   shouldIncludeModelSupersededItems(),
+                                                                                   shouldIncludeDeletedItems())
             return
         }
         // If id provided then build the tree for that item, as we build the containers on the default we will assume this a catalogue item
@@ -86,10 +86,18 @@ class TreeItemController extends RestfulController<TreeItem> implements MdmContr
 
         // Only return the containers
         if (params.boolean(CONTAINERS_ONLY_PARAM) || params.boolean(FOLDERS_ONLY_PARAM)) {
-            if(params.boolean(MODEL_CREATEABLE_ONLY_PARAM)){
-                return respond(treeItemService.buildModelCreatableContainerOnlyTree(params.containerClass, currentUserSecurityPolicyManager))
+            if (params.boolean(MODEL_CREATEABLE_ONLY_PARAM)) {
+                return respond(treeItemService.buildModelCreatableContainerOnlyTree(params.containerClass,
+                                                                                    currentUserSecurityPolicyManager,
+                                                                                    shouldIncludeDocumentSupersededItems(),
+                                                                                    shouldIncludeModelSupersededItems(),
+                                                                                    shouldIncludeDeletedItems()))
             }
-            return respond(treeItemService.buildContainerOnlyTree(params.containerClass, currentUserSecurityPolicyManager))
+            return respond(treeItemService.buildContainerOnlyTree(params.containerClass,
+                                                                  currentUserSecurityPolicyManager,
+                                                                  shouldIncludeDocumentSupersededItems(),
+                                                                  shouldIncludeModelSupersededItems(),
+                                                                  shouldIncludeDeletedItems()))
         }
 
         // Default behaviour is to return the root tree of containers
@@ -102,7 +110,10 @@ class TreeItemController extends RestfulController<TreeItem> implements MdmContr
     def search() {
         log.debug('Call to tree search for {}', params.containerClass)
         respond treeItemService.buildContainerSearchTree(params.containerClass, currentUserSecurityPolicyManager,
-                                                         params.searchTerm as String, params.domainType as String)
+                                                         params.searchTerm as String, params.domainType as String,
+                                                         shouldIncludeDocumentSupersededItems(),
+                                                         shouldIncludeModelSupersededItems(),
+                                                         shouldIncludeDeletedItems())
     }
 
     def documentationSupersededModels() {

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -1197,8 +1197,8 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         savedCopy
     }
 
-    List<VersionedFolder> filterAllReadableModels(Collection<VersionedFolder> containers, boolean includeDocumentSuperseded,
-                                                  boolean includeModelSuperseded, boolean includeDeleted) {
+    List<VersionedFolder> filterAllReadableContainers(Collection<VersionedFolder> containers, boolean includeDocumentSuperseded,
+                                                      boolean includeModelSuperseded, boolean includeDeleted) {
         List<UUID> ids = containers.findAll {includeDeleted ? true : !it.deleted}.collect {it.id}
         List<UUID> constrainedIds
         // The list of ids are ALL the readable ids by the user, no matter the model status

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -274,8 +274,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             long st = System.currentTimeMillis()
             Collection<Model> modelsInFolder = service.findAllByFolderIdInList(foldersInside)
             log.debug('Found {} {} inside VF', modelsInFolder.size(), service.getDomainClass().simpleName)
-            modelsInFolder.each {model -> service.finaliseModel(model as Model, user, folderVersion, null, folderVersionTag)
-            }
+            modelsInFolder.each {model -> service.finaliseModel(model as Model, user, folderVersion, null, folderVersionTag)}
             log.debug('Finalisation of {} models took {}', modelsInFolder.size(), Utils.timeTaken(st))
         }
 
@@ -812,21 +811,18 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
     void removeBranchNameDiff(ObjectDiff diff) {
 
-        Predicate branchNamePredicate = [test: {FieldDiff fieldDiff -> fieldDiff.fieldName == 'branchName'
-        },] as Predicate
+        Predicate branchNamePredicate = [test: {FieldDiff fieldDiff -> fieldDiff.fieldName == 'branchName'}] as Predicate
 
         diff.diffs.removeIf(branchNamePredicate)
 
         ArrayDiff modelsDiff = diff.diffs.find {it.fieldName == 'models'}
         if (modelsDiff) {
-            modelsDiff.modified.each {md -> md.diffs.removeIf(branchNamePredicate)
-            }
+            modelsDiff.modified.each {md -> md.diffs.removeIf(branchNamePredicate)}
         }
 
         ArrayDiff folderDiff = diff.diffs.find {it.fieldName == 'folders'}
         if (folderDiff) {
-            folderDiff.modified.each {fd -> removeBranchNameDiff(fd)
-            }
+            folderDiff.modified.each {fd -> removeBranchNameDiff(fd)}
         }
     }
 
@@ -1110,7 +1106,8 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         relativePathToMergeTo.each {node ->
             if (!modelService) {
                 // Build up the path to the model
-                if (!modelRelativeToTargetPath) modelRelativeToTargetPath = Path.from(node) else modelRelativeToTargetPath.addToPathNodes(node)
+                if (!modelRelativeToTargetPath) modelRelativeToTargetPath = Path.from(node)
+                else modelRelativeToTargetPath.addToPathNodes(node)
 
                 modelService = modelServices.find {s -> s.handlesPathPrefix(node.prefix)}
             }
@@ -1121,7 +1118,9 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                 // Make sure we repoint the path to the target model so we can use the model service code to do the copy
                 if (!modelItemToModelAbsolutePath) modelItemToModelAbsolutePath = Path.from(node).tap {
                     it.first().modelIdentifier = getModelIdentifier(targetVersionedFolder)
-                } else modelItemToModelAbsolutePath.addToPathNodes(node)
+                } else {
+                    modelItemToModelAbsolutePath.addToPathNodes(node)
+                }
             }
         }
         if (!modelService) throw new ApiInternalException('MSXX', "No model service to handle creation of model item [${modelItemDomainType}]")
@@ -1130,9 +1129,11 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, modelRelativeToTargetPath,
                                                            getModelIdentifier(targetVersionedFolder)) as Model
 
-        [targetModel                 : targetModel,
-         modelService                : modelService,
-         modelItemToModelAbsolutePath: modelItemToModelAbsolutePath]
+        [
+            targetModel                 : targetModel,
+            modelService                : modelService,
+            modelItemToModelAbsolutePath: modelItemToModelAbsolutePath
+        ]
     }
 
     static String getModelIdentifier(VersionedFolder versionedFolder) {
@@ -1203,7 +1204,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         List<UUID> constrainedIds
         // The list of ids are ALL the readable ids by the user, no matter the model status
         if (includeDocumentSuperseded && includeModelSuperseded) {
-            constrainedIds = new ArrayList<>(ids)
+            constrainedIds = ids
         } else if (includeModelSuperseded) {
             constrainedIds = findAllExcludingDocumentSupersededIds(ids)
         } else if (includeDocumentSuperseded) {

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -156,7 +156,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     List<VersionedFolder> findAllReadableContainersBySearchTerm(UserSecurityPolicyManager userSecurityPolicyManager, String searchTerm) {
         log.debug('Searching readable folders for search term in label')
         List<UUID> readableIds = userSecurityPolicyManager.listReadableSecuredResourceIds(Folder)
-        VersionedFolder.treeLabelHibernateSearch(readableIds.collect { it.toString() }, searchTerm)
+        VersionedFolder.treeLabelHibernateSearch(readableIds.collect {it.toString()}, searchTerm)
     }
 
     @Override
@@ -248,8 +248,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                                              "${OffsetDateTimeConverter.toString(folder.dateFinalised)}")
 
         editService.createAndSaveEdit(EditTitle.FINALISE, folder.id, folder.domainType,
-                                      "${folder.label} finalised by ${user.firstName} ${user.lastName} on " +
-                                      "${OffsetDateTimeConverter.toString(folder.dateFinalised)}",
+                                      "${folder.label} finalised by ${user.firstName} ${user.lastName} on " + "${OffsetDateTimeConverter.toString(folder.dateFinalised)}",
                                       user)
 
         if (Environment.current != Environment.TEST) {
@@ -275,8 +274,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             long st = System.currentTimeMillis()
             Collection<Model> modelsInFolder = service.findAllByFolderIdInList(foldersInside)
             log.debug('Found {} {} inside VF', modelsInFolder.size(), service.getDomainClass().simpleName)
-            modelsInFolder.each {model ->
-                service.finaliseModel(model as Model, user, folderVersion, null, folderVersionTag)
+            modelsInFolder.each {model -> service.finaliseModel(model as Model, user, folderVersion, null, folderVersionTag)
             }
             log.debug('Finalisation of {} models took {}', modelsInFolder.size(), Utils.timeTaken(st))
         }
@@ -284,10 +282,10 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         log.debug('Folder contents finalisation took {}', Utils.timeTaken(start))
     }
 
-    Set<UUID> collectAllFoldersIdsInsideFolder(UUID folderId){
+    Set<UUID> collectAllFoldersIdsInsideFolder(UUID folderId) {
         Set<UUID> folderIds = new HashSet<>()
         List<Folder> folders = folderService.findAllByParentId(folderId)
-        folderIds.addAll(folders.collect{it.id})
+        folderIds.addAll(folders.collect {it.id})
         folderIds.addAll(folders.collectMany {collectAllFoldersIdsInsideFolder(it.id)})
         folderIds
     }
@@ -396,7 +394,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
         if (permanent) {
             // delete version links which point to this VF
-            versionLinkService.findAllByTargetModelId(folder.id).each{
+            versionLinkService.findAllByTargetModelId(folder.id).each {
                 versionLinkService.delete(it, flush)
             }
         }
@@ -482,14 +480,13 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
         if (!draftFolderOnMainBranchForLabel) {
             log.info('Creating a new branch model version of {} with name {}', folder.id, VersionAwareConstraints.DEFAULT_BRANCH_NAME)
-            VersionedFolder newMainBranchModelVersion = copyFolderAsNewBranchFolder(
-                folder,
-                user,
-                copyPermissions,
-                folder.label,
-                VersionAwareConstraints.DEFAULT_BRANCH_NAME,
-                additionalArguments.throwErrors as boolean,
-                userSecurityPolicyManager)
+            VersionedFolder newMainBranchModelVersion = copyFolderAsNewBranchFolder(folder,
+                                                                                    user,
+                                                                                    copyPermissions,
+                                                                                    folder.label,
+                                                                                    VersionAwareConstraints.DEFAULT_BRANCH_NAME,
+                                                                                    additionalArguments.throwErrors as boolean,
+                                                                                    userSecurityPolicyManager)
             setFolderIsNewBranchModelVersionOfFolder(newMainBranchModelVersion, folder, user)
 
             // If the branch name isn't main and the main branch doesnt exist then we need to validate and save it
@@ -508,14 +505,13 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             }
         }
         log.info('Creating a new branch model version of {} with name {}', folder.id, branchName)
-        VersionedFolder newBranchModelVersion = copyFolderAsNewBranchFolder(
-            folder,
-            user,
-            copyPermissions,
-            folder.label,
-            branchName,
-            additionalArguments.throwErrors as boolean,
-            userSecurityPolicyManager)
+        VersionedFolder newBranchModelVersion = copyFolderAsNewBranchFolder(folder,
+                                                                            user,
+                                                                            copyPermissions,
+                                                                            folder.label,
+                                                                            branchName,
+                                                                            additionalArguments.throwErrors as boolean,
+                                                                            userSecurityPolicyManager)
 
         setFolderIsNewBranchModelVersionOfFolder(newBranchModelVersion, folder, user)
 
@@ -609,27 +605,21 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     }
 
     void setFolderIsNewBranchModelVersionOfFolder(VersionedFolder newVersionedFolder, VersionedFolder oldVersionedFolder, User catalogueUser) {
-        newVersionedFolder.addToVersionLinks(
-            linkType: VersionLinkType.NEW_MODEL_VERSION_OF,
-            createdBy: catalogueUser.emailAddress,
-            targetModel: oldVersionedFolder
-        )
+        newVersionedFolder.addToVersionLinks(linkType: VersionLinkType.NEW_MODEL_VERSION_OF,
+                                             createdBy: catalogueUser.emailAddress,
+                                             targetModel: oldVersionedFolder)
     }
 
     void setFolderIsNewForkModelOfFolder(VersionedFolder newFolder, VersionedFolder oldFolder, User catalogueUser) {
-        newFolder.addToVersionLinks(
-            linkType: VersionLinkType.NEW_FORK_OF,
-            createdBy: catalogueUser.emailAddress,
-            targetModel: oldFolder
-        )
+        newFolder.addToVersionLinks(linkType: VersionLinkType.NEW_FORK_OF,
+                                    createdBy: catalogueUser.emailAddress,
+                                    targetModel: oldFolder)
     }
 
     void setModelIsNewDocumentationVersionOfModel(VersionedFolder newFolder, VersionedFolder oldFolder, User catalogueUser) {
-        newFolder.addToVersionLinks(
-            linkType: VersionLinkType.NEW_DOCUMENTATION_VERSION_OF,
-            createdBy: catalogueUser.emailAddress,
-            targetModel: oldFolder
-        )
+        newFolder.addToVersionLinks(linkType: VersionLinkType.NEW_DOCUMENTATION_VERSION_OF,
+                                    createdBy: catalogueUser.emailAddress,
+                                    targetModel: oldFolder)
     }
 
     VersionedFolder findLatestModelByLabel(String label) {
@@ -651,8 +641,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     VersionedFolder findOldestAncestor(VersionedFolder versionedFolder) {
         // Look for model version or doc version only
         VersionLink versionLink = versionLinkService.findBySourceModelIdAndLinkType(versionedFolder.id, VersionLinkType.NEW_MODEL_VERSION_OF)
-        versionLink =
-            versionLink ?: versionLinkService.findBySourceModelIdAndLinkType(versionedFolder.id, VersionLinkType.NEW_DOCUMENTATION_VERSION_OF)
+        versionLink = versionLink ?: versionLinkService.findBySourceModelIdAndLinkType(versionedFolder.id, VersionLinkType.NEW_DOCUMENTATION_VERSION_OF)
 
         // If no versionlink then we're at the oldest ancestor
         if (!versionLink) {
@@ -764,9 +753,9 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         getDiffForVersionedFolders(thisCachedDiffable, otherCachedDiffable, contentContext)
     }
 
-    ObjectDiff<VersionedFolder> getDiffForVersionedFolders( CachedDiffable<VersionedFolder> thisCachedDiffable, CachedDiffable<VersionedFolder> otherCachedDiffable,
-                                                            String contentContext = 'none') {
-        ObjectDiff<VersionedFolder> coreDiff =  thisCachedDiffable.diff(otherCachedDiffable, 'none')
+    ObjectDiff<VersionedFolder> getDiffForVersionedFolders(CachedDiffable<VersionedFolder> thisCachedDiffable, CachedDiffable<VersionedFolder> otherCachedDiffable,
+                                                           String contentContext = 'none') {
+        ObjectDiff<VersionedFolder> coreDiff = thisCachedDiffable.diff(otherCachedDiffable, 'none')
         folderService.loadModelsIntoFolderObjectDiff(coreDiff, thisCachedDiffable.diffable, otherCachedDiffable.diffable, contentContext)
         coreDiff
     }
@@ -802,14 +791,13 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         removeBranchNameDiff(caDiffSource)
         removeBranchNameDiff(caDiffTarget)
 
-      MergeDiff<VersionedFolder> mergeDiff =  mergeDiffService.generateMergeDiff(DiffBuilder
-                                               .mergeDiff(VersionedFolder)
-                                               .forMergingDiffable(sourceVersionedFolder)
-                                               .intoDiffable(targetVersionedFolder)
-                                               .havingCommonAncestor(commonAncestor)
-                                               .withCommonAncestorDiffedAgainstSource(caDiffSource)
-                                               .withCommonAncestorDiffedAgainstTarget(caDiffTarget)
-        )
+        MergeDiff<VersionedFolder> mergeDiff = mergeDiffService.generateMergeDiff(DiffBuilder
+                                                                                      .mergeDiff(VersionedFolder)
+                                                                                      .forMergingDiffable(sourceVersionedFolder)
+                                                                                      .intoDiffable(targetVersionedFolder)
+                                                                                      .havingCommonAncestor(commonAncestor)
+                                                                                      .withCommonAncestorDiffedAgainstSource(caDiffSource)
+                                                                                      .withCommonAncestorDiffedAgainstTarget(caDiffTarget))
             .flatten()
             .clean {
                 Path diffPath = it.fullyQualifiedPath
@@ -824,23 +812,20 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
     void removeBranchNameDiff(ObjectDiff diff) {
 
-        Predicate branchNamePredicate = [test: {FieldDiff fieldDiff ->
-            fieldDiff.fieldName == 'branchName'
+        Predicate branchNamePredicate = [test: {FieldDiff fieldDiff -> fieldDiff.fieldName == 'branchName'
         },] as Predicate
 
         diff.diffs.removeIf(branchNamePredicate)
 
         ArrayDiff modelsDiff = diff.diffs.find {it.fieldName == 'models'}
         if (modelsDiff) {
-            modelsDiff.modified.each {md ->
-                md.diffs.removeIf(branchNamePredicate)
+            modelsDiff.modified.each {md -> md.diffs.removeIf(branchNamePredicate)
             }
         }
 
         ArrayDiff folderDiff = diff.diffs.find {it.fieldName == 'folders'}
         if (folderDiff) {
-            folderDiff.modified.each {fd ->
-                removeBranchNameDiff(fd)
+            folderDiff.modified.each {fd -> removeBranchNameDiff(fd)
             }
         }
     }
@@ -979,8 +964,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
         // Use the domain service validation to ensure proper object validation
         domainService.validate(domain)
-        if (domain.hasErrors())
-            throw new ApiInvalidModelException('MS01', 'Modified domain is invalid', domain.errors, messageSource)
+        if (domain.hasErrors()) throw new ApiInvalidModelException('MS01', 'Modified domain is invalid', domain.errors, messageSource)
         domainService.save(domain, flush: false, validate: false)
     }
 
@@ -1082,8 +1066,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                                                            getModelIdentifier(targetVersionedFolder)) as MultiFacetAware
         MultiFacetItemAware copy = multiFacetItemAwareService.copy(multiFacetItemAwareToCopy, parentToCopyInto)
 
-        if (!copy.validate())
-            throw new ApiInvalidModelException('MS01', 'Copied Facet is invalid', copy.errors, messageSource)
+        if (!copy.validate()) throw new ApiInvalidModelException('MS01', 'Copied Facet is invalid', copy.errors, messageSource)
 
         multiFacetItemAwareService.save(copy, flush: false, validate: false)
     }
@@ -1127,8 +1110,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         relativePathToMergeTo.each {node ->
             if (!modelService) {
                 // Build up the path to the model
-                if (!modelRelativeToTargetPath) modelRelativeToTargetPath = Path.from(node)
-                else modelRelativeToTargetPath.addToPathNodes(node)
+                if (!modelRelativeToTargetPath) modelRelativeToTargetPath = Path.from(node) else modelRelativeToTargetPath.addToPathNodes(node)
 
                 modelService = modelServices.find {s -> s.handlesPathPrefix(node.prefix)}
             }
@@ -1139,8 +1121,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                 // Make sure we repoint the path to the target model so we can use the model service code to do the copy
                 if (!modelItemToModelAbsolutePath) modelItemToModelAbsolutePath = Path.from(node).tap {
                     it.first().modelIdentifier = getModelIdentifier(targetVersionedFolder)
-                }
-                else modelItemToModelAbsolutePath.addToPathNodes(node)
+                } else modelItemToModelAbsolutePath.addToPathNodes(node)
             }
         }
         if (!modelService) throw new ApiInternalException('MSXX', "No model service to handle creation of model item [${modelItemDomainType}]")
@@ -1149,11 +1130,9 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, modelRelativeToTargetPath,
                                                            getModelIdentifier(targetVersionedFolder)) as Model
 
-        [
-            targetModel                 : targetModel,
-            modelService                : modelService,
-            modelItemToModelAbsolutePath: modelItemToModelAbsolutePath
-        ]
+        [targetModel                 : targetModel,
+         modelService                : modelService,
+         modelItemToModelAbsolutePath: modelItemToModelAbsolutePath]
     }
 
     static String getModelIdentifier(VersionedFolder versionedFolder) {
@@ -1174,7 +1153,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
         log.trace('Loading Folder')
         List<Folder> folders = getAllFoldersInside(loadedFolder)
-        Map<UUID,List<Folder>> foldersMap = folders.groupBy{it.parentFolder.id}
+        Map<UUID, List<Folder>> foldersMap = folders.groupBy {it.parentFolder.id}
 
         log.trace('Loading Facets')
         List<UUID> allIds = Utils.gatherIds(Collections.singleton(folderId),
@@ -1183,7 +1162,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         Map<String, Map<UUID, List<Diffable>>> facetData = loadAllDiffableFacetsIntoMemoryByIds(allIds)
 
         DiffCache diffCache = folderService.createFolderDiffCache(null, loadedFolder, facetData)
-        folderService.createFolderDiffCaches(diffCache,  foldersMap, facetData, folderId)
+        folderService.createFolderDiffCaches(diffCache, foldersMap, facetData, folderId)
 
         log.debug('Folder loaded into memory, took {}', Utils.timeTaken(start))
         new CachedDiffable(loadedFolder, diffCache)
@@ -1216,5 +1195,24 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             securityPolicyManagerService.addSecurityForSecurableResource(savedCopy, user, savedCopy.label)
         }
         savedCopy
+    }
+
+    List<VersionedFolder> filterAllReadableModels(Collection<VersionedFolder> containers, boolean includeDocumentSuperseded,
+                                                  boolean includeModelSuperseded, boolean includeDeleted) {
+        List<UUID> ids = containers.findAll {includeDeleted ? true : !it.deleted}.collect {it.id}
+        List<UUID> constrainedIds
+        // The list of ids are ALL the readable ids by the user, no matter the model status
+        if (includeDocumentSuperseded && includeModelSuperseded) {
+            constrainedIds = new ArrayList<>(ids)
+        } else if (includeModelSuperseded) {
+            constrainedIds = findAllExcludingDocumentSupersededIds(ids)
+        } else if (includeDocumentSuperseded) {
+            constrainedIds = findAllExcludingModelSupersededIds(ids)
+        } else {
+            constrainedIds = findAllExcludingDocumentAndModelSupersededIds(ids)
+        }
+        if (!constrainedIds) return []
+
+        containers.findAll {it.id in constrainedIds}
     }
 }

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemService.groovy
@@ -504,7 +504,7 @@ class TreeItemService {
         }
 
         def readableVersionedContainers =
-            versionedFolderService.filterAllReadableModels(versionedContainers as List<VersionedFolder>, includeDocumentSuperseded, includeModelSuperseded, includeDeleted)
+            versionedFolderService.filterAllReadableContainers(versionedContainers as List<VersionedFolder>, includeDocumentSuperseded, includeModelSuperseded, includeDeleted)
 
         List<K> combined = []
         combined.addAll(nonVersionedContainers)

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemService.groovy
@@ -103,7 +103,9 @@ class TreeItemService {
                                                                              boolean includeDeleted) {
         log.info('Creating container only tree')
         buildContainerTreeFromContainerTreeItems(
-            getAllReadableContainerTreeItems(containerClass, userSecurityPolicyManager, includeDocumentSuperseded, includeModelSuperseded, includeDeleted), false)
+            getAllReadableContainerTreeItems(containerClass, userSecurityPolicyManager, includeDocumentSuperseded, includeModelSuperseded, includeDeleted),
+            false
+        )
     }
 
     def <K extends Container> List<ContainerTreeItem> buildModelCreatableContainerOnlyTree(Class<K> containerClass,
@@ -113,7 +115,9 @@ class TreeItemService {
                                                                                            boolean includeDeleted) {
         log.info('Creating model creatable container only tree')
         buildContainerTreeFromContainerTreeItems(
-            getAllModelCreatableContainerTreeItems(containerClass, userSecurityPolicyManager, includeDocumentSuperseded, includeModelSuperseded, includeDeleted), false)
+            getAllModelCreatableContainerTreeItems(containerClass, userSecurityPolicyManager, includeDocumentSuperseded, includeModelSuperseded, includeDeleted),
+            false
+        )
     }
 
     /**

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderServiceSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderServiceSpec.groovy
@@ -18,7 +18,6 @@
 package uk.ac.ox.softeng.maurodatamapper.core.container
 
 import uk.ac.ox.softeng.maurodatamapper.core.authority.Authority
-import uk.ac.ox.softeng.maurodatamapper.core.facet.VersionLink
 import uk.ac.ox.softeng.maurodatamapper.core.facet.VersionLinkType
 import uk.ac.ox.softeng.maurodatamapper.security.UserSecurityPolicyManager
 import uk.ac.ox.softeng.maurodatamapper.security.basic.NoAccessSecurityPolicyManager
@@ -30,7 +29,6 @@ import grails.gorm.transactions.Rollback
 import grails.testing.mixin.integration.Integration
 import groovy.util.logging.Slf4j
 
-import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.UNIT_TEST
 import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.UNIT_TEST
 
 @Slf4j

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderServiceSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderServiceSpec.groovy
@@ -18,15 +18,19 @@
 package uk.ac.ox.softeng.maurodatamapper.core.container
 
 import uk.ac.ox.softeng.maurodatamapper.core.authority.Authority
+import uk.ac.ox.softeng.maurodatamapper.core.facet.VersionLink
+import uk.ac.ox.softeng.maurodatamapper.core.facet.VersionLinkType
 import uk.ac.ox.softeng.maurodatamapper.security.UserSecurityPolicyManager
 import uk.ac.ox.softeng.maurodatamapper.security.basic.NoAccessSecurityPolicyManager
 import uk.ac.ox.softeng.maurodatamapper.security.basic.PublicAccessSecurityPolicyManager
 import uk.ac.ox.softeng.maurodatamapper.test.integration.BaseIntegrationSpec
+import uk.ac.ox.softeng.maurodatamapper.version.Version
 
 import grails.gorm.transactions.Rollback
 import grails.testing.mixin.integration.Integration
 import groovy.util.logging.Slf4j
 
+import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.UNIT_TEST
 import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress.UNIT_TEST
 
 @Slf4j
@@ -34,7 +38,10 @@ import static uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddre
 @Rollback
 class VersionedFolderServiceSpec extends BaseIntegrationSpec {
 
+    private static String VF_HISTORY_LABEL = 'VF History'
+
     UUID id
+    List<VersionedFolder> versionedContainers
     VersionedFolderService versionedFolderService
 
     Authority getTestAuthority() {
@@ -63,6 +70,23 @@ class VersionedFolderServiceSpec extends BaseIntegrationSpec {
 
         checkAndSave(folder)
         id = folder.id
+
+        // Setup VersionedFolder model version history
+        def vf1Version1 = new VersionedFolder(label: VF_HISTORY_LABEL, createdBy: UNIT_TEST, authority: testAuthority, modelVersion: Version.from('1'), finalised: true)
+        checkAndSave(vf1Version1)
+        def vf1Version2 = new VersionedFolder(label: VF_HISTORY_LABEL, createdBy: UNIT_TEST, authority: testAuthority, modelVersion: Version.from('2'), finalised: true)
+        checkAndSave(vf1Version2)
+        def vf1Version3Draft = new VersionedFolder(label: VF_HISTORY_LABEL, createdBy: UNIT_TEST, authority: testAuthority, finalised: false, branchName: 'main',
+                                                   deleted: true)
+        checkAndSave(vf1Version3Draft)
+
+        vf1Version2.addToVersionLinks(linkType: VersionLinkType.NEW_MODEL_VERSION_OF, createdBy: UNIT_TEST, targetModel: vf1Version1)
+        checkAndSave(vf1Version1)
+
+        vf1Version3Draft.addToVersionLinks(linkType: VersionLinkType.NEW_MODEL_VERSION_OF, createdBy: UNIT_TEST, targetModel: vf1Version2)
+        checkAndSave(vf1Version2)
+
+        versionedContainers = [vf1Version1, vf1Version2, vf1Version3Draft]
     }
 
     void 'test get'() {
@@ -89,7 +113,7 @@ class VersionedFolderServiceSpec extends BaseIntegrationSpec {
         setupDomainData()
 
         expect:
-        versionedFolderService.count() == 8
+        versionedFolderService.count() == 11
     }
 
     void 'test delete'() {
@@ -97,15 +121,15 @@ class VersionedFolderServiceSpec extends BaseIntegrationSpec {
         setupDomainData()
 
         expect:
-        versionedFolderService.count() == 8
+        versionedFolderService.count() == 11
 
         when:
         versionedFolderService.delete(id)
         sessionFactory.currentSession.flush()
 
         then:
-        VersionedFolder.countByDeleted(false) == 7
-        VersionedFolder.countByDeleted(true) == 1
+        VersionedFolder.countByDeleted(false) == 9
+        VersionedFolder.countByDeleted(true) == 2
     }
 
     void 'test findAllByUser'() {
@@ -120,7 +144,7 @@ class VersionedFolderServiceSpec extends BaseIntegrationSpec {
         List<VersionedFolder> folderList = versionedFolderService.findAllByUser(testPolicy)
 
         then:
-        folderList.size() == 8
+        folderList.size() == 11
 
         when: 'using policy that can only read the id folder'
         testPolicy = Mock()
@@ -148,7 +172,7 @@ class VersionedFolderServiceSpec extends BaseIntegrationSpec {
         folderList = versionedFolderService.findAllByUser(PublicAccessSecurityPolicyManager.instance)
 
         then:
-        folderList.size() == 8
+        folderList.size() == 11
     }
 
     void 'test version family tree on id'() {
@@ -264,5 +288,73 @@ class VersionedFolderServiceSpec extends BaseIntegrationSpec {
 
         expect:
         !versionedFolderService.doesMovePlaceVersionedFolderInsideVersionedFolder(moving, moveTo)
+    }
+
+    void 'test excluding model superseded and deleted containers'() {
+        given:
+        setupDomainData()
+
+        when:
+        List<VersionedFolder> filtered = versionedFolderService.filterAllReadableContainers(versionedContainers,
+                                                                                            false,
+                                                                                            false,
+                                                                                            false)
+
+        then:
+        filtered.size() == 1
+        !filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 1}
+        filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 2}
+        !filtered.any {it.label == VF_HISTORY_LABEL && !it.finalised && it.deleted}
+    }
+
+    void 'test including model superseded containers'() {
+        given:
+        setupDomainData()
+
+        when:
+        List<VersionedFolder> filtered = versionedFolderService.filterAllReadableContainers(versionedContainers,
+                                                                                            false,
+                                                                                            true,
+                                                                                            false)
+
+        then:
+        filtered.size() == 2
+        filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 1}
+        filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 2}
+        !filtered.any {it.label == VF_HISTORY_LABEL && !it.finalised && it.deleted}
+    }
+
+    void 'test include deleted containers'() {
+        given:
+        setupDomainData()
+
+        when:
+        List<VersionedFolder> filtered = versionedFolderService.filterAllReadableContainers(versionedContainers,
+                                                                                            false,
+                                                                                            false,
+                                                                                            true)
+
+        then:
+        filtered.size() == 2
+        !filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 1}
+        filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 2}
+        filtered.any {it.label == VF_HISTORY_LABEL && !it.finalised && it.deleted}
+    }
+
+    void 'test include model superseded and deleted containers'() {
+        given:
+        setupDomainData()
+
+        when:
+        List<VersionedFolder> filtered = versionedFolderService.filterAllReadableContainers(versionedContainers,
+                                                                                            false,
+                                                                                            true,
+                                                                                            true)
+
+        then:
+        filtered.size() == 3
+        filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 1}
+        filtered.any {it.label == VF_HISTORY_LABEL && it.modelVersion?.major == 2}
+        filtered.any {it.label == VF_HISTORY_LABEL && !it.finalised && it.deleted}
     }
 }

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/tree/TreeItemFunctionalSpec.groovy
@@ -554,4 +554,276 @@ class TreeItemFunctionalSpec extends BaseFunctionalSpec {
         DELETE("folders/$parentId?permanent=true")
         assert response.status() == HttpStatus.NO_CONTENT
     }
+
+    void '11. test tree with VersionedFolders: exclude model superseded'() {
+        given:
+        boolean includeModelSuperseded = false
+        String expectedChildren = '''[
+        {
+            "id": "${json-unit.matches:id}",
+            "domainType": "VersionedFolder",
+            "label": "Functional Versioned Folder",
+            "hasChildren": false,
+            "availableActions": [],
+            "deleted": false,
+            "parentFolder": "${json-unit.matches:id}",
+            "finalised": true,
+            "documentationVersion": "1.0.0",
+            "modelVersion": "2.0.0"
+        }
+    ]'''
+
+        when: 'creating new folder'
+        POST('folders', [label: 'Functional Test Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'creating new versioned folder'
+        def parentId = response.body().id
+        POST("folders/$parentId/versionedFolders", [label: 'Functional Versioned Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'finalise versioned folder for v1'
+        def versionedFolderVer1Id = response.body().id
+        PUT("versionedFolders/$versionedFolderVer1Id/finalise", [versionChangeType: 'Major'])
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'create next model version of versioned folder'
+        PUT("versionedFolders/$versionedFolderVer1Id/newBranchModelVersion", [:])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'finalise versioned folder for v2'
+        def versionedFolderVer2Id = response.body().id
+        PUT("versionedFolders/$versionedFolderVer2Id/finalise", [versionChangeType: 'Major'])
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'getting folder tree'
+        GET("$folderTreeResourcePath/$parentId?includeModelSuperseded=$includeModelSuperseded", STRING_ARG)
+
+        then:
+        verifyJsonResponse HttpStatus.OK, expectedChildren
+
+        cleanup:
+        DELETE("folders/$parentId?permanent=true")
+        assert response.status() == HttpStatus.NO_CONTENT
+    }
+
+    void '12. test tree with VersionedFolders: include model superseded'() {
+        given:
+        boolean includeModelSuperseded = true
+        String expectedChildren = '''[
+        {
+            "id": "${json-unit.matches:id}",
+            "domainType": "VersionedFolder",
+            "label": "Functional Versioned Folder",
+            "hasChildren": false,
+            "availableActions": [],
+            "deleted": false,
+            "parentFolder": "${json-unit.matches:id}",
+            "finalised": true,
+            "documentationVersion": "1.0.0",
+            "modelVersion": "1.0.0"
+        },
+        {
+            "id": "${json-unit.matches:id}",
+            "domainType": "VersionedFolder",
+            "label": "Functional Versioned Folder",
+            "hasChildren": false,
+            "availableActions": [],
+            "deleted": false,
+            "parentFolder": "${json-unit.matches:id}",
+            "finalised": true,
+            "documentationVersion": "1.0.0",
+            "modelVersion": "2.0.0"
+        }
+    ]'''
+
+        when: 'creating new folder'
+        POST('folders', [label: 'Functional Test Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'creating new versioned folder'
+        def parentId = response.body().id
+        POST("folders/$parentId/versionedFolders", [label: 'Functional Versioned Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'finalise versioned folder for v1'
+        def versionedFolderVer1Id = response.body().id
+        PUT("versionedFolders/$versionedFolderVer1Id/finalise", [versionChangeType: 'Major'])
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'create next model version of versioned folder'
+        PUT("versionedFolders/$versionedFolderVer1Id/newBranchModelVersion", [:])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'finalise versioned folder for v2'
+        def versionedFolderVer2Id = response.body().id
+        PUT("versionedFolders/$versionedFolderVer2Id/finalise", [versionChangeType: 'Major'])
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'getting folder tree'
+        GET("$folderTreeResourcePath/$parentId?includeModelSuperseded=$includeModelSuperseded", STRING_ARG)
+
+        then:
+        verifyJsonResponse HttpStatus.OK, expectedChildren
+
+        cleanup:
+        DELETE("folders/$parentId?permanent=true")
+        assert response.status() == HttpStatus.NO_CONTENT
+    }
+
+    void '13. test tree with VersionedFolders: exclude deleted'() {
+        given:
+        boolean includeDeleted = false
+        String expectedChildren = '''[
+        {
+            "id": "${json-unit.matches:id}",
+            "domainType": "VersionedFolder",
+            "label": "Functional Versioned Folder",
+            "hasChildren": false,
+            "availableActions": [],
+            "deleted": false,
+            "parentFolder": "${json-unit.matches:id}",
+            "finalised": true,
+            "documentationVersion": "1.0.0",
+            "modelVersion": "1.0.0"
+        }
+    ]'''
+
+        when: 'creating new folder'
+        POST('folders', [label: 'Functional Test Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'creating new versioned folder'
+        def parentId = response.body().id
+        POST("folders/$parentId/versionedFolders", [label: 'Functional Versioned Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'finalise versioned folder for v1'
+        def versionedFolderVer1Id = response.body().id
+        PUT("versionedFolders/$versionedFolderVer1Id/finalise", [versionChangeType: 'Major'])
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'create next model version of versioned folder'
+        PUT("versionedFolders/$versionedFolderVer1Id/newBranchModelVersion", [:])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'mark draft versioned folder as deleted'
+        def versionedFolderVer2Id = response.body().id
+        DELETE("versionedFolders/$versionedFolderVer2Id?permanent=false")
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'getting folder tree'
+        GET("$folderTreeResourcePath/$parentId?includeDeleted=$includeDeleted", STRING_ARG)
+
+        then:
+        verifyJsonResponse HttpStatus.OK, expectedChildren
+
+        cleanup:
+        DELETE("folders/$parentId?permanent=true")
+        assert response.status() == HttpStatus.NO_CONTENT
+    }
+
+    void '14. test tree with VersionedFolders: include deleted'() {
+        given:
+        boolean includeDeleted = true
+        String expectedChildren = '''[
+        {
+            "id": "${json-unit.matches:id}",
+            "domainType": "VersionedFolder",
+            "label": "Functional Versioned Folder",
+            "hasChildren": false,
+            "availableActions": [],
+            "deleted": false,
+            "parentFolder": "${json-unit.matches:id}",
+            "finalised": true,
+            "documentationVersion": "1.0.0",
+            "modelVersion": "1.0.0"
+        },
+        {
+            "id": "${json-unit.matches:id}",
+            "domainType": "VersionedFolder",
+            "label": "Functional Versioned Folder",
+            "hasChildren": false,
+            "availableActions": [],
+            "deleted": true,
+            "parentFolder": "${json-unit.matches:id}",
+            "finalised": false,
+            "documentationVersion": "1.0.0",
+            "branchName": "main"
+        }
+    ]'''
+
+        when: 'creating new folder'
+        POST('folders', [label: 'Functional Test Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'creating new versioned folder'
+        def parentId = response.body().id
+        POST("folders/$parentId/versionedFolders", [label: 'Functional Versioned Folder'])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'finalise versioned folder for v1'
+        def versionedFolderVer1Id = response.body().id
+        PUT("versionedFolders/$versionedFolderVer1Id/finalise", [versionChangeType: 'Major'])
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'create next model version of versioned folder'
+        PUT("versionedFolders/$versionedFolderVer1Id/newBranchModelVersion", [:])
+
+        then:
+        verifyResponse HttpStatus.CREATED, response
+
+        when: 'mark draft versioned folder as deleted'
+        def versionedFolderVer2Id = response.body().id
+        DELETE("versionedFolders/$versionedFolderVer2Id?permanent=false")
+
+        then:
+        verifyResponse HttpStatus.OK, response
+
+        when: 'getting folder tree'
+        GET("$folderTreeResourcePath/$parentId?includeDeleted=$includeDeleted", STRING_ARG)
+
+        then:
+        verifyJsonResponse HttpStatus.OK, expectedChildren
+
+        cleanup:
+        DELETE("folders/$parentId?permanent=true")
+        assert response.status() == HttpStatus.NO_CONTENT
+    }
 }

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/tree/TreeItemServiceSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/tree/TreeItemServiceSpec.groovy
@@ -259,8 +259,8 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
         treeItems.any {it.label == testFolder.label}
 
         when:
-        def tf =treeItemService.buildDirectChildrenContainerTree(Folder, testFolder, PublicAccessSecurityPolicyManager.instance,
-                                                                 true, false, false)
+        def tf = treeItemService.buildDirectChildrenContainerTree(Folder, testFolder, PublicAccessSecurityPolicyManager.instance,
+                                                                  true, false, false)
         then:
         tf
         tf.size() == 3
@@ -515,7 +515,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
         String searchTerm = 'test'
 
         when:
-        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null)
+        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null, false, false, false)
 
         then:
         treeItems.size() == 1
@@ -545,7 +545,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
         String searchTerm = 'child'
 
         when:
-        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null)
+        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null, false, false, false)
 
         then:
         treeItems.size() == 1
@@ -585,7 +585,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
         String searchTerm = 'string'
 
         when:
-        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null)
+        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null, false, false, false)
 
         then: 'no domain provided should not search datatypes'
         treeItems.size() == 0
@@ -606,7 +606,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
         String searchTerm = 'ele'
 
         when:
-        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null)
+        List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm, null, false, false, false)
 
         then: 'no domain provided should not search data elements'
         treeItems.size() == 0
@@ -635,7 +635,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
 
         when:
         List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm,
-                                                                            'DataModel')
+                                                                            'DataModel', false, false, false)
 
         then:
         treeItems.size() == 0
@@ -648,7 +648,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
 
         when:
         List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm,
-                                                                            'DataType')
+                                                                            'DataType', false, false, false)
 
         then: 'no domain provided should not search datatypes'
         treeItems.size() == 1
@@ -674,7 +674,7 @@ class TreeItemServiceSpec extends BaseDataModelIntegrationSpec {
 
         when:
         List<TreeItem> treeItems = treeItemService.buildContainerSearchTree(Folder, PublicAccessSecurityPolicyManager.instance, searchTerm,
-                                                                            'DataElement')
+                                                                            'DataElement', false, false, false)
 
         then: 'no domain provided should not search data elements'
         treeItems.size() == 1


### PR DESCRIPTION
Resolves #288 

Update the tree endpoints, like `GET api/tree/folders/{id}` to use the provided `includeModelSuperseded` and `includeDeleted` parameters on Versioned Folders. By default Versioned Folders that are superseded are _not_ included in the tree response, unless `includeModelSuperseded=true` is provided.

Tests around the `VersionedFolderService` and `TreeItemService` have also been updated to test the behaviour.

This is my first PR to `mdm-core`, and also my first experience working in Groovy, so any feedback would be welcome.