### PR TITLE
Fix memory leak when importing multiple models

### DIFF
--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/SecurableResourceGroupRoleService.groovy
@@ -82,7 +82,7 @@ class SecurableResourceGroupRoleService implements MdmDomainService<SecurableRes
             securableResource: securableResource,
             createdBy: createdBy.emailAddress
         )
-        userGroup.addToSecurableResourceGroupRoles(securableResourceGroupRole)
+        securableResourceGroupRole.userGroup = userGroup
         updateAndSaveSecurableResourceGroupRole(securableResourceGroupRole, groupRole)
     }
 


### PR DESCRIPTION
This PR prevents Grails/Hibernate from loading the `securableResourceGroupRoles` association on `UserGroup`s when `UserSecurityPolicyManager::addSecurityForSecurableResource` is called, which was causing a memory leak because the old `SecurableResourceGroupRole` objects were staying in memory after requests completed.

If code that calls `addSecurityForSecurableResource` later tries to check the same permissions on a UserGroup in the same request, the new security role might not appear there yet, but I think this is unlikely to be an issue.

I've tested in a local instance that the memory usage isn't increasing when importing multiple models with a script.

Resolves #420.