### PR TITLE
Handle reordering of ModelItems depending on direction of reordering

### DIFF
--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/domain/IndexedSiblingAware.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/domain/IndexedSiblingAware.groovy
@@ -110,11 +110,11 @@ trait IndexedSiblingAware {
             log.trace('Before >> MI {} has idx {} sorted to {}', mi.label, mi.idx, i)
             // Reorder the index which matches the one we just added
             if (i == updatedIndex) {
-                if (updated.getPersistentValue('idx') > updated.idx) {
-                    // If `updated` was moved down the list, order the adjacent item after `updated`
+                if (updated.getPersistentValue('idx') == null || updated.getPersistentValue('idx') > updated.idx) {
+                    // If `updated` was moved up the list or newly inserted, order the adjacent item after `updated`
                     mi.idx = i + 1
                 } else {
-                    // If `updated` was moved up the list, order the adjacent item before `updated`
+                    // If `updated` was moved down the list, order the adjacent item before `updated`
                     mi.idx = i - 1
                 }
             } else if (mi.idx != i) {

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/domain/IndexedSiblingAware.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/domain/IndexedSiblingAware.groovy
@@ -91,6 +91,8 @@ trait IndexedSiblingAware {
     void sortAndReorderAllIndexes(ModelItem updated, Collection<ModelItem> siblings) {
         int updatedIndex = updated.idx
         int maxIndex = siblings.size() - 1
+
+        // Sort the collection to set the new index for the updated ModelItem, taking account of whether it was moved up or down the list
         siblings.sort().eachWithIndex {ModelItem mi, int i ->
             //EV is the updated one, skipping any changes
             if (mi == updated) {
@@ -108,12 +110,12 @@ trait IndexedSiblingAware {
             log.trace('Before >> MI {} has idx {} sorted to {}', mi.label, mi.idx, i)
             // Reorder the index which matches the one we just added
             if (i == updatedIndex) {
-                if (i == maxIndex) {
-                    // If at end of list then move the current value back one to ensure the updated value is at then end of the list
-                    mi.idx = i - 1
-                } else {
-                    // Otherwise alphabetical sorting has placed the elements in the wrong order so shift the value by 1
+                if (updated.getPersistentValue('idx') > updated.idx) {
+                    // If `updated` was moved down the list, order the adjacent item after `updated`
                     mi.idx = i + 1
+                } else {
+                    // If `updated` was moved up the list, order the adjacent item before `updated`
+                    mi.idx = i - 1
                 }
             } else if (mi.idx != i) {
                 // Sorting has got the order right so make sure the idx is set correctly

--- a/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/OrderedResourceFunctionalSpec.groovy
+++ b/mdm-testing-framework/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/test/functional/OrderedResourceFunctionalSpec.groovy
@@ -265,4 +265,56 @@ abstract class OrderedResourceFunctionalSpec<D extends GormEntity> extends Resou
         response.body().items[1].label == 'content'
         response.body().items[2].label == 'emptyclass'
    }
+
+    void 'OR5: Test ordering on update when moving items up and down the list'() {
+        given: 'Five resources with specified indices'
+        String aId = createNewItem(getValidLabelJson('A', 0))
+        String bId = createNewItem(getValidLabelJson('B', 1))
+        String cId = createNewItem(getValidLabelJson('C', 2))
+        String dId = createNewItem(getValidLabelJson('D', 3))
+        String eId = createNewItem(getValidLabelJson('E', 4))
+
+        when: 'All items are listed'
+        GET('?sort=idx')
+
+        then: 'They are in the order A, B, C, D, E'
+        response.body().items[0].label == 'A'
+        response.body().items[1].label == 'B'
+        response.body().items[2].label == 'C'
+        response.body().items[3].label == 'D'
+        response.body().items[4].label == 'E'
+
+        when: 'Item A is moved down to the middle of the list'
+        PUT(aId, getValidLabelJson('A', 2))
+
+        then: 'The PUT works'
+        response.status == HttpStatus.OK
+        String fId = response.body().id
+
+        when: 'All items are listed'
+        GET('?sort=idx')
+
+        then: 'They are in the order B, C, A, D, E'
+        response.body().items[0].label == 'B'
+        response.body().items[1].label == 'C'
+        response.body().items[2].label == 'A'
+        response.body().items[3].label == 'D'
+        response.body().items[4].label == 'E'
+
+        when: 'Item E is moved up to the middle of the list'
+        PUT(eId, getValidLabelJson('E', 2))
+
+        then: 'The PUT works'
+        response.status == HttpStatus.OK
+
+        when: 'All items are listed'
+        GET('?sort=idx')
+
+        then: 'They are in the order B, C, E, A, D'
+        response.body().items[0].label == 'B'
+        response.body().items[1].label == 'C'
+        response.body().items[2].label == 'E'
+        response.body().items[3].label == 'A'
+        response.body().items[4].label == 'D'
+    }
 }


### PR DESCRIPTION
When reordering a ModelItem in a collection, take into account the direction in which the ModelItem is moved when reordering the siblings. Add a test for this. Resolves #367.