### PR TITLE
gh-411 - Fix migration error

### DIFF
--- a/mdm-security/grails-app/conf/db/migration/security/V1_2_0__security.sql
+++ b/mdm-security/grails-app/conf/db/migration/security/V1_2_0__security.sql
@@ -97,7 +97,7 @@ CREATE INDEX userGroup_created_by_idx ON security.user_group(created_by);
 ALTER TABLE IF EXISTS security.user_group
     ADD CONSTRAINT UK_kas9w8ead0ska5n3csefp2bpp UNIQUE (name);
 ALTER TABLE IF EXISTS security.catalogue_user
-    ADD CONSTRAINT FKrvd4rw9ujjx4ca9b4dkps3jyt FOREIGN KEY (profile_picture_id) REFERENCES core.user_image_file;
+    ADD CONSTRAINT FKrvd4rw9ujjx4ca9b4dkps3jyt FOREIGN KEY (profile_picture_id) REFERENCES core.image_file;
 ALTER TABLE IF EXISTS security.group_role
     ADD CONSTRAINT FK9y8ew5lpksnila4b7g56xcl1n FOREIGN KEY (parent_id) REFERENCES security.group_role;
 ALTER TABLE IF EXISTS security.join_catalogue_user_to_user_group

--- a/mdm-security/grails-app/conf/db/migration/security/beforeValidate.sql
+++ b/mdm-security/grails-app/conf/db/migration/security/beforeValidate.sql
@@ -2,3 +2,8 @@ UPDATE security.flyway_schema_history
 SET checksum = -1673556944
 WHERE version = '2.1.0' AND
       checksum = 1304140234;
+
+UPDATE security.flyway_schema_history
+SET checksum = -666600599
+WHERE version = '1.2.0' AND
+      checksum = -399282874;


### PR DESCRIPTION
Update migration script fixes the issue when working with a fresh database. 
Also updated the security projects beforeValidate.sql script to ensure it works with existing databases.