### PR TITLE
Batch potentially large SQL operations

### DIFF
--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/util/Utils.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/util/Utils.groovy
@@ -22,6 +22,8 @@ import grails.config.Config
 import grails.core.GrailsApplication
 import grails.core.GrailsClass
 import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 import groovy.util.logging.Slf4j
 import org.grails.core.artefact.DomainClassArtefactHandler
 import org.slf4j.Logger
@@ -226,5 +228,20 @@ class Utils {
         }
         return partitions
     }
+
+    public final static Integer BATCH_SIZE = 10000
+
+/*
+    This method executes a closure in batches to ensure that we don't inadvertently call with too many ids and
+    break Postgres: Tried to send an out-of-range integer as a 2-byte value
+ */
+
+    static void executeInBatches(List items, @ClosureParams(value= SimpleType.class, options="java.util.List") Closure closure) {
+        List<List> partitions = partition(items, BATCH_SIZE)
+        partitions.each { partition ->
+            closure.call(partition)
+        }
+    }
+
 
 }

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/BreadcrumbTreeService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/facet/BreadcrumbTreeService.groovy
@@ -56,12 +56,13 @@ class BreadcrumbTreeService {
     void deleteAllByDomainIds(Set<UUID> domainIds) {
         List<String> idPrefixesToDelete = domainIds.collect {it.toString() + '|'}
 
-        sessionFactory.currentSession
-            .createSQLQuery('DELETE FROM core.breadcrumb_tree WHERE SUBSTR(tree_string, 1, :id_length+1) IN :id_prefixes')
-            .setParameter('id_length', Utils.UUID_CHARACTER_LENGTH)
-            .setParameterList('id_prefixes', idPrefixesToDelete)
-            .executeUpdate()
-
+        Utils.executeInBatches(idPrefixesToDelete, { ids ->
+            sessionFactory.currentSession
+                    .createSQLQuery('DELETE FROM core.breadcrumb_tree WHERE SUBSTR(tree_string, 1, :id_length+1) IN :id_prefixes')
+                    .setParameter('id_length', Utils.UUID_CHARACTER_LENGTH)
+                    .setParameterList('id_prefixes', ids)
+                    .executeUpdate()
+        })
         log.trace('BreadcrumbTrees removed')
     }
 }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/service/MultiFacetAwareService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/service/MultiFacetAwareService.groovy
@@ -168,12 +168,15 @@ trait MultiFacetAwareService<K extends MultiFacetAware> {
     }
 
     void deleteAllFacetsByMultiFacetAwareIds(List<UUID> multiFacetAwareIds, String queryToDeleteFromJoinTable) {
-        sessionFactory.currentSession
-            .createSQLQuery(queryToDeleteFromJoinTable)
-            .setParameter('ids', multiFacetAwareIds)
-            .executeUpdate()
 
-        deleteAllFacetDataByMultiFacetAwareIds multiFacetAwareIds
+        Utils.executeInBatches(multiFacetAwareIds, {ids ->
+            sessionFactory.currentSession
+                .createSQLQuery(queryToDeleteFromJoinTable)
+                .setParameter('ids', ids)
+                .executeUpdate()
+
+            deleteAllFacetDataByMultiFacetAwareIds ids
+        })
     }
 
     void deleteAllFacetDataByMultiFacetAwareIds(List<UUID> multiFacetAwareIds) {

--- a/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/DataFlowService.groovy
+++ b/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/DataFlowService.groovy
@@ -105,11 +105,13 @@ class DataFlowService extends ModelItemService<DataFlow> {
                                                 'delete from dataflow.join_dataflow_to_facet where dataflow_id in :ids')
 
             log.trace('Removing {} DataFlows', dataFlowIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM dataflow.data_flow WHERE source_id in :ids OR target_id in :ids')
-                .setParameter('ids', modelIds)
-                .executeUpdate()
 
+            Utils.executeInBatches(modelIds, { ids ->
+                sessionFactory.currentSession
+                        .createSQLQuery('DELETE FROM dataflow.data_flow WHERE source_id in :ids OR target_id in :ids')
+                        .setParameter('ids', ids)
+                        .executeUpdate()
+            })
             log.trace('DataFlows removed')
         }
     }

--- a/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentService.groovy
+++ b/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataClassComponentService.groovy
@@ -113,25 +113,30 @@ class DataClassComponentService extends ModelItemService<DataClassComponent> {
             dataElementComponentService.deleteAllByModelIds(modelIds)
 
             log.trace('Removing links to DataClasses in {} DataClassComponents', dataClassComponentIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('delete from dataflow.join_data_class_component_to_source_data_class where data_class_component_id in :ids')
-                .setParameter('ids', dataClassComponentIds)
-                .executeUpdate()
+            Utils.executeInBatches(dataClassComponentIds, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('delete from dataflow.join_data_class_component_to_source_data_class where data_class_component_id in :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
 
-            sessionFactory.currentSession
-                .createSQLQuery('delete from dataflow.join_data_class_component_to_target_data_class where data_class_component_id in :ids')
-                .setParameter('ids', dataClassComponentIds)
-                .executeUpdate()
+                sessionFactory.currentSession
+                    .createSQLQuery('delete from dataflow.join_data_class_component_to_target_data_class where data_class_component_id in :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('Removing facets for {} DataClassComponents', dataClassComponentIds.size())
             deleteAllFacetsByMultiFacetAwareIds(dataClassComponentIds,
                                                 'delete from dataflow.join_dataclasscomponent_to_facet where dataclasscomponent_id in :ids')
 
             log.trace('Removing {} DataClassComponents', dataClassComponentIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('delete from dataflow.data_class_component where id in :ids')
-                .setParameter('ids', dataClassComponentIds)
-                .executeUpdate()
+
+            Utils.executeInBatches(dataClassComponentIds, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('delete from dataflow.data_class_component where id in :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('DataClassComponents removed')
         }

--- a/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentService.groovy
+++ b/mdm-plugin-dataflow/grails-app/services/uk/ac/ox/softeng/maurodatamapper/dataflow/component/DataElementComponentService.groovy
@@ -106,25 +106,29 @@ class DataElementComponentService extends ModelItemService<DataElementComponent>
         if (dataElementComponentIds) {
 
             log.trace('Removing links to DataElements in {} DataElementComponents', dataElementComponentIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('delete from dataflow.join_data_element_component_to_source_data_element where data_element_component_id in :ids')
-                .setParameter('ids', dataElementComponentIds)
-                .executeUpdate()
+            Utils.executeInBatches(dataElementComponentIds, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('delete from dataflow.join_data_element_component_to_source_data_element where data_element_component_id in :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
 
-            sessionFactory.currentSession
-                .createSQLQuery('delete from dataflow.join_data_element_component_to_target_data_element where data_element_component_id in :ids')
-                .setParameter('ids', dataElementComponentIds)
-                .executeUpdate()
+                sessionFactory.currentSession
+                    .createSQLQuery('delete from dataflow.join_data_element_component_to_target_data_element where data_element_component_id in :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('Removing facets for {} DataElementComponents', dataElementComponentIds.size())
             deleteAllFacetsByMultiFacetAwareIds(dataElementComponentIds,
                                                 'delete from dataflow.join_dataelementcomponent_to_facet where dataelementcomponent_id in :ids')
 
             log.trace('Removing {} DataElementComponents', dataElementComponentIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('delete from dataflow.data_element_component where id in :ids')
-                .setParameter('ids', dataElementComponentIds)
-                .executeUpdate()
+            Utils.executeInBatches(dataElementComponentIds, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('delete from dataflow.data_element_component where id in :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('DataElementComponents removed')
         }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -481,10 +481,12 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
         deleteAllFacetsByMultiFacetAwareIds(idsToDelete.toList(), 'delete from datamodel.join_datamodel_to_facet where datamodel_id in :ids')
 
         log.trace('Content removed')
-        sessionFactory.currentSession
-            .createSQLQuery('DELETE FROM datamodel.data_model WHERE id IN :ids')
-            .setParameter('ids', idsToDelete)
-            .executeUpdate()
+        Utils.executeInBatches(idsToDelete as List, {ids ->
+            sessionFactory.currentSession
+                .createSQLQuery('DELETE FROM datamodel.data_model WHERE id IN :ids')
+                .setParameter('ids', ids)
+                .executeUpdate()
+        })
 
         log.trace('DataModels removed')
 

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataClassService.groovy
@@ -215,10 +215,13 @@ class DataClassService extends ModelItemService<DataClass> implements SummaryMet
                                                 'delete from datamodel.join_dataclass_to_facet where dataclass_id in :ids')
 
             log.trace('Removing {} DataClasses', dataClassIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM datamodel.data_class WHERE data_model_id IN :ids')
-                .setParameter('ids', dataModelIds)
-                .executeUpdate()
+
+            Utils.executeInBatches(dataModelIds as List, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('DELETE FROM datamodel.data_class WHERE data_model_id IN :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('DataClasses removed')
         }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -117,11 +117,11 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
 
         if (dataElementIds) {
             log.trace('Removing facets for {} DataElements', ids.size())
-            deleteAllFacetsByMultiFacetAwareIds(ids,
+            deleteAllFacetsByMultiFacetAwareIds(dataElementIds,
                                             'delete from datamodel.join_dataelement_to_facet where dataelement_id in :ids')
 
 
-            log.trace('Removing {} DataElements', ids.size())
+            log.trace('Removing {} DataElements', dataElementIds.size())
             Utils.executeInBatches(dataElementIds, {ids ->
                 sessionFactory.currentSession
                     .createSQLQuery('DELETE FROM datamodel.data_element WHERE id IN :ids')

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -116,20 +116,18 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
         }.id().list() as List<UUID>
 
         if (dataElementIds) {
-            List<List<UUID>> batches = Utils.partition(dataElementIds, BATCH_SIZE)
-            batches.each { ids ->
+            log.trace('Removing facets for {} DataElements', ids.size())
+            deleteAllFacetsByMultiFacetAwareIds(ids,
+                                            'delete from datamodel.join_dataelement_to_facet where dataelement_id in :ids')
 
-                log.trace('Removing facets for {} DataElements', ids.size())
 
-                deleteAllFacetsByMultiFacetAwareIds(ids,
-                                                    'delete from datamodel.join_dataelement_to_facet where dataelement_id in :ids')
-
-                log.trace('Removing {} DataElements', ids.size())
+            log.trace('Removing {} DataElements', ids.size())
+            Utils.executeInBatches(dataElementIds, {ids ->
                 sessionFactory.currentSession
                     .createSQLQuery('DELETE FROM datamodel.data_element WHERE id IN :ids')
                     .setParameter('ids', ids)
                     .executeUpdate()
-            }
+            })
         }
         log.trace('DataElements removed')
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/DataElementService.groovy
@@ -116,7 +116,7 @@ class DataElementService extends ModelItemService<DataElement> implements Summar
         }.id().list() as List<UUID>
 
         if (dataElementIds) {
-            log.trace('Removing facets for {} DataElements', ids.size())
+            log.trace('Removing facets for {} DataElements', dataElementIds.size())
             deleteAllFacetsByMultiFacetAwareIds(dataElementIds,
                                             'delete from datamodel.join_dataelement_to_facet where dataelement_id in :ids')
 

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/DataTypeService.groovy
@@ -133,10 +133,13 @@ class DataTypeService extends ModelItemService<DataType> implements DefaultDataT
 
             log.trace('Removing {} DataTypes', dataTypeIds.size())
 
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM datamodel.data_type WHERE data_model_id IN :ids')
-                .setParameter('ids', dataModelIds)
-                .executeUpdate()
+            Utils.executeInBatches(dataModelIds as List, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('DELETE FROM datamodel.data_type WHERE data_model_id IN :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+
+            })
 
             log.trace('DataTypes removed')
         }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ReferenceTypeService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/ReferenceTypeService.groovy
@@ -98,10 +98,12 @@ class ReferenceTypeService extends ModelItemService<ReferenceType> implements Su
                                                 'delete from datamodel.join_datatype_to_facet where datatype_id in :ids')
 
             log.trace('Removing {} ReferenceTypes', referenceTypeIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM datamodel.data_type WHERE id IN :ids')
-                .setParameter('ids', referenceTypeIds)
-                .executeUpdate()
+            Utils.executeInBatches(referenceTypeIds, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('DELETE FROM datamodel.data_type WHERE id IN :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('ReferenceTypes removed')
         }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/item/datatype/enumeration/EnumerationValueService.groovy
@@ -91,11 +91,13 @@ class EnumerationValueService extends ModelItemService<EnumerationValue> impleme
                                                 'delete from datamodel.join_enumerationvalue_to_facet where enumerationvalue_id in :ids')
 
             log.trace('Removing {} EnumerationValues', enumerationValueIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM datamodel.enumeration_value WHERE id IN :ids')
-                .setParameter('ids', enumerationValueIds)
-                .executeUpdate()
 
+            Utils.executeInBatches(enumerationValueIds, {ids ->
+                sessionFactory.currentSession
+                        .createSQLQuery('DELETE FROM datamodel.enumeration_value WHERE id IN :ids')
+                        .setParameter('ids', ids)
+                        .executeUpdate()
+            })
             log.trace('EnumerationValues removed')
         }
     }

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
@@ -357,10 +357,12 @@ class TerminologyService extends ModelService<Terminology> {
         deleteAllFacetsByMultiFacetAwareIds(idsToDelete.toList(), 'delete from terminology.join_terminology_to_facet where terminology_id in :ids')
 
         log.trace('Content removed')
-        sessionFactory.currentSession
-            .createSQLQuery('DELETE FROM terminology.terminology WHERE id IN :ids')
-            .setParameter('ids', idsToDelete)
-            .executeUpdate()
+        Utils.executeInBatches(idsToDelete as List, {ids ->
+            sessionFactory.currentSession
+                .createSQLQuery('DELETE FROM terminology.terminology WHERE id IN :ids')
+                .setParameter('ids', ids)
+                .executeUpdate()
+        })
 
         log.trace('Terminologies removed')
 

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermRelationshipTypeService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/TermRelationshipTypeService.groovy
@@ -141,10 +141,12 @@ class TermRelationshipTypeService extends ModelItemService<TermRelationshipType>
                                                 'delete from terminology.join_termrelationshiptype_to_facet where termrelationshiptype_id in :ids')
 
             log.trace('Removing {} TermRelationshipTypes', termRelationshipTypeIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM terminology.term_relationship_type WHERE terminology_id IN :ids')
-                .setParameter('ids', modelIds)
-                .executeUpdate()
+            Utils.executeInBatches(modelIds as List, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('DELETE FROM terminology.term_relationship_type WHERE terminology_id IN :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('TermRelationshipTypes removed')
 

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/item/term/TermRelationshipService.groovy
@@ -96,10 +96,12 @@ class TermRelationshipService extends ModelItemService<TermRelationship> {
                                                 'delete from terminology.join_term_to_facet where term_id in :ids')
 
             log.trace('Removing {} TermRelationships', termRelationshipIds.size())
-            sessionFactory.currentSession
-                .createSQLQuery('DELETE FROM terminology.term_relationship WHERE id IN :ids')
-                .setParameter('ids', termRelationshipIds)
-                .executeUpdate()
+            Utils.executeInBatches(termRelationshipIds, {ids ->
+                sessionFactory.currentSession
+                    .createSQLQuery('DELETE FROM terminology.term_relationship WHERE id IN :ids')
+                    .setParameter('ids', ids)
+                    .executeUpdate()
+            })
 
             log.trace('TermRelationships removed')
         }


### PR DESCRIPTION
Fixes #404 
When a large list of ids is passed to SQL as part of a delete statement, the Postgres connection can be closed if the total is more than 2-bytes (65536).  I've added a closure that batches operations on large lists, and applied it everywhere I can find a `DELETE FROM...WHERE...IN`... statement.