### PR TITLE
Add new ApiProperty to disable revealing exceptions in error messages

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyService.groovy
@@ -51,11 +51,11 @@ class ApiPropertyService {
         apiProperty.delete(flush: true)
     }
 
-    ApiProperty findByKey(String key) {
+    static ApiProperty findByKey(String key) {
         ApiProperty.findByKey(key)
     }
 
-    ApiProperty findByApiPropertyEnum(ApiPropertyEnum key) {
+    static ApiProperty findByApiPropertyEnum(ApiPropertyEnum key) {
         findByKey(key.key)
     }
 

--- a/mdm-core/grails-app/views/error.gson
+++ b/mdm-core/grails-app/views/error.gson
@@ -1,4 +1,6 @@
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiException
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyEnum
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyService
 
 import grails.util.Environment
 import grails.util.Holders
@@ -19,6 +21,7 @@ model {
 
 Throwable extractedException = findCoreException(exception)
 HttpStatus determinedHttpStatus = getExceptionStatus(extractedException) ?: httpStatus ?: INTERNAL_SERVER_ERROR
+boolean showExceptions = getShowExceptions()
 
 if (!errors) {
     if (extractedException instanceof ValidationException) errors = ((ValidationException) extractedException).errors
@@ -35,8 +38,10 @@ json {
     status determinedHttpStatus.value()
     reason determinedHttpStatus.reasonPhrase
 
-    errorCode errorCode ?: getExceptionErrorCode(extractedException) ?: 'JS--'
-    message message ?: getExceptionMessage(extractedException) ?: 'JS-- - Unknown error'
+    if (showExceptions) {
+        errorCode errorCode ?: getExceptionErrorCode(extractedException) ?: 'JS--'
+        message message ?: getExceptionMessage(extractedException) ?: 'JS-- - Unknown error'
+    }
     path request.getUri()
 
     if (Environment.current != Environment.PRODUCTION) environment Environment.current
@@ -47,7 +52,7 @@ json {
     if (errors) validationErrors tmpl.'/errors/errors'(errors)
     else if (errorsList) validationErrors tmpl.'/errors/errors'(errorsList)
 
-    else if (determinedHttpStatus != BAD_REQUEST) {
+    else if (showExceptions && determinedHttpStatus != BAD_REQUEST) {
         // SQL Exceptions are iterable so we need to only show the first
         if (extractedException instanceof SQLException) {
             exception tmpl.'/errors/exception'(exception: extractedException)
@@ -101,4 +106,8 @@ static HttpStatus getExceptionStatus(Throwable exception) {
     } catch (NullPointerException ignored) {
         return null
     }
+}
+
+static boolean getShowExceptions() {
+    !ApiPropertyService.findByApiPropertyEnum(ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS)?.value?.toBoolean()
 }

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -102,21 +102,21 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
     Map getValidJsonCollection() {
         [count: 2,
          items: [
-                 [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbe',
-                  key     : 'functional.test.key.one',
-                  value   : 'Some random thing1',
-                  category: 'Functional Test',
-                  publiclyVisible: false,
-                  lastUpdatedBy: 'hello@example.com',
-                  lastUpdated: '2021-10-27T11:02:32.682Z'],
-                 [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbf',
-                  key     : 'functional.test.key.two',
-                  value   : 'Some random thing2',
-                  category: 'Functional Test',
-                  publiclyVisible: false,
-                  lastUpdatedBy: 'hello@example.com',
-                  lastUpdated: '2021-10-27T11:02:32.682Z']
-                ]
+             [id             : 'e2b3398f-f3e5-4d70-8793-25526bbe0dbe',
+              key            : 'functional.test.key.one',
+              value          : 'Some random thing1',
+              category       : 'Functional Test',
+              publiclyVisible: false,
+              lastUpdatedBy  : 'hello@example.com',
+              lastUpdated    : '2021-10-27T11:02:32.682Z'],
+             [id             : 'e2b3398f-f3e5-4d70-8793-25526bbe0dbf',
+              key            : 'functional.test.key.two',
+              value          : 'Some random thing2',
+              category       : 'Functional Test',
+              publiclyVisible: false,
+              lastUpdatedBy  : 'hello@example.com',
+              lastUpdated    : '2021-10-27T11:02:32.682Z']
+         ]
         ]
     }
 
@@ -124,20 +124,20 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
     Map getInvalidJsonCollection() {
         [count: 2,
          items: [
-             [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbe',
-              key     : 'functional.test.key.ten',
-              value   : 'Some random thing1',
-              category: 'Functional Test',
+             [id             : 'e2b3398f-f3e5-4d70-8793-25526bbe0dbe',
+              key            : 'functional.test.key.ten',
+              value          : 'Some random thing1',
+              category       : 'Functional Test',
               publiclyVisible: false,
-              lastUpdatedBy: 'hello@example.com',
-              lastUpdated: '2021-10-27T11:02:32.682Z'],
-             [id: 'e2b3398f-f3e5-4d70-8793-25526bbe0dbf',
-              key     : 'functional.test.key.ten',
-              value   : 'Some random thing2',
-              category: 'Functional Test',
+              lastUpdatedBy  : 'hello@example.com',
+              lastUpdated    : '2021-10-27T11:02:32.682Z'],
+             [id             : 'e2b3398f-f3e5-4d70-8793-25526bbe0dbf',
+              key            : 'functional.test.key.ten',
+              value          : 'Some random thing2',
+              category       : 'Functional Test',
               publiclyVisible: false,
-              lastUpdatedBy: 'hello@example.com',
-              lastUpdated: '2021-10-27T11:02:32.682Z']
+              lastUpdatedBy  : 'hello@example.com',
+              lastUpdated    : '2021-10-27T11:02:32.682Z']
          ]
         ]
     }
@@ -223,10 +223,13 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         assert responseBody().count == 15
 
         ApiPropertyEnum.values()
-            .findAll {!(it in [ApiPropertyEnum.SITE_URL,
-                               ApiPropertyEnum.EMAIL_FROM_ADDRESS,
-                               ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
-                               ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER])}
+            .findAll {
+                !(it in [ApiPropertyEnum.SITE_URL,
+                         ApiPropertyEnum.EMAIL_FROM_ADDRESS,
+                         ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
+                         ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
+                         ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS])
+            }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", responseBody().items.any {
                     it.key == ape.key &&
@@ -256,7 +259,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 }'''
     }
 
-    def 'check public api property endpoint with no additional properties'(){
+    def 'check public api property endpoint with no additional properties'() {
         when:
         GET('properties', MAP_ARG, true)
 
@@ -266,11 +269,11 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 
     }
 
-    def 'check public api property endpoint with public additional property'(){
+    def 'check public api property endpoint with public additional property'() {
         given:
         Map publicProperty = getValidJson()
         publicProperty.publiclyVisible = true
-        POST('',publicProperty)
+        POST('', publicProperty)
         verifyResponse(HttpStatus.CREATED, response)
         assert responseBody().publiclyVisible
         String id = responseBody().id
@@ -315,7 +318,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         assert response.status() == HttpStatus.NO_CONTENT
     }
 
-    void 'check index and show endpoints for CSV'(){
+    void 'check index and show endpoints for CSV'() {
         when:
         GET('?format=csv', STRING_ARG)
 
@@ -338,7 +341,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         assert lines2[0] == 'id,key,value,category,publiclyVisible,lastUpdatedBy,createdBy,lastUpdated'
     }
 
-    void 'check index endpoint for XML'(){
+    void 'check index endpoint for XML'() {
         given:
         Path expectedIndexPath = xmlResourcesPath.resolve('apiProperties.xml')
         if (!Files.exists(expectedIndexPath)) {
@@ -355,7 +358,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         assert compareXml(expectedIndexXml, actualIndexXml)
     }
 
-    void 'check show endpoint for XML'(){
+    void 'check show endpoint for XML'() {
         given:
         Path expectedShowPath = xmlResourcesPath.resolve('apiProperty.xml')
         if (!Files.exists(expectedShowPath)) {

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyEnum.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyEnum.groovy
@@ -39,7 +39,8 @@ enum ApiPropertyEnum {
     EMAIL_PASSWORD_RESET_SUBJECT('email.password_reset.subject'),
     EMAIL_PASSWORD_RESET_BODY('email.password_reset.body'),
     SECURITY_RESTRICT_ROOT_FOLDER('security.restrict.root.folder'),
-    SECURITY_RESTRICT_CLASSIFIER_CREATE('security.restrict.classifier.create')
+    SECURITY_RESTRICT_CLASSIFIER_CREATE('security.restrict.classifier.create'),
+    SECURITY_HIDE_EXCEPTIONS('security.hide.exception')
 
     String key
 

--- a/mdm-security/grails-app/views/error.gson
+++ b/mdm-security/grails-app/views/error.gson
@@ -1,4 +1,6 @@
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiException
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyEnum
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyService
 
 import grails.util.Environment
 import grails.util.Holders
@@ -19,6 +21,7 @@ model {
 
 Throwable extractedException = findCoreException(exception)
 HttpStatus determinedHttpStatus = getExceptionStatus(extractedException) ?: httpStatus ?: INTERNAL_SERVER_ERROR
+boolean showExceptions = getShowExceptions()
 
 if (!errors) {
     if (extractedException instanceof ValidationException) errors = ((ValidationException) extractedException).errors
@@ -35,8 +38,10 @@ json {
     status determinedHttpStatus.value()
     reason determinedHttpStatus.reasonPhrase
 
-    errorCode errorCode ?: getExceptionErrorCode(extractedException) ?: 'JS--'
-    message message ?: getExceptionMessage(extractedException) ?: 'JS-- - Unknown error'
+    if (showExceptions) {
+        errorCode errorCode ?: getExceptionErrorCode(extractedException) ?: 'JS--'
+        message message ?: getExceptionMessage(extractedException) ?: 'JS-- - Unknown error'
+    }
     path request.getUri()
 
     if (Environment.current != Environment.PRODUCTION) environment Environment.current
@@ -47,7 +52,7 @@ json {
     if (errors) validationErrors tmpl.'/errors/errors'(errors)
     else if (errorsList) validationErrors tmpl.'/errors/errors'(errorsList)
 
-    else if (determinedHttpStatus != BAD_REQUEST) {
+    else if (showExceptions && determinedHttpStatus != BAD_REQUEST) {
         // SQL Exceptions are iterable so we need to only show the first
         if (extractedException instanceof SQLException) {
             exception tmpl.'/errors/exception'(exception: extractedException)
@@ -101,4 +106,8 @@ static HttpStatus getExceptionStatus(Throwable exception) {
     } catch (NullPointerException ignored) {
         return null
     }
+}
+
+static boolean getShowExceptions() {
+    !ApiPropertyService.findByApiPropertyEnum(ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS)?.value?.toBoolean()
 }

--- a/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserControllerSpec.groovy
+++ b/mdm-security/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/security/CatalogueUserControllerSpec.groovy
@@ -17,6 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.security
 
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
 import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyService
 import uk.ac.ox.softeng.maurodatamapper.core.bootstrap.StandardEmailAddress
 import uk.ac.ox.softeng.maurodatamapper.core.email.EmailService
@@ -76,6 +77,7 @@ class CatalogueUserControllerSpec extends ResourceControllerSpec<CatalogueUser> 
 
         mockDomain(Edit)
         mockDomain(UserGroup)
+        mockDomain(ApiProperty)
         group = new UserGroup(name: 'testgroup', createdBy: StandardEmailAddress.UNIT_TEST).addToGroupMembers(admin)
         checkAndSave(group)
 
@@ -106,9 +108,7 @@ class CatalogueUserControllerSpec extends ResourceControllerSpec<CatalogueUser> 
             (isR2_3 ? 1 : 0) * sendEmailToUser(_, EMAIL_SELF_REGISTER_SUBJECT, EMAIL_SELF_REGISTER_BODY, _)
         }
 
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            (isR2_3 ? 1 : 0) * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
 
         givenParameters()
     }
@@ -613,9 +613,7 @@ json {
         controller.emailService = Mock(EmailService) {
             (expectedStatus == CREATED ? 1 : 0) * sendEmailToUser(_, EMAIL_ADMIN_REGISTER_SUBJECT, EMAIL_ADMIN_REGISTER_BODY, _)
         }
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            (expectedStatus == CREATED ? 1 : 0) * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         request.method = 'POST'
 
         when:
@@ -800,9 +798,7 @@ json {
             (expectedStatus == OK ? 1 : 0) * sendEmailToUser(_, EMAIL_ADMIN_CONFIRM_REGISTRATION_SUBJECT,
                                                              EMAIL_ADMIN_CONFIRM_REGISTRATION_BODY, _)
         }
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            (expectedStatus == OK ? 1 : 0) * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         request.method = 'PUT'
 
         when:
@@ -902,9 +898,7 @@ json {
 
     void 'test reset password with a null token after token requested'() {
         given:
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            1 * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         controller.emailService = Mock(EmailService) {
             1 * sendEmailToUser(_, EMAIL_FORGOTTEN_PASSWORD_SUBJECT,
                                 EMAIL_FORGOTTEN_PASSWORD_BODY, _, _)
@@ -991,9 +985,7 @@ json {
 
     void 'test reset password with the user after reset link sent'() {
         given:
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            1 * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         controller.emailService = Mock(EmailService) {
             1 * sendEmailToUser(_, EMAIL_FORGOTTEN_PASSWORD_SUBJECT,
                                 EMAIL_FORGOTTEN_PASSWORD_BODY, _, _)
@@ -1053,9 +1045,7 @@ json {
 
     void 'test reset password with the user logging in after reset link sent'() {
         given:
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            1 * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         controller.emailService = Mock(EmailService) {
             1 * sendEmailToUser(_, EMAIL_FORGOTTEN_PASSWORD_SUBJECT,
                                 EMAIL_FORGOTTEN_PASSWORD_BODY, _, _)
@@ -1147,9 +1137,7 @@ json {
     void 'test admin password reset for user'() {
 
         given:
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            1 * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         controller.emailService = Mock(EmailService) {
             1 * sendEmailToUser(_, EMAIL_PASSWORD_RESET_SUBJECT, EMAIL_PASSWORD_RESET_BODY, _)
         }
@@ -1210,9 +1198,7 @@ json {
         controller.emailService = Mock(EmailService) {
             1 * sendEmailToUser(_, EMAIL_ADMIN_REGISTER_SUBJECT, EMAIL_ADMIN_REGISTER_BODY, _)
         }
-        controller.apiPropertyService = Mock(ApiPropertyService) {
-            1 * findByApiPropertyEnum(SITE_URL) >> null
-        }
+        controller.apiPropertyService = Mock(ApiPropertyService)
         request.method = 'POST'
 
         when:

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -112,12 +112,12 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
     Map getValidJsonCollection() {
         [count: 2,
          items: [
-                 [key     : 'functional.test.key.one',
-                  value   : 'Some random thing1',
-                  category: 'Functional Test'],
-                 [key     : 'functional.test.key.two',
-                  value   : 'Some random thing2',
-                  category: 'Functional Test']
+             [key     : 'functional.test.key.one',
+              value   : 'Some random thing1',
+              category: 'Functional Test'],
+             [key     : 'functional.test.key.two',
+              value   : 'Some random thing2',
+              category: 'Functional Test']
          ]
         ]
     }
@@ -217,9 +217,12 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         then: 'The response is correct'
         verifyResponse OK, response
         ApiPropertyEnum.values()
-            .findAll {!(it in [ApiPropertyEnum.SITE_URL,
-                               ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
-                               ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER])}
+            .findAll {
+                !(it in [ApiPropertyEnum.SITE_URL,
+                         ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
+                         ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
+                         ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS])
+            }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", responseBody().items.any {
                     it.key == ape.key &&
@@ -233,9 +236,12 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
         then: 'The response is correct'
         verifyResponse OK, jsonCapableResponse
         ApiPropertyEnum.values()
-            .findAll {!(it in [ApiPropertyEnum.SITE_URL,
-                               ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
-                               ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER])}
+            .findAll {
+                !(it in [ApiPropertyEnum.SITE_URL,
+                         ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
+                         ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
+                         ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS])
+            }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", jsonCapableResponse.body().toString().contains("<key>${ape.key}</key>")
             }
@@ -254,9 +260,12 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
 
         and:
         ApiPropertyEnum.values()
-            .findAll {!(it in [ApiPropertyEnum.SITE_URL,
-                               ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
-                               ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER])}
+            .findAll {
+                !(it in [ApiPropertyEnum.SITE_URL,
+                         ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
+                         ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
+                         ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS])
+            }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", jsonCapableResponse.body().toString().contains("${ape.key},")
             }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/error/ErrorFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/error/ErrorFunctionalSpec.groovy
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.ac.ox.softeng.maurodatamapper.testing.functional.core.error
+
+import uk.ac.ox.softeng.maurodatamapper.testing.functional.FunctionalSpec
+
+import grails.testing.mixin.integration.Integration
+import groovy.util.logging.Slf4j
+import spock.lang.Shared
+
+import static io.micronaut.http.HttpStatus.NO_CONTENT
+import static io.micronaut.http.HttpStatus.OK
+import static io.micronaut.http.HttpStatus.CREATED
+import static io.micronaut.http.HttpStatus.INTERNAL_SERVER_ERROR
+
+@Integration
+@Slf4j
+class ErrorFunctionalSpec extends FunctionalSpec {
+
+    @Shared String errorApiKeyId
+
+    String getResourcePath() {
+        ''
+    }
+
+    void 'AuthError01 : Login with invalid request gives stacktrace'() {
+        when:
+        POST('authentication/login', ' ', MAP_ARG, true)
+
+        then:
+        verifyResponse(INTERNAL_SERVER_ERROR, response)
+        responseBody().status == 500
+        responseBody().reason == 'Internal Server Error'
+
+        and: 'stacktrace info is shown'
+        responseBody().errorCode == 'UEX--'
+        responseBody().message
+        responseBody().exception
+        responseBody().exception.message
+        responseBody().exception.stacktrace.size() > 0
+    }
+
+    void 'AuthError02 : Login with invalid request and stacktrace disabled'() {
+        given:
+        loginAdmin()
+        POST('admin/properties', [key: 'security.hide.exception', value: 'true', publiclyVisible: false, category: 'security'])
+        verifyResponse(CREATED, response)
+        errorApiKeyId = responseBody().id
+        logout()
+
+        when:
+        POST('authentication/login', ' ', MAP_ARG, true)
+
+        then:
+        verifyResponse(INTERNAL_SERVER_ERROR, response)
+        responseBody().status == 500
+        responseBody().reason == 'Internal Server Error'
+
+        and: 'stacktrace info is not shown'
+        !responseBody().errorCode
+        !responseBody().message
+        !responseBody().exception
+    }
+
+    void 'AuthError03 : Login with invalid request and stacktrace re-enabled'() {
+        given:
+        loginAdmin()
+        PUT("admin/properties/$errorApiKeyId", [value: 'false'])
+        verifyResponse(OK, response)
+        logout()
+
+        when:
+        POST('authentication/login', ' ', MAP_ARG, true)
+
+        then:
+        verifyResponse(INTERNAL_SERVER_ERROR, response)
+        responseBody().status == 500
+        responseBody().reason == 'Internal Server Error'
+
+        and: 'stacktrace info is shown'
+        responseBody().errorCode == 'UEX--'
+        responseBody().message
+        responseBody().exception
+        responseBody().exception.message
+        responseBody().exception.stacktrace.size() > 0
+
+        when:
+        loginAdmin()
+        DELETE("admin/properties/$errorApiKeyId")
+        verifyResponse(NO_CONTENT, response)
+        logout()
+        POST('authentication/login', ' ', MAP_ARG, true)
+
+        then:
+        verifyResponse(INTERNAL_SERVER_ERROR, response)
+        responseBody().status == 500
+        responseBody().reason == 'Internal Server Error'
+
+        and: 'stacktrace info is shown'
+        responseBody().errorCode == 'UEX--'
+        responseBody().message
+        responseBody().exception
+        responseBody().exception.message
+        responseBody().exception.stacktrace.size() > 0
+    }
+}


### PR DESCRIPTION
Resolves #381.

If ApiProperty `security.hide.exception` is present and set to true, exception stack traces, internal error codes and error messages are hidden. If not set, exceptions are shown as normal. This setting doesn't affect Grails validation errors, for example "field is required" messages.