### PR TITLE
gh-389 Update SummaryMetadata to support filtering for index queries

### DIFF
--- a/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/SummaryMetadata.groovy
+++ b/mdm-plugin-datamodel/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/SummaryMetadata.groovy
@@ -112,7 +112,7 @@ class SummaryMetadata implements MultiFacetItemAware, InformationAware, MdmDomai
     }
 
     static DetachedCriteria<SummaryMetadata> withFilter(DetachedCriteria<SummaryMetadata> criteria, Map filters) {
-        if (filters.label) criteria = criteria.ilike('label', "%${filters.name}%")
+        if (filters.label) criteria = criteria.ilike('label', "%${filters.label}%")
         criteria
     }
 }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/SummaryMetadataService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/facet/SummaryMetadataService.groovy
@@ -101,7 +101,7 @@ class SummaryMetadataService implements MultiFacetItemAwareService<SummaryMetada
 
     @Override
     List<SummaryMetadata> findAllByMultiFacetAwareItemId(UUID multiFacetAwareItemId, Map pagination = [:]) {
-        SummaryMetadata.byMultiFacetAwareItemId(multiFacetAwareItemId).list(pagination)
+        SummaryMetadata.withFilter(SummaryMetadata.byMultiFacetAwareItemId(multiFacetAwareItemId), pagination).list(pagination)
     }
 
     @Override

--- a/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/test/functional/CatalogueItemSummaryMetadataFunctionalSpec.groovy
+++ b/mdm-plugin-datamodel/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/test/functional/CatalogueItemSummaryMetadataFunctionalSpec.groovy
@@ -172,4 +172,69 @@ abstract class CatalogueItemSummaryMetadataFunctionalSpec extends CatalogueItemF
         cleanup:
         cleanUpData(id)
     }
+
+    void 'CISM02: test filtering of summaryMetadata'() {
+        given: 'Create new summaryMetadata items'
+        def id1 = createNewItem([
+            label              : 'Summary the first',
+            summaryMetadataType: SummaryMetadataType.NUMBER
+        ])
+        def id2 = createNewItem([
+            label              : 'Summary the second',
+            summaryMetadataType: SummaryMetadataType.NUMBER
+        ])
+
+        when: 'No filter used'
+        GET('')
+
+        then: 'Check all summaryMetadata returned'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().count == 2
+
+        when: 'Filter by label'
+        GET('?label=sec')
+
+        then: 'Check filtered summaryMetadata returned'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().count == 1
+        response.body().items[0].id == id2
+
+        cleanup:
+        cleanUpData(id1)
+        cleanUpData(id2)
+    }
+
+    void 'CISM03: test sorting of summaryMetadata'() {
+        given: 'Create new summaryMetadata items'
+        def id1 = createNewItem([
+            label              : 'A summaryMetadata',
+            summaryMetadataType: SummaryMetadataType.NUMBER
+        ])
+        def id2 = createNewItem([
+            label              : 'B summaryMetadata',
+            summaryMetadataType: SummaryMetadataType.NUMBER
+        ])
+
+        when: 'Default sorting by label'
+        GET('')
+
+        then: 'Check summaryMetadata returned in ascending label order'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().count == 2
+        response.body().items[0].id == id1
+        response.body().items[1].id == id2
+
+        when: 'Sort by label descending'
+        GET('?sort=label&order=desc')
+
+        then: 'Check summaryMetadata returned in descending label order'
+        verifyResponse(HttpStatus.OK, response)
+        response.body().count == 2
+        response.body().items[0].id == id2
+        response.body().items[1].id == id1
+
+        cleanup:
+        cleanUpData(id1)
+        cleanUpData(id2)
+    }
 }


### PR DESCRIPTION
Also created tests for filtering/sorting summaryMetadata.

Following endpoints now supported:

```
GET /{domainType}/{id}/summaryMetadata?label=<value>

GET /{domainType}/{id}/summaryMetadata?sort=label&order=desc
```

Fixes #389 