### PR TITLE
Adjust interval labels for integers and dates in summary metadata

### DIFF
--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DateIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DateIntervalHelper.groovy
@@ -169,27 +169,49 @@ class DateIntervalHelper extends AbstractIntervalHelper<LocalDateTime> {
         intervalStarts.each {start ->
 
             LocalDateTime finish = start.plus(intervalLengthSize, intervalLengthDimension)
+            ChronoUnit finishLabelAdjust
+            switch (intervalLengthDimension) {
+                case ChronoUnit.DECADES:
+                case ChronoUnit.YEARS:
+                    finishLabelAdjust =  ChronoUnit.MONTHS
+                    break
+                case ChronoUnit.MONTHS:
+                    finishLabelAdjust =  ChronoUnit.DAYS
+                    break
+                case ChronoUnit.DAYS:
+                    finishLabelAdjust =  ChronoUnit.HOURS
+                    break
+                case ChronoUnit.HOURS:
+                    finishLabelAdjust =  ChronoUnit.MINUTES
+                    break
+                case ChronoUnit.MINUTES:
+                    finishLabelAdjust =  ChronoUnit.SECONDS
+                    break
+                default:
+                    finishLabelAdjust = ChronoUnit.SECONDS
+            }
+            LocalDateTime labelFinish = finish.minus(1, finishLabelAdjust)
             String label
-            if ("${start.getYear()}" == "${finish.getYear()}" && intervalLengthDimension == ChronoUnit.YEARS) {
+            if ("${start.getYear()}" == "${labelFinish.getYear()}" && intervalLengthDimension == ChronoUnit.YEARS) {
                 label = "${start.getYear()}"
             } else if (intervalLengthDimension == ChronoUnit.DECADES || intervalLengthDimension == ChronoUnit.YEARS) {
-                label = "${start.getYear()}${labelSeparator}${finish.getYear()}"
-            } else if ("${start.format(monthDateFormatter)}" == "${finish.format(monthDateFormatter)}" && intervalLengthDimension == ChronoUnit.MONTHS) {
+                label = "${start.getYear()}${labelSeparator}${labelFinish.getYear()}"
+            } else if ("${start.format(monthDateFormatter)}" == "${labelFinish.format(monthDateFormatter)}" && intervalLengthDimension == ChronoUnit.MONTHS) {
                 label = start.format(monthDateFormatter)
             } else if (intervalLengthDimension == ChronoUnit.MONTHS) {
-                label = "${start.format(monthDateFormatter)}${labelSeparator}${finish.format(monthDateFormatter)}"
-            } else if ("${start.format(dateFormatter)}" == "${finish.format(dateFormatter)}" && intervalLengthDimension == ChronoUnit.DAYS) {
+                label = "${start.format(monthDateFormatter)}${labelSeparator}${labelFinish.format(monthDateFormatter)}"
+            } else if ("${start.format(dateFormatter)}" == "${labelFinish.format(dateFormatter)}" && intervalLengthDimension == ChronoUnit.DAYS) {
                 label = start.format(dateFormatter)
             } else if (intervalLengthDimension == ChronoUnit.DAYS) {
-                label = "${start.format(dateFormatter)}${labelSeparator}${finish.format(dateFormatter)}"
-            } else if ("${start.format(dateTimeFormatter)}" == "${finish.format(dateTimeFormatter)}" && intervalLengthDimension == ChronoUnit.HOURS) {
+                label = "${start.format(dateFormatter)}${labelSeparator}${labelFinish.format(dateFormatter)}"
+            } else if ("${start.format(dateTimeFormatter)}" == "${labelFinish.format(dateTimeFormatter)}" && intervalLengthDimension == ChronoUnit.HOURS) {
                 label = start.format(dateTimeFormatter)
             } else if (intervalLengthDimension == ChronoUnit.HOURS) {
-                label = "${start.format(dateTimeFormatter)}${labelSeparator}${finish.format(dateTimeFormatter)}"
-            } else if ("${start.format(dateTimeFormatter)}" == "${finish.format(dateTimeFormatter)}" && intervalLengthDimension == ChronoUnit.MINUTES) {
+                label = "${start.format(dateTimeFormatter)}${labelSeparator}${labelFinish.format(dateTimeFormatter)}"
+            } else if ("${start.format(dateTimeFormatter)}" == "${labelFinish.format(dateTimeFormatter)}" && intervalLengthDimension == ChronoUnit.MINUTES) {
                 label = start.format(dateTimeFormatter)
             } else {
-                label = "${start.format(dateTimeFormatter)}${labelSeparator}${finish.format(dateTimeFormatter)}"
+                label = "${start.format(dateTimeFormatter)}${labelSeparator}${labelFinish.format(dateTimeFormatter)}"
             }
             addInterval(label, new Pair(start, finish))
         }

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DateIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DateIntervalHelper.groovy
@@ -170,23 +170,23 @@ class DateIntervalHelper extends AbstractIntervalHelper<LocalDateTime> {
 
             LocalDateTime finish = start.plus(intervalLengthSize, intervalLengthDimension)
             String label
-            if (intervalLengthSize == 1 && intervalLengthDimension == ChronoUnit.YEARS) {
+            if ("${start.getYear()}" == "${finish.getYear()}" && intervalLengthDimension == ChronoUnit.YEARS) {
                 label = "${start.getYear()}"
             } else if (intervalLengthDimension == ChronoUnit.DECADES || intervalLengthDimension == ChronoUnit.YEARS) {
                 label = "${start.getYear()}${labelSeparator}${finish.getYear()}"
-            } else if (intervalLengthSize == 1 && intervalLengthDimension == ChronoUnit.MONTHS) {
+            } else if ("${start.format(monthDateFormatter)}" == "${finish.format(monthDateFormatter)}" && intervalLengthDimension == ChronoUnit.MONTHS) {
                 label = start.format(monthDateFormatter)
             } else if (intervalLengthDimension == ChronoUnit.MONTHS) {
                 label = "${start.format(monthDateFormatter)}${labelSeparator}${finish.format(monthDateFormatter)}"
-            } else if (intervalLengthSize == 1 && intervalLengthDimension == ChronoUnit.DAYS) {
+            } else if ("${start.format(dateFormatter)}" == "${finish.format(dateFormatter)}" && intervalLengthDimension == ChronoUnit.DAYS) {
                 label = start.format(dateFormatter)
             } else if (intervalLengthDimension == ChronoUnit.DAYS) {
                 label = "${start.format(dateFormatter)}${labelSeparator}${finish.format(dateFormatter)}"
-            } else if (intervalLengthSize == 1 && intervalLengthDimension == ChronoUnit.HOURS) {
+            } else if ("${start.format(dateTimeFormatter)}" == "${finish.format(dateTimeFormatter)}" && intervalLengthDimension == ChronoUnit.HOURS) {
                 label = start.format(dateTimeFormatter)
             } else if (intervalLengthDimension == ChronoUnit.HOURS) {
                 label = "${start.format(dateTimeFormatter)}${labelSeparator}${finish.format(dateTimeFormatter)}"
-            } else if (intervalLengthSize == 1 && intervalLengthDimension == ChronoUnit.MINUTES) {
+            } else if ("${start.format(dateTimeFormatter)}" == "${finish.format(dateTimeFormatter)}" && intervalLengthDimension == ChronoUnit.MINUTES) {
                 label = start.format(dateTimeFormatter)
             } else {
                 label = "${start.format(dateTimeFormatter)}${labelSeparator}${finish.format(dateTimeFormatter)}"

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DecimalIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DecimalIntervalHelper.groovy
@@ -17,7 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.summarymetadata
 
-
+import grails.util.Pair
 import groovy.transform.CompileStatic
 
 import java.math.RoundingMode
@@ -27,6 +27,15 @@ class DecimalIntervalHelper extends NumericIntervalHelper<BigDecimal> {
 
     DecimalIntervalHelper(BigDecimal minValue, BigDecimal maxValue) {
         super(minValue, maxValue)
+    }
+
+    @Override
+    void calculateIntervals() {
+        intervalStarts.each {start ->
+            BigDecimal finish = safeConvert(start + getIntervalLength())
+            String label = "${start}${labelSeparator}${finish}"
+            addInterval(label, new Pair(start, finish))
+        }
     }
 
     void calculateInterval() {

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/IntegerIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/IntegerIntervalHelper.groovy
@@ -17,7 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.summarymetadata
 
-
+import grails.util.Pair
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -31,6 +31,17 @@ class IntegerIntervalHelper extends NumericIntervalHelper<Integer> {
     @Override
     Integer safeConvert(Number number) {
         number.toInteger()
+    }
+
+    @Override
+    void calculateIntervals() {
+        intervalStarts.each {start ->
+            Integer labelIntervalLength = getIntervalLength() > 0 ? getIntervalLength() - 1 : getIntervalLength()
+            Integer finish = safeConvert(start + getIntervalLength())
+            Integer labelFinish = safeConvert(start + labelIntervalLength)
+            String label = "${start}" == "${labelFinish}" ? "${start}" : "${start}${labelSeparator}${labelFinish}"
+            addInterval(label, new Pair(start, finish))
+        }
     }
 }
 

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/LongIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/LongIntervalHelper.groovy
@@ -17,7 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.datamodel.summarymetadata
 
-
+import grails.util.Pair
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -33,5 +33,15 @@ class LongIntervalHelper extends NumericIntervalHelper<Long> {
         number.toLong()
     }
 
+    @Override
+    void calculateIntervals() {
+        intervalStarts.each {start ->
+            Long labelIntervalLength = getIntervalLength() > 0 ? getIntervalLength() - 1 : getIntervalLength()
+            Long finish = safeConvert(start + getIntervalLength())
+            Long labelFinish = safeConvert(start + labelIntervalLength)
+            String label = "${start}" == "${labelFinish}" ? "${start}" : "${start}${labelSeparator}${labelFinish}"
+            addInterval(label, new Pair(start, finish))
+        }
+    }
 }
 

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/NumericIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/NumericIntervalHelper.groovy
@@ -39,14 +39,6 @@ abstract class NumericIntervalHelper<N extends Number> extends AbstractIntervalH
         }
     }
 
-    void calculateIntervals() {
-        intervalStarts.each {start ->
-            N finish = safeConvert(start + getIntervalLength())
-            String label = "${start}" == "${finish}" ? "${start}" : "${start}${labelSeparator}${finish}"
-            addInterval(label, new Pair(start, finish))
-        }
-    }
-
     @Override
     void calculateInterval() {
 

--- a/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/NumericIntervalHelper.groovy
+++ b/mdm-plugin-datamodel/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/NumericIntervalHelper.groovy
@@ -42,7 +42,7 @@ abstract class NumericIntervalHelper<N extends Number> extends AbstractIntervalH
     void calculateIntervals() {
         intervalStarts.each {start ->
             N finish = safeConvert(start + getIntervalLength())
-            String label = "${start}${labelSeparator}${finish}"
+            String label = "${start}" == "${finish}" ? "${start}" : "${start}${labelSeparator}${finish}"
             addInterval(label, new Pair(start, finish))
         }
     }

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DateIntervalHelperSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/DateIntervalHelperSpec.groovy
@@ -58,63 +58,63 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
 
         when:
         LinkedHashMap expectedIntervals = new LinkedHashMap()
-        expectedIntervals['01/12/2019 - 03/12/2019'] = new Pair(
+        expectedIntervals['01/12/2019 - 02/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-01T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-03T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['03/12/2019 - 05/12/2019'] = new Pair(
+        expectedIntervals['03/12/2019 - 04/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-03T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-05T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['05/12/2019 - 07/12/2019'] = new Pair(
+        expectedIntervals['05/12/2019 - 06/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-05T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-07T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['07/12/2019 - 09/12/2019'] = new Pair(
+        expectedIntervals['07/12/2019 - 08/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-07T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-09T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['09/12/2019 - 11/12/2019'] = new Pair(
+        expectedIntervals['09/12/2019 - 10/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-09T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-11T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['11/12/2019 - 13/12/2019'] = new Pair(
+        expectedIntervals['11/12/2019 - 12/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-11T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-13T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['13/12/2019 - 15/12/2019'] = new Pair(
+        expectedIntervals['13/12/2019 - 14/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-13T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-15T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['15/12/2019 - 17/12/2019'] = new Pair(
+        expectedIntervals['15/12/2019 - 16/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-15T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-17T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['17/12/2019 - 19/12/2019'] = new Pair(
+        expectedIntervals['17/12/2019 - 18/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-17T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-19T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['19/12/2019 - 21/12/2019'] = new Pair(
+        expectedIntervals['19/12/2019 - 20/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-19T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-21T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['21/12/2019 - 23/12/2019'] = new Pair(
+        expectedIntervals['21/12/2019 - 22/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-21T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-23T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['23/12/2019 - 25/12/2019'] = new Pair(
+        expectedIntervals['23/12/2019 - 24/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-23T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-25T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['25/12/2019 - 27/12/2019'] = new Pair(
+        expectedIntervals['25/12/2019 - 26/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-25T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-27T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['27/12/2019 - 29/12/2019'] = new Pair(
+        expectedIntervals['27/12/2019 - 28/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-27T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-29T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
-        expectedIntervals['29/12/2019 - 31/12/2019'] = new Pair(
+        expectedIntervals['29/12/2019 - 30/12/2019'] = new Pair(
             LocalDateTime.parse('2019-12-29T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             LocalDateTime.parse('2019-12-31T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 
@@ -161,7 +161,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MINUTES
         dih.intervalLengthSize == 2
         dih.intervals.size() == 7
-        hasFirstAndLast('23/02/2019 01:04 - 23/02/2019 01:06', '23/02/2019 01:16 - 23/02/2019 01:18')
+        hasFirstAndLast('23/02/2019 01:04 - 23/02/2019 01:05', '23/02/2019 01:16 - 23/02/2019 01:17')
 
         when:
         to = from.plusMinutes(22)
@@ -172,7 +172,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MINUTES
         dih.intervalLengthSize == 5
         dih.intervals.size() == 6
-        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:05', '23/02/2019 01:25 - 23/02/2019 01:30')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:04', '23/02/2019 01:25 - 23/02/2019 01:29')
 
         when:
         to = from.plusMinutes(36)
@@ -183,7 +183,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MINUTES
         dih.intervalLengthSize == 5
         dih.intervals.size() == 9
-        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:05', '23/02/2019 01:40 - 23/02/2019 01:45')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:04', '23/02/2019 01:40 - 23/02/2019 01:44')
 
         when:
         to = from.plusMinutes(65)
@@ -194,7 +194,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MINUTES
         dih.intervalLengthSize == 15
         dih.intervals.size() == 5
-        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:15', '23/02/2019 02:00 - 23/02/2019 02:15')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:14', '23/02/2019 02:00 - 23/02/2019 02:14')
 
         when:
         to = from.plusMinutes(125)
@@ -205,7 +205,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MINUTES
         dih.intervalLengthSize == 30
         dih.intervals.size() == 5
-        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:30', '23/02/2019 03:00 - 23/02/2019 03:30')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:29', '23/02/2019 03:00 - 23/02/2019 03:29')
 
     }
 
@@ -221,7 +221,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 1
         dih.intervals.size() == 7
-        hasFirstAndLast('23/02/2019 01:00', '23/02/2019 07:00')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:59', '23/02/2019 07:00 - 23/02/2019 07:59')
 
         when:
         to = from.plusHours(12)
@@ -232,7 +232,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 1
         dih.intervals.size() == 13
-        hasFirstAndLast('23/02/2019 01:00', '23/02/2019 13:00')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 01:59', '23/02/2019 13:00 - 23/02/2019 13:59')
 
         when:
         to = from.plusHours(18)
@@ -243,7 +243,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 10
-        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 03:00', '23/02/2019 19:00 - 23/02/2019 21:00')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 02:59', '23/02/2019 19:00 - 23/02/2019 20:59')
 
         when:
         to = from.plusHours(23)
@@ -254,7 +254,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 12
-        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 03:00', '23/02/2019 23:00 - 24/02/2019 01:00')
+        hasFirstAndLast('23/02/2019 01:00 - 23/02/2019 02:59', '23/02/2019 23:00 - 24/02/2019 00:59')
 
         when:
         to = from.plusDays(1)
@@ -265,7 +265,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 6
         dih.intervals.size() == 5
-        hasFirstAndLast('23/02/2019 00:00 - 23/02/2019 06:00', '24/02/2019 00:00 - 24/02/2019 06:00')
+        hasFirstAndLast('23/02/2019 00:00 - 23/02/2019 05:59', '24/02/2019 00:00 - 24/02/2019 05:59')
 
         when:
         to = from.plusDays(2)
@@ -276,7 +276,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 6
         dih.intervals.size() == 9
-        hasFirstAndLast('23/02/2019 00:00 - 23/02/2019 06:00', '25/02/2019 00:00 - 25/02/2019 06:00')
+        hasFirstAndLast('23/02/2019 00:00 - 23/02/2019 05:59', '25/02/2019 00:00 - 25/02/2019 05:59')
 
         when:
         to = from.plusDays(5)
@@ -287,7 +287,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.HOURS
         dih.intervalLengthSize == 12
         dih.intervals.size() == 11
-        hasFirstAndLast('23/02/2019 00:00 - 23/02/2019 12:00', '28/02/2019 00:00 - 28/02/2019 12:00')
+        hasFirstAndLast('23/02/2019 00:00 - 23/02/2019 11:59', '28/02/2019 00:00 - 28/02/2019 11:59')
     }
 
     void 'test interval buckets sizes for days'() {
@@ -325,7 +325,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.DAYS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 9
-        hasFirstAndLast('23/02/2019 - 25/02/2019', '11/03/2019 - 13/03/2019')
+        hasFirstAndLast('23/02/2019 - 24/02/2019', '11/03/2019 - 12/03/2019')
 
         when:
         // Change month to allow a 30 day check
@@ -338,7 +338,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.DAYS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 16
-        hasFirstAndLast('23/03/2019 - 25/03/2019', '22/04/2019 - 24/04/2019')
+        hasFirstAndLast('23/03/2019 - 24/03/2019', '22/04/2019 - 23/04/2019')
     }
 
     void 'test interval buckets sizes for months'() {
@@ -399,7 +399,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MONTHS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 7
-        hasFirstAndLast('Jan 2019 - Mar 2019', 'Jan 2020 - Mar 2020')
+        hasFirstAndLast('Jan 2019 - Feb 2019', 'Jan 2020 - Feb 2020')
 
         when:
         to = from.plusMonths(18)
@@ -410,7 +410,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MONTHS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 10
-        hasFirstAndLast('Jan 2019 - Mar 2019', 'Jul 2020 - Sept 2020')
+        hasFirstAndLast('Jan 2019 - Feb 2019', 'Jul 2020 - Aug 2020')
 
         when:
         to = from.plusMonths(24).minusDays(1)
@@ -421,7 +421,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.MONTHS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 13
-        hasFirstAndLast('Jan 2019 - Mar 2019', 'Jan 2021 - Mar 2021')
+        hasFirstAndLast('Jan 2019 - Feb 2019', 'Jan 2021 - Feb 2021')
     }
 
     void 'test interval buckets sizes for years'() {
@@ -470,7 +470,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.YEARS
         dih.intervalLengthSize == 2
         dih.intervals.size() == 9
-        hasFirstAndLast('2018 - 2020', '2034 - 2036')
+        hasFirstAndLast('2018 - 2019', '2034 - 2035')
 
         when:
         to = from.plusYears(20)
@@ -481,7 +481,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.YEARS
         dih.intervalLengthSize == 5
         dih.intervals.size() == 5
-        hasFirstAndLast('2015 - 2020', '2035 - 2040')
+        hasFirstAndLast('2015 - 2019', '2035 - 2039')
 
         when:
         to = from.plusYears(35)
@@ -492,7 +492,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.YEARS
         dih.intervalLengthSize == 5
         dih.intervals.size() == 8
-        hasFirstAndLast('2015 - 2020', '2050 - 2055')
+        hasFirstAndLast('2015 - 2019', '2050 - 2054')
 
         when:
         to = from.plusYears(50).minusDays(1)
@@ -503,7 +503,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.YEARS
         dih.intervalLengthSize == 5
         dih.intervals.size() == 11
-        hasFirstAndLast('2015 - 2020', '2065 - 2070')
+        hasFirstAndLast('2015 - 2019', '2065 - 2069')
 
     }
 
@@ -521,7 +521,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         !dih.needToMergeOrRemoveEmptyBuckets
         dih.intervalLengthSize == 1
         dih.intervals.size() == 6
-        hasFirstAndLast('2010 - 2020', '2060 - 2070')
+        hasFirstAndLast('2010 - 2019', '2060 - 2069')
 
 
         when:
@@ -534,7 +534,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.needToMergeOrRemoveEmptyBuckets
         dih.intervalLengthSize == 1
         dih.intervals.size() == 11
-        hasFirstAndLast('2010 - 2020', '2110 - 2120')
+        hasFirstAndLast('2010 - 2019', '2110 - 2119')
 
         when:
         to = from.plusYears(100)
@@ -545,7 +545,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.DECADES
         dih.needToMergeOrRemoveEmptyBuckets
         dih.intervalLengthSize == 1
-        hasFirstAndLast('2010 - 2020', '2110 - 2120')
+        hasFirstAndLast('2010 - 2019', '2110 - 2119')
 
         when:
         to = from.plusYears(150)
@@ -556,7 +556,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         dih.intervalLengthDimension == ChronoUnit.DECADES
         dih.needToMergeOrRemoveEmptyBuckets
         dih.intervalLengthSize == 1
-        hasFirstAndLast('2010 - 2020', '2160 - 2170')
+        hasFirstAndLast('2010 - 2019', '2160 - 2169')
 
         when:
         to = from.plusYears(500)
@@ -566,7 +566,7 @@ class DateIntervalHelperSpec extends MdmSpecification implements GrailsUnitTest 
         then:
         dih.intervalLengthDimension == ChronoUnit.DECADES
         dih.intervalLengthSize == 1
-        hasFirstAndLast('2010 - 2020', '2510 - 2520')
+        hasFirstAndLast('2010 - 2019', '2510 - 2519')
 
     }
 

--- a/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/IntegerIntervalHelperSpec.groovy
+++ b/mdm-plugin-datamodel/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/datamodel/summarymetadata/IntegerIntervalHelperSpec.groovy
@@ -42,7 +42,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(1, 500)
 
         then:
-        checkIntervals(50, '0 - 50', '500 - 550')
+        checkIntervals(50, '0 - 49', '500 - 549')
     }
 
     void 'Negative minimum left of boundary'() {
@@ -51,7 +51,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(-30000001, 19999999)
 
         then:
-        checkIntervals(5000000, '-35000000 - -30000000', '15000000 - 20000000')
+        checkIntervals(5000000, '-35000000 - -30000001', '15000000 - 19999999')
     }
 
     void 'Negative minimum on boundary'() {
@@ -60,7 +60,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(-30000000, 19999999)
 
         then:
-        checkIntervals(5000000, '-30000000 - -25000000', '15000000 - 20000000')
+        checkIntervals(5000000, '-30000000 - -25000001', '15000000 - 19999999')
     }
 
     void 'Negative minimum right of boundary'() {
@@ -69,7 +69,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(-29999999, 19999999)
 
         then:
-        checkIntervals(5000000, '-30000000 - -25000000', '15000000 - 20000000')
+        checkIntervals(5000000, '-30000000 - -25000001', '15000000 - 19999999')
     }
 
     void 'Negative max, left of boundary'() {
@@ -78,7 +78,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(-5100, -1001)
 
         then:
-        checkIntervals(500, '-5500 - -5000', '-1500 - -1000')
+        checkIntervals(500, '-5500 - -5001', '-1500 - -1001')
     }
 
     void 'Negative max, onboundary'() {
@@ -87,7 +87,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(-5100, -1000)
 
         then:
-        checkIntervals(500, '-5500 - -5000', '-1000 - -500')
+        checkIntervals(500, '-5500 - -5001', '-1000 - -501')
     }
 
     void 'Negative max, right of boundary'() {
@@ -96,7 +96,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(-5100, -999)
 
         then:
-        checkIntervals(500, '-5500 - -5000', '-1000 - -500')
+        checkIntervals(500, '-5500 - -5001', '-1000 - -501')
     }
 
     void 'Zero interval'() {
@@ -105,7 +105,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(83, 83)
 
         then:
-        checkIntervals(1, '83 - 84', '83 - 84')
+        checkIntervals(1, '83', '83')
     }
 
     void 'Positive min and max, both left of boundary'() {
@@ -114,7 +114,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(999, 5999)
 
         then:
-        checkIntervals(500, '500 - 1000', '5500 - 6000')
+        checkIntervals(500, '500 - 999', '5500 - 5999')
     }
 
     void 'Positive min and max, both on boundary'() {
@@ -123,7 +123,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(1000, 6000)
 
         then:
-        checkIntervals(500, '1000 - 1500', '6000 - 6500')
+        checkIntervals(500, '1000 - 1499', '6000 - 6499')
     }
 
     void 'Positive min and max, both right of boundary'() {
@@ -132,7 +132,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(1001, 6001)
 
         then:
-        checkIntervals(500, '1000 - 1500', '6000 - 6500')
+        checkIntervals(500, '1000 - 1499', '6000 - 6499')
     }
 
     void 'Beyond defined intervals'() {
@@ -141,7 +141,7 @@ class IntegerIntervalHelperSpec extends MdmSpecification implements GrailsUnitTe
         iih = new IntegerIntervalHelper(123, 558000000)
 
         then:
-        checkIntervals(100000000, '0 - 100000000', '500000000 - 600000000')
+        checkIntervals(100000000, '0 - 99999999', '500000000 - 599999999')
     }
 
     private void checkIntervals(int length, String firstKey, String lastKey) {


### PR DESCRIPTION
Intervals are internally calculated by an IntervalHelper as ranges like `[minValue, maxValue)`, this PR adjusts the label text so that for Integer and Date values the interval labels are not overlapping, like `[1 - 2], [3 - 4]` or `[Jan 2023 - Feb 2023], [Mar 2023 - Apr 2023]`, or labelled as whole values like `[Jan 2023], [Feb 2023], [Mar 2023]`.

Part of https://github.com/MauroDataMapper-Plugins/mdm-plugin-database-sqlserver/issues/24