### PR TITLE
Add search type option to metadata search endpoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -527,7 +527,7 @@ pipeline {
             jacoco classPattern: '**/build/classes', execPattern: '**/build/jacoco/*.exec', sourceInclusionPattern: '**/*.java,**/*.groovy',
                    sourcePattern: '**/src/main/groovy,**/grails-app/controllers,**/grails-app/domain,**/grails-app/services,**/grails-app/utils'
             archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.log'
-            zulipNotification(topic: 'mdm-core')
+//             zulipNotification(topic: 'mdm-core')
         }
     }
 }


### PR DESCRIPTION
When searching on metadata values, allow specifying a criteria `type`. The default is `phrase`, the existing search type. The type `query` is similar to the default search on Catalogue Items. The `contains` type searches for terms that contain all of the search terms.

For an example item with metadata defined:
```json
{
    "namespace": "ns",
    "key": "key",
    "value": "ABC_DEF"
}
```

The following search (POSTed to `/api/catalogueItems/search`) will find the item:

```json
{
    "profileFields": [
        {
            "metadataNamespace": "ns",
            "metadataPropertyName": "key",
            "filterTerm": "de",
            "type": "contains"
        }
    ]
}
```

The following searches won't find the item:

```javascript
{
    "profileFields": [
        {
            "metadataNamespace": "ns",
            "metadataPropertyName": "key",
            "filterTerm": "DEF",
            "type": "phrase" // won't find item as `value` tokens not split on `_`
        }
    ]
}
```

```javascript
{
    "profileFields": [
        {
            "metadataNamespace": "ns",
            "metadataPropertyName": "key",
            "filterTerm": "DEF",
            "type": "query" // won't find item as `value` tokens not split on `_`
        }
    ]
}
```

Resolves #399.
