### PR TITLE
gh-808 Added validation for max file size property

### DIFF
--- a/mdm-core/grails-app/conf/application.yml
+++ b/mdm-core/grails-app/conf/application.yml
@@ -97,6 +97,9 @@ grails:
             maxsize: 1000
     controllers:
         defaultScope: singleton
+        upload:
+            maxFileSize: 200000000 # 190 MB * 1024 * 1024
+            maxRequestSize: 200000000 # 190 MB * 1024 * 1024
     converters:
         encoding: UTF-8
     exceptionresolver:

--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyController.groovy
@@ -17,6 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core.admin
 
+import org.springframework.beans.factory.annotation.Value
 import uk.ac.ox.softeng.maurodatamapper.api.exception.ApiInternalException
 import uk.ac.ox.softeng.maurodatamapper.core.controller.EditLoggingController
 import uk.ac.ox.softeng.maurodatamapper.security.User
@@ -37,6 +38,10 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
     ApiPropertyController() {
         super(ApiProperty)
     }
+
+    @Value('${grails.controllers.upload.maxFileSize}')
+    private Integer maxFileUploadSize;
+
 
     @Override
     def index(Integer max) {
@@ -74,6 +79,7 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
     @Override
     protected boolean validateResource(ApiProperty instance, String view) {
         instance.lastUpdatedBy = currentUser.emailAddress
+        instance = apiPropertyService.validate(instance)
         super.validateResource(instance, view)
     }
 
@@ -116,6 +122,7 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
 
             if (!errorInstance) {
                 instance.validate()
+                instance = apiPropertyService.validate(instance)
 
                 if (instance.hasErrors()) {
                     errorInstance = instance
@@ -164,4 +171,5 @@ class ApiPropertyController extends EditLoggingController<ApiProperty> {
 
         cleanedInstances
     }
+
 }

--- a/mdm-core/grails-app/init/uk/ac/ox/softeng/maurodatamapper/core/BootStrap.groovy
+++ b/mdm-core/grails-app/init/uk/ac/ox/softeng/maurodatamapper/core/BootStrap.groovy
@@ -17,6 +17,8 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core
 
+import org.springframework.beans.factory.annotation.Value
+import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiProperty
 import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyEnum
 import uk.ac.ox.softeng.maurodatamapper.core.admin.ApiPropertyService
 import uk.ac.ox.softeng.maurodatamapper.core.async.AsyncJobService
@@ -61,6 +63,9 @@ class BootStrap {
 
     @Autowired
     MessageSource messageSource
+
+    @Value('${grails.controllers.upload.maxFileSize}')
+    Integer maxFileUploadSize
 
     def init = {servletContext ->
 
@@ -146,6 +151,18 @@ class BootStrap {
         apiPropertyService.checkAndSetSiteUrl(grailsApplication.config.getProperty('grails.serverURL', String),
                                               grailsApplication.config.getProperty('grails.contextPath', String),
                                               bootstrapUser)
+
+        // Get the default maximum upload file size from config
+        if (!apiPropertyService.findByKey(ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT.key)) {
+            Integer maxFileUploadSizeMb = (maxFileUploadSize / 1024 / 1024)
+            apiPropertyService.save(
+                    ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT.key,
+                    maxFileUploadSizeMb,
+                    bootstrapUser,
+                    ApiProperty.extractDefaultCategoryFromKey(ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT.key)
+            )
+        }
+
     }
 
     boolean configureEmailProviderServices(Config config) {

--- a/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-core/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -39,12 +39,12 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
     @RunOnce
     @Transactional
     def setup() {
-        assert apiPropertyService.count() == 15
+        assert apiPropertyService.count() == 16
     }
 
     @Override
     int getExpectedInitialResourceCount() {
-        15
+        16
     }
 
     @Override
@@ -220,7 +220,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 
     void verifyR1EmptyIndexResponse() {
         verifyResponse(HttpStatus.OK, response)
-        assert responseBody().count == 15
+        assert responseBody().count == 16
 
         ApiPropertyEnum.values()
             .findAll {
@@ -229,7 +229,9 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
                          ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
                          ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
                          ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS,
-                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION])
+                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION,
+                         ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT
+                ])
             }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", responseBody().items.any {
@@ -241,8 +243,8 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
 
     void verifyR3IndexResponse(String expectedId) {
         verifyResponse(HttpStatus.OK, response)
-        assert responseBody().count == 16
-        assert responseBody().items.size() == 16
+        assert responseBody().count == 17
+        assert responseBody().items.size() == 17
         assert responseBody().items.any {it.id == expectedId}
     }
 
@@ -327,7 +329,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         verifyResponse(HttpStatus.OK, jsonCapableResponse)
         String csv = jsonCapableResponse.body().toString()
         String[] lines = csv.split('\r\n')
-        assert lines.size() == 16 //header + 15 rows
+        assert lines.size() == 17 //header + 17 rows
         assert lines[0] == 'id,key,value,category,publiclyVisible,lastUpdatedBy,createdBy,lastUpdated'
         String id = lines[1].split(",")[0]
 
@@ -372,7 +374,7 @@ class ApiPropertyFunctionalSpec extends ResourceFunctionalSpec<ApiProperty> impl
         GET('')
 
         then:
-        responseBody().count == 15
+        responseBody().count == 16
         responseBody().items[0].key == 'email.invite_edit.body'
         String id = responseBody().items[0].id
 

--- a/mdm-core/src/integration-test/resources/xml/apiProperties.xml
+++ b/mdm-core/src/integration-test/resources/xml/apiProperties.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <apiProperties>
-    <count>15</count>
+    <count>16</count>
     <items>
         <apiProperty>
             <id>cd07f97f-5315-45f4-894f-ed814b835653</id>
@@ -202,6 +202,16 @@
 
                 (This is an automated mail).</value>
             <category>Email</category>
+            <publiclyVisible>false</publiclyVisible>
+            <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
+            <createdBy>bootstrap.user@maurodatamapper.com</createdBy>
+            <lastUpdated>2021-10-28T13:49:24.804440+01:00</lastUpdated>
+        </apiProperty>
+        <apiProperty>
+            <id>d90f11b1-411e-423a-b353-320b3ca207aa</id>
+            <key>feature.attachment_size_limit_mb</key>
+            <value>190</value>
+            <category>Feature</category>
             <publiclyVisible>false</publiclyVisible>
             <lastUpdatedBy>bootstrap.user@maurodatamapper.com</lastUpdatedBy>
             <createdBy>bootstrap.user@maurodatamapper.com</createdBy>

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyEnum.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyEnum.groovy
@@ -41,7 +41,8 @@ enum ApiPropertyEnum {
     SECURITY_RESTRICT_ROOT_FOLDER('security.restrict.root.folder'),
     SECURITY_RESTRICT_CLASSIFIER_CREATE('security.restrict.classifier.create'),
     SECURITY_HIDE_EXCEPTIONS('security.hide.exception'),
-    FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION('feature.copy_annotations_to_new_version')
+    FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION('feature.copy_annotations_to_new_version'),
+    FEATURE_ATTACHMENT_SIZE_LIMIT('feature.attachment_size_limit_mb')
 
     String key
 

--- a/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/AdminControllerSpec.groovy
+++ b/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/AdminControllerSpec.groovy
@@ -17,7 +17,6 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core.admin
 
-
 import uk.ac.ox.softeng.maurodatamapper.core.BootStrap
 import uk.ac.ox.softeng.maurodatamapper.core.hibernate.search.HibernateSearchIndexingService
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.HibernateSearchIndexParameters
@@ -46,7 +45,7 @@ class AdminControllerSpec extends BaseUnitSpec implements ControllerUnitTest<Adm
         mockDomain(ApiProperty)
 
         ApiPropertyService apiPropertyService = new ApiPropertyService()
-
+        apiPropertyService.maxFileUploadSize(200000000)
         apiPropertyService.assetResourceLocator = Mock(AssetResourceLocator) {
             findAssetForURI('defaults.properties') >> {
                 Path path = Paths.get('grails-app/assets/api/defaults.properties')
@@ -64,6 +63,7 @@ class AdminControllerSpec extends BaseUnitSpec implements ControllerUnitTest<Adm
         }
 
         BootStrap bootStrap = new BootStrap()
+        bootStrap.maxFileUploadSize(200000000)
         bootStrap.grailsApplication = grailsApplication
         bootStrap.apiPropertyService = apiPropertyService
         bootStrap.grailsApplication.config.simplejavamail.smtp.username = 'Unit Test Controller'

--- a/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/AdminControllerSpec.groovy
+++ b/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/AdminControllerSpec.groovy
@@ -45,7 +45,7 @@ class AdminControllerSpec extends BaseUnitSpec implements ControllerUnitTest<Adm
         mockDomain(ApiProperty)
 
         ApiPropertyService apiPropertyService = new ApiPropertyService()
-        apiPropertyService.maxFileUploadSize(200000000)
+        apiPropertyService.maxFileUploadSize = 200000000
         apiPropertyService.assetResourceLocator = Mock(AssetResourceLocator) {
             findAssetForURI('defaults.properties') >> {
                 Path path = Paths.get('grails-app/assets/api/defaults.properties')
@@ -63,7 +63,7 @@ class AdminControllerSpec extends BaseUnitSpec implements ControllerUnitTest<Adm
         }
 
         BootStrap bootStrap = new BootStrap()
-        bootStrap.maxFileUploadSize(200000000)
+        bootStrap.maxFileUploadSize = 200000000
         bootStrap.grailsApplication = grailsApplication
         bootStrap.apiPropertyService = apiPropertyService
         bootStrap.grailsApplication.config.simplejavamail.smtp.username = 'Unit Test Controller'

--- a/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyServiceSpec.groovy
+++ b/mdm-core/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/core/admin/ApiPropertyServiceSpec.groovy
@@ -17,7 +17,6 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.core.admin
 
-
 import uk.ac.ox.softeng.maurodatamapper.test.unit.BaseUnitSpec
 
 import asset.pipeline.grails.AssetResourceLocator

--- a/mdm-plugin-datamodel/grails-app/conf/application.yml
+++ b/mdm-plugin-datamodel/grails-app/conf/application.yml
@@ -21,6 +21,10 @@ grails:
             # Disabled by default for performance reasons
             events: false
         failOnError: true
+    controllers:
+        upload:
+            maxFileSize: 200000000 # 190 MB * 1024 * 1024
+            maxRequestSize: 200000000 # 190 MB * 1024 * 1024
     resources:
         pattern: /**
 info:

--- a/mdm-plugin-referencedata/grails-app/conf/application.yml
+++ b/mdm-plugin-referencedata/grails-app/conf/application.yml
@@ -21,6 +21,10 @@ grails:
             # Disabled by default for performance reasons
             events: false
         failOnError: true
+    controllers:
+        upload:
+            maxFileSize: 200000000 # 190 MB * 1024 * 1024
+            maxRequestSize: 200000000 # 190 MB * 1024 * 1024
     resources:
         pattern: /**
 info:

--- a/mdm-testing-functional/grails-app/conf/application.yml
+++ b/mdm-testing-functional/grails-app/conf/application.yml
@@ -24,6 +24,10 @@ grails:
             # Disabled by default for performance reasons
             events: false
         failOnError: true
+    controllers:
+        upload:
+            maxFileSize: 200000000 # 190 MB * 1024 * 1024
+            maxRequestSize: 200000000 # 190 MB * 1024 * 1024
     resources:
         pattern: /**
 info:

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/admin/ApiPropertyFunctionalSpec.groovy
@@ -222,7 +222,9 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
                          ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
                          ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
                          ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS,
-                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION])
+                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION,
+                         ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT
+                ])
             }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", responseBody().items.any {
@@ -242,7 +244,9 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
                          ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
                          ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
                          ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS,
-                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION])
+                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION,
+                         ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT
+                ])
             }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", jsonCapableResponse.body().toString().contains("<key>${ape.key}</key>")
@@ -267,7 +271,9 @@ class ApiPropertyFunctionalSpec extends FunctionalSpec implements CsvComparer, X
                          ApiPropertyEnum.SECURITY_RESTRICT_CLASSIFIER_CREATE,
                          ApiPropertyEnum.SECURITY_RESTRICT_ROOT_FOLDER,
                          ApiPropertyEnum.SECURITY_HIDE_EXCEPTIONS,
-                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION])
+                         ApiPropertyEnum.FEATURE_COPY_ANNOTATIONS_TO_NEW_VERSION,
+                         ApiPropertyEnum.FEATURE_ATTACHMENT_SIZE_LIMIT
+                ])
             }
             .each {ape ->
                 Assert.assertTrue "${ape.key} should exist", jsonCapableResponse.body().toString().contains("${ape.key},")

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/file/ThemeImageFileFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/core/file/ThemeImageFileFunctionalSpec.groovy
@@ -91,7 +91,7 @@ class ThemeImageFileFunctionalSpec extends FunctionalSpec {
         sessionFactory.currentSession.flush()
         getOrCreateApiProperties()
         assert CatalogueUser.count() == 10
-        assert ApiProperty.count() == 20
+        assert ApiProperty.count() == 21
         sessionFactory.currentSession.flush()
         UUID userId = CatalogueUser.findByEmailAddress(userEmailAddresses.editor).id
         assert userId


### PR DESCRIPTION
gh-808 Is to add a helpful user message to the UI when a file that exceeds the maximum file size is set to be uploaded. 
Since this is set in the plugin.yml of mdm-core, the ApiPropertyService was updated to not allow a maximum file size configuration to be added that is greater than the Grails config maximum request size.

Bootstrap was also updated to set the api property, if it doesn't already exist, to a value that equals the Grails configured maximum file size. 