### PR TITLE
Add SQL indexes to Data Model join tables

### DIFF
--- a/mdm-core/grails-app/conf/db/migration/core/V5_2_2__add_indexes.sql
+++ b/mdm-core/grails-app/conf/db/migration/core/V5_2_2__add_indexes.sql
@@ -1,0 +1,2 @@
+-- create index to speed up BreadcrumbTreeService::deleteAllByDomainIds
+CREATE INDEX breadcrumb_tree_tree_string_prefix_idx ON core.breadcrumb_tree (SUBSTR(tree_string, 1, 36+1));

--- a/mdm-plugin-datamodel/grails-app/conf/db/migration/datamodel/V5_1_1__add_indexes.sql
+++ b/mdm-plugin-datamodel/grails-app/conf/db/migration/datamodel/V5_1_1__add_indexes.sql
@@ -1,0 +1,52 @@
+-- index all columns on datamodel.join_dataelement_to_facet
+
+CREATE INDEX join_dataelement_to_facet_dataelement_idx ON datamodel.join_dataelement_to_facet(dataelement_id);
+CREATE INDEX join_dataelement_to_facet_classifier_idx ON datamodel.join_dataelement_to_facet(classifier_id);
+CREATE INDEX join_dataelement_to_facet_annotation_idx ON datamodel.join_dataelement_to_facet(annotation_id);
+CREATE INDEX join_dataelement_to_facet_semantic_link_idx ON datamodel.join_dataelement_to_facet(semantic_link_id);
+CREATE INDEX join_dataelement_to_facet_reference_file_idx ON datamodel.join_dataelement_to_facet(reference_file_id);
+CREATE INDEX join_dataelement_to_facet_metadata_idx ON datamodel.join_dataelement_to_facet(metadata_id);
+CREATE INDEX join_dataelement_to_facet_summary_metadata_idx ON datamodel.join_dataelement_to_facet(summary_metadata_id);
+CREATE INDEX join_dataelement_to_facet_rule_idx ON datamodel.join_dataelement_to_facet(rule_id);
+
+-- index all columns on datamodel.join_dataclass_to_facet
+
+CREATE INDEX join_dataclass_to_facet_dataclass_idx ON datamodel.join_dataclass_to_facet(dataclass_id);
+CREATE INDEX join_dataclass_to_facet_classifier_idx ON datamodel.join_dataclass_to_facet(classifier_id);
+CREATE INDEX join_dataclass_to_facet_annotation_idx ON datamodel.join_dataclass_to_facet(annotation_id);
+CREATE INDEX join_dataclass_to_facet_semantic_link_idx ON datamodel.join_dataclass_to_facet(semantic_link_id);
+CREATE INDEX join_dataclass_to_facet_reference_file_idx ON datamodel.join_dataclass_to_facet(reference_file_id);
+CREATE INDEX join_dataclass_to_facet_metadata_idx ON datamodel.join_dataclass_to_facet(metadata_id);
+CREATE INDEX join_dataclass_to_facet_summary_metadata_idx ON datamodel.join_dataclass_to_facet(summary_metadata_id);
+CREATE INDEX join_dataclass_to_facet_rule_idx ON datamodel.join_dataclass_to_facet(rule_id);
+
+-- index all columns on datamodel.join_datamodel_to_facet
+
+CREATE INDEX join_datamodel_to_facet_datamodel_idx ON datamodel.join_datamodel_to_facet(datamodel_id);
+CREATE INDEX join_datamodel_to_facet_classifier_idx ON datamodel.join_datamodel_to_facet(classifier_id);
+CREATE INDEX join_datamodel_to_facet_annotation_idx ON datamodel.join_datamodel_to_facet(annotation_id);
+CREATE INDEX join_datamodel_to_facet_semantic_link_idx ON datamodel.join_datamodel_to_facet(semantic_link_id);
+CREATE INDEX join_datamodel_to_facet_version_link_idx ON datamodel.join_datamodel_to_facet(version_link_id);
+CREATE INDEX join_datamodel_to_facet_reference_file_idx ON datamodel.join_datamodel_to_facet(reference_file_id);
+CREATE INDEX join_datamodel_to_facet_metadata_idx ON datamodel.join_datamodel_to_facet(metadata_id);
+CREATE INDEX join_datamodel_to_facet_summary_metadata_idx ON datamodel.join_datamodel_to_facet(summary_metadata_id);
+CREATE INDEX join_datamodel_to_facet_rule_idx ON datamodel.join_datamodel_to_facet(rule_id);
+
+-- index all columns on datamodel.join_datatype_to_facet
+
+CREATE INDEX join_datatype_to_facet_datatype_idx ON datamodel.join_datatype_to_facet(datatype_id);
+CREATE INDEX join_datatype_to_facet_classifier_idx ON datamodel.join_datatype_to_facet(classifier_id);
+CREATE INDEX join_datatype_to_facet_annotation_idx ON datamodel.join_datatype_to_facet(annotation_id);
+CREATE INDEX join_datatype_to_facet_semantic_link_idx ON datamodel.join_datatype_to_facet(semantic_link_id);
+CREATE INDEX join_datatype_to_facet_reference_file_idx ON datamodel.join_datatype_to_facet(reference_file_id);
+CREATE INDEX join_datatype_to_facet_metadata_idx ON datamodel.join_datatype_to_facet(metadata_id);
+CREATE INDEX join_datatype_to_facet_summary_metadata_idx ON datamodel.join_datatype_to_facet(summary_metadata_id);
+CREATE INDEX join_datatype_to_facet_rule_idx ON datamodel.join_datatype_to_facet(rule_id);
+
+-- indexes on imported item IDs
+CREATE INDEX join_datamodel_to_imported_data_class_imported_dataclass_idx ON datamodel.join_datamodel_to_imported_data_class(imported_dataclass_id);
+CREATE INDEX join_dataclass_to_imported_data_element_imported_de_idx ON datamodel.join_dataclass_to_imported_data_element(imported_dataelement_id);
+
+-- create breadcrumb tree index on datamodel
+
+CREATE INDEX data_model_breadcrumb_tree_idx ON datamodel.data_model(breadcrumb_tree_id);

--- a/mdm-plugin-terminology/grails-app/conf/db/migration/terminology/V5_2_2__add_indexes.sql
+++ b/mdm-plugin-terminology/grails-app/conf/db/migration/terminology/V5_2_2__add_indexes.sql
@@ -30,9 +30,10 @@ CREATE INDEX join_codeset_to_facet_reference_file_idx ON terminology.join_codese
 CREATE INDEX join_codeset_to_facet_metadata_idx ON terminology.join_codeset_to_facet(metadata_id);
 CREATE INDEX join_codeset_to_facet_rule_idx ON terminology.join_codeset_to_facet(rule_id);
 
--- create breadcrumb tree index on codeset
+-- create breadcrumb tree index on codeset and terminology
 
 CREATE INDEX code_set_breadcrumb_tree_idx ON terminology.code_set(breadcrumb_tree_id);
+CREATE INDEX terminology_breadcrumb_tree_idx ON terminology.terminology(breadcrumb_tree_id);
 
 -- create indexes on codeset join table
 

--- a/mdm-plugin-terminology/grails-app/conf/db/migration/terminology/V5_2_2__add_indexes.sql
+++ b/mdm-plugin-terminology/grails-app/conf/db/migration/terminology/V5_2_2__add_indexes.sql
@@ -1,0 +1,40 @@
+-- index all columns on terminology.join_term_to_facet
+
+CREATE INDEX join_term_to_facet_term_idx ON terminology.join_term_to_facet(term_id);
+CREATE INDEX join_term_to_facet_classifier_idx ON terminology.join_term_to_facet(classifier_id);
+CREATE INDEX join_term_to_facet_annotation_idx ON terminology.join_term_to_facet(annotation_id);
+CREATE INDEX join_term_to_facet_semantic_link_idx ON terminology.join_term_to_facet(semantic_link_id);
+CREATE INDEX join_term_to_facet_reference_file_idx ON terminology.join_term_to_facet(reference_file_id);
+CREATE INDEX join_term_to_facet_metadata_idx ON terminology.join_term_to_facet(metadata_id);
+CREATE INDEX join_term_to_facet_rule_idx ON terminology.join_term_to_facet(rule_id);
+
+-- index all columns on terminology.join_terminology_to_facet
+
+CREATE INDEX join_terminology_to_facet_terminology_idx ON terminology.join_terminology_to_facet(terminology_id);
+CREATE INDEX join_terminology_to_facet_classifier_idx ON terminology.join_terminology_to_facet(classifier_id);
+CREATE INDEX join_terminology_to_facet_annotation_idx ON terminology.join_terminology_to_facet(annotation_id);
+CREATE INDEX join_terminology_to_facet_semantic_link_idx ON terminology.join_terminology_to_facet(semantic_link_id);
+CREATE INDEX join_terminology_to_facet_version_link_idx ON terminology.join_terminology_to_facet(version_link_id);
+CREATE INDEX join_terminology_to_facet_reference_file_idx ON terminology.join_terminology_to_facet(reference_file_id);
+CREATE INDEX join_terminology_to_facet_metadata_idx ON terminology.join_terminology_to_facet(metadata_id);
+CREATE INDEX join_terminology_to_facet_rule_idx ON terminology.join_terminology_to_facet(rule_id);
+
+-- index all columns on terminology.join_codeset_to_facet
+
+CREATE INDEX join_codeset_to_facet_codeset_idx ON terminology.join_codeset_to_facet(codeset_id);
+CREATE INDEX join_codeset_to_facet_classifier_idx ON terminology.join_codeset_to_facet(classifier_id);
+CREATE INDEX join_codeset_to_facet_annotation_idx ON terminology.join_codeset_to_facet(annotation_id);
+CREATE INDEX join_codeset_to_facet_semantic_link_idx ON terminology.join_codeset_to_facet(semantic_link_id);
+CREATE INDEX join_codeset_to_facet_version_link_idx ON terminology.join_codeset_to_facet(version_link_id);
+CREATE INDEX join_codeset_to_facet_reference_file_idx ON terminology.join_codeset_to_facet(reference_file_id);
+CREATE INDEX join_codeset_to_facet_metadata_idx ON terminology.join_codeset_to_facet(metadata_id);
+CREATE INDEX join_codeset_to_facet_rule_idx ON terminology.join_codeset_to_facet(rule_id);
+
+-- create breadcrumb tree index on codeset
+
+CREATE INDEX code_set_breadcrumb_tree_idx ON terminology.code_set(breadcrumb_tree_id);
+
+-- create indexes on codeset join table
+
+CREATE INDEX join_codeset_to_term_term_idx ON terminology.join_codeset_to_term(term_id);
+CREATE INDEX join_codeset_to_term_codeset_idx ON terminology.join_codeset_to_term(codeset_id);


### PR DESCRIPTION
Improve performance by adding indexes on DataModel/facet join tables and breadcrumb tree columns. Speeds up some operations and the Lucene re-index.

- Indexes found by looking at long running queries and `pg_stat_user_tables` in an instance with many datamodels.
- Indexes on all the join table columns are needed because lookups happen on the datamodel/element/class ID and also when rows are deleted from the model/element/class table, a full table scan on the other columns (metadata ID etc.) can happen because of the foreign key constraints.