### PR TITLE
Add batching to potentially large deletion operations

### DIFF
--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/util/Utils.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/util/Utils.groovy
@@ -215,4 +215,16 @@ class Utils {
             Thread.currentThread().interrupt()
         }
     }
+
+    /*
+        Batching: for partitioning collections into sets of smaller ones
+     */
+    static List<List> partition(List inputList, int partitionSize ) {
+        List<List> partitions = []
+        for (int i = 0; i < inputList.size(); i += partitionSize) {
+            partitions.add(inputList.subList(i, Math.min(i + partitionSize, inputList.size())));
+        }
+        return partitions
+    }
+
 }


### PR DESCRIPTION
Fixes #354 by breaking large delete statements into smaller ones.  This means that the error: `Tried to send an out-of-range integer as a 2-byte value` doesn't get thrown and the database connection doesn't get closed.  Some details here: https://github.com/pgjdbc/pgjdbc/issues/1311.