### PR TITLE
Make case insensitive ordering fall back on ordering by case

### DIFF
--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/tree/ModelItemTreeItem.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/tree/ModelItemTreeItem.groovy
@@ -44,6 +44,7 @@ class ModelItemTreeItem extends TreeItem implements Comparable<TreeItem> {
         ModelItemTreeItem other = that as ModelItemTreeItem
         res = this.hasChildren() <=> other.hasChildren()
         if (res == 0) res = this.order <=> other.order
+        if (res == 0) res = this.label?.toLowerCase() <=> other.label?.toLowerCase()
         if (res == 0) res = this.label <=> other.label
         res
     }

--- a/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/tree/TreeItem.groovy
+++ b/mdm-core/grails-app/utils/uk/ac/ox/softeng/maurodatamapper/core/rest/transport/tree/TreeItem.groovy
@@ -97,6 +97,7 @@ class TreeItem implements Comparable<TreeItem> {
     int compareTo(TreeItem that) {
         def res = this.domainTypeIndex <=> that.domainTypeIndex
         if (res == 0) res = this.label?.toLowerCase() <=> that.label?.toLowerCase()
+        if (res == 0) res = this.label <=> that.label
         res
     }
 

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/CatalogueItemService.groovy
@@ -422,10 +422,14 @@ abstract class CatalogueItemService<K extends CatalogueItem> implements MdmDomai
     private static StringBuilder addLowercaseSort(StringBuilder stringBuilder, String ciQueryPrefix, String sort, String order, boolean isDistinct, boolean isSingle) {
         StringBuilder sortedQuery = new StringBuilder()
         // Need to add the lower variant to the select query if isDistinct
-        if (isDistinct) sortedQuery.append('\n, lower(').append(ciQueryPrefix).append('.').append(sort).append(') ')
+        if (isDistinct) {
+            sortedQuery.append('\n, lower(').append(ciQueryPrefix).append('.').append(sort).append(') ')
+            sortedQuery.append(', ').append(ciQueryPrefix).append('.').append(sort)
+        }
         sortedQuery.append(stringBuilder.toString())
         if (isSingle) sortedQuery.append('\nORDER BY ')
         sortedQuery.append('lower(').append(ciQueryPrefix).append('.').append(sort).append(') ').append(order)
+        sortedQuery.append(', ').append(ciQueryPrefix).append('.').append(sort).append(' ').append(order)
     }
 
     String applyHQLFilters(String originalQuery, String ciQueryPrefix, Map filters) {


### PR DESCRIPTION
Make case insensitive label ordering the equivalent of `ORDER BY lower(label), label` in CatalogueItemService and TreeItemService.

Resolves #377.
