### PR TITLE
Optimise the deletion of versioned folders by reducing the number of queries

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/FolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/FolderService.groovy
@@ -160,7 +160,7 @@ class FolderService extends ContainerService<Folder> {
     Set<SecurableResource> delete(Folder folder, boolean permanent, boolean flush = true, boolean rebuildSecurity = true) {
         if (!folder) {
             log.warn('Attempted to delete Folder which doesnt exist')
-            return
+            return []
         }
         if (permanent) {
             Set<SecurableResource> deletedResources = []
@@ -168,21 +168,24 @@ class FolderService extends ContainerService<Folder> {
             modelServices.each {deletedResources.addAll(it.deleteAllInContainer(folder, false))}
             folder.trackChanges()
             folder.delete(flush: flush)
-            if (securityPolicyManagerService && rebuildSecurity) {
-                Map<String, List<SecurableResource>> deletionMap = deletedResources.groupBy{ it.domainType}
-                deletionMap.each { String domainType, List<SecurableResource> resourcesOfType ->
-                    securityPolicyManagerService.removeSecurityForSecurableResourceIds(domainType, resourcesOfType.collect {it.id})
+            if (securityPolicyManagerService) {
+                securityPolicyManagerService.removeSecurityForSecurableResource(folder, null)
+                if(rebuildSecurity) {
+                    Map<String, List<SecurableResource>> deletionMap = deletedResources.groupBy {it.domainType}
+                    deletionMap.each {String domainType, List<SecurableResource> resourcesOfType ->
+                        securityPolicyManagerService.removeSecurityForSecurableResourceIds(domainType, resourcesOfType.collect {it.id})
+                    }
+                    return []
                 }
-                return []
-                //securityPolicyManagerService.removeSecurityForSecurableResource(folder, null)
-            } else {
-                return deletedResources
             }
+
+            return deletedResources
         } else {
             folder.childFolders.each {delete(it)}
             delete(folder)
             return []
         }
+
     }
 
     Folder validate(Folder folder) {

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/FolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/FolderService.groovy
@@ -37,6 +37,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.model.Model
 import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
 import uk.ac.ox.softeng.maurodatamapper.path.Path
 import uk.ac.ox.softeng.maurodatamapper.path.PathNode
+import uk.ac.ox.softeng.maurodatamapper.security.SecurableResource
 import uk.ac.ox.softeng.maurodatamapper.security.SecurityPolicyManagerService
 import uk.ac.ox.softeng.maurodatamapper.security.User
 import uk.ac.ox.softeng.maurodatamapper.security.UserSecurityPolicyManager
@@ -156,22 +157,31 @@ class FolderService extends ContainerService<Folder> {
         folder?.deleted = true
     }
 
-    void delete(Folder folder, boolean permanent, boolean flush = true) {
+    Set<SecurableResource> delete(Folder folder, boolean permanent, boolean flush = true, boolean rebuildSecurity = true) {
         if (!folder) {
             log.warn('Attempted to delete Folder which doesnt exist')
             return
         }
         if (permanent) {
-            folder.childFolders.each {delete(it, permanent, false)}
-            modelServices.each {it.deleteAllInContainer(folder)}
+            Set<SecurableResource> deletedResources = []
+            folder.childFolders.each {deletedResources.addAll(delete(it, permanent, false, false))}
+            modelServices.each {deletedResources.addAll(it.deleteAllInContainer(folder, false))}
             folder.trackChanges()
             folder.delete(flush: flush)
-            if (securityPolicyManagerService) {
-                securityPolicyManagerService.removeSecurityForSecurableResource(folder, null)
+            if (securityPolicyManagerService && rebuildSecurity) {
+                Map<String, List<SecurableResource>> deletionMap = deletedResources.groupBy{ it.domainType}
+                deletionMap.each { String domainType, List<SecurableResource> resourcesOfType ->
+                    securityPolicyManagerService.removeSecurityForSecurableResourceIds(domainType, resourcesOfType.collect {it.id})
+                }
+                return []
+                //securityPolicyManagerService.removeSecurityForSecurableResource(folder, null)
+            } else {
+                return deletedResources
             }
         } else {
             folder.childFolders.each {delete(it)}
             delete(folder)
+            return []
         }
     }
 

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/FolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/FolderService.groovy
@@ -169,8 +169,8 @@ class FolderService extends ContainerService<Folder> {
             folder.trackChanges()
             folder.delete(flush: flush)
             if (securityPolicyManagerService) {
-                securityPolicyManagerService.removeSecurityForSecurableResource(folder, null)
                 if(rebuildSecurity) {
+                    securityPolicyManagerService.removeSecurityForSecurableResource(folder, null)
                     Map<String, List<SecurableResource>> deletionMap = deletedResources.groupBy {it.domainType}
                     deletionMap.each {String domainType, List<SecurableResource> resourcesOfType ->
                         securityPolicyManagerService.removeSecurityForSecurableResourceIds(domainType, resourcesOfType.collect {it.id})
@@ -243,8 +243,10 @@ class FolderService extends ContainerService<Folder> {
     List<Folder> findAllWhereDirectParentOfModel(Model model) {
         List<Folder> folders = []
         Folder modelFolder = get(model.folder.id)
-        folders << modelFolder
-        folders.addAll(findAllWhereDirectParentOfContainer(modelFolder))
+        if(modelFolder) {
+            folders << modelFolder
+            folders.addAll(findAllWhereDirectParentOfContainer(modelFolder))
+        }
         folders
     }
 

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -878,6 +878,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     }
 
     boolean doesDepthTreeContainVersionedFolder(Folder folder) {
+        //List<Model> models = folderModelMap[folder.id]
         folder.instanceOf(VersionedFolder) || folderService.findAllByParentId(folder.id).any {doesDepthTreeContainVersionedFolder(it)}
     }
 
@@ -885,9 +886,23 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         folder.instanceOf(VersionedFolder) || hasVersionedFolderParent(folder)
     }
 
-    boolean doesDepthTreeContainFinalisedModel(Folder folder) {
-        List<Model> models = folderService.findAllModelsInFolder(folder)
-        models.any {it.finalised} || findAllByParentId(folder.id).any {doesDepthTreeContainFinalisedModel(it)}
+    boolean doesDepthTreeContainFinalisedModel(Folder folder, Map<UUID, List<Model>> folderModelMap) {
+        List<Model> models = []
+        if(!folderModelMap && modelServices) {
+            List<Model> allModels = modelServices.collectMany {service ->
+                service.list()
+            } as List<Model>
+
+            folderModelMap = allModels.groupBy { it.id}
+        }
+        if(folderModelMap) {
+            models = folderModelMap[folder.id]
+        }
+
+        if(models) {
+            return models.any {it.finalised} || findAllByParentId(folder.id).any {doesDepthTreeContainFinalisedModel(it, folderModelMap)}
+        }
+        return false
     }
 
     ObjectDiff<VersionedFolder> getDiffForVersionedFolders(VersionedFolder thisVersionedFolder, VersionedFolder otherVersionedFolder, String contentContext = 'none') {

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -404,7 +404,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     }
 
     void delete(VersionedFolder folder, boolean permanent, boolean flush = true) {
-        folderService.delete(folder, permanent, flush)
+        folderService.delete(folder, permanent, flush, true)
 
         if (permanent) {
             // delete version links which point to this VF
@@ -866,20 +866,27 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         hasVersionedFolderParent(folder.parentFolder)
     }
 
-    boolean doesMovePlaceVersionedFolderInsideVersionedFolder(Folder folderBeingMoved, Folder folderToMoveTo) {
+    boolean doesMovePlaceVersionedFolderInsideVersionedFolder(Folder folderBeingMoved, Folder folderToMoveTo, Map<UUID, List<Model>> folderModelMap = null) {
         // Check up the tree
+        if(!folderModelMap) {
+            folderModelMap = calculateFolderModelMap()
+        }
+
         if (isVersionedFolderFamily(folderBeingMoved) && isVersionedFolderFamily(folderToMoveTo)) return true
         if (isVersionedFolderFamily(folderToMoveTo)) {
             // If not up the tree then slower check going down the tree of the folder being moved to ensure it doesnt contain a VF
             // Only need to do this if the folder being moved into has a VF tree
-            return doesDepthTreeContainVersionedFolder(folderBeingMoved)
+            return doesDepthTreeContainVersionedFolder(folderBeingMoved, folderModelMap)
         }
         false
     }
 
-    boolean doesDepthTreeContainVersionedFolder(Folder folder) {
-        //List<Model> models = folderModelMap[folder.id]
-        folder.instanceOf(VersionedFolder) || folderService.findAllByParentId(folder.id).any {doesDepthTreeContainVersionedFolder(it)}
+    boolean doesDepthTreeContainVersionedFolder(Folder folder, Map<UUID, List<Model>> folderModelMap) {
+        if(!folderModelMap) {
+            folderModelMap = calculateFolderModelMap()
+        }
+
+        folder.instanceOf(VersionedFolder) || folderService.findAllByParentId(folder.id).any {doesDepthTreeContainVersionedFolder(it, folderModelMap)}
     }
 
     boolean isVersionedFolderFamily(Folder folder) {
@@ -888,19 +895,16 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
     boolean doesDepthTreeContainFinalisedModel(Folder folder, Map<UUID, List<Model>> folderModelMap) {
         List<Model> models = []
-        if(!folderModelMap && modelServices) {
-            List<Model> allModels = modelServices.collectMany {service ->
-                service.list()
-            } as List<Model>
-
-            folderModelMap = allModels.groupBy { it.id}
+        if(!folderModelMap) {
+            folderModelMap = calculateFolderModelMap()
         }
+
         if(folderModelMap) {
             models = folderModelMap[folder.id]
         }
 
         if(models) {
-            return models.any {it.finalised} || findAllByParentId(folder.id).any {doesDepthTreeContainFinalisedModel(it, folderModelMap)}
+            return models.any {it.finalised} || folderService.findAllByParentId(folder.id).any {doesDepthTreeContainFinalisedModel(it, folderModelMap)}
         }
         return false
     }
@@ -1376,5 +1380,16 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         if (!constrainedIds) return []
 
         containers.findAll {it.id in constrainedIds}
+    }
+
+    Map<UUID, List<Model>> calculateFolderModelMap() {
+        if (modelServices) {
+            List<Model> allModels = modelServices.collectMany {service ->
+                service.list()
+            } as List<Model>
+
+            return allModels.groupBy {it.folder.id}
+        }
+        return [:]
     }
 }

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -138,7 +138,7 @@ abstract class ModelService<K extends Model>
 
     abstract List<K> findAllByContainerId(UUID containerId)
 
-    abstract void deleteAllInContainer(Container container)
+    abstract List<K> deleteAllInContainer(Container container, boolean updateSecurity = true)
 
     abstract void removeAllFromContainer(Container container)
 
@@ -232,7 +232,7 @@ abstract class ModelService<K extends Model>
         deleteAll(models.id, true)
     }
 
-    List<K> deleteAll(List<Serializable> idsToDelete, Boolean permanent) {
+    List<K> deleteAll(List<Serializable> idsToDelete, Boolean permanent, boolean updateSecurity = true) {
         if (!permanent) {
             // Use findResults rather than collect so that we don't add
             // null values, which would happen if an unknown ID has been provided,
@@ -251,7 +251,7 @@ abstract class ModelService<K extends Model>
         if (!ids) return []
 
         // Batch deletion
-        if (securityPolicyManagerService) {
+        if (securityPolicyManagerService && updateSecurity) {
             securityPolicyManagerService.removeSecurityForSecurableResourceIds(getDomainClass().simpleName, ids)
         }
         long start = System.currentTimeMillis()

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -728,10 +728,27 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
             dataTypeService.copyDataType(copy, dt, copier, userSecurityPolicyManager, copySummaryMetadata, dataTypeCache)
         }
 
+        Map<DataClass, DataClass> oldNewClasses = [:]
         // Copy all the dataclasses (this will also match up the reference types)
         rootDataClasses.sort().each {dc ->
-            dataClassService.copyDataClass(copy, dc, copier, userSecurityPolicyManager, null, copySummaryMetadata, dataClassCache)
+            DataClass newClass = dataClassService.copyDataClass(copy, dc, copier, userSecurityPolicyManager, null, copySummaryMetadata, dataClassCache)
+            oldNewClasses[dc] = newClass
         }
+
+
+        rootDataClasses.sort().each {dc ->
+            DataClass newDataClass = oldNewClasses[dc]
+            dc.extendedDataClasses.each {extendedDC ->
+                // TODO: Assumption here - that it's either in the same data model, or it's external but not in the same VersionedFolder.
+                if(oldNewClasses[extendedDC]) {
+                    newDataClass.addToExtendedDataClasses(oldNewClasses[extendedDC])
+                } else {
+                    newDataClass.addToExtendedDataClasses(dc)
+                }
+            }
+        }
+
+
 
         List<DataType> importedDataTypes = dataTypeService.findAllByImportingDataModelId(original.id)
         copyImportedElements(copy, original, importedDataTypes, 'importedDataTypes', copier)
@@ -879,13 +896,14 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
     }
 
     @Override
-    void deleteAllInContainer(Container container) {
+    List<DataModel> deleteAllInContainer(Container container, boolean updateSecurity = false) {
         if (container.instanceOf(Folder)) {
-            deleteAll(DataModel.byFolderId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(DataModel.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
         if (container.instanceOf(Classifier)) {
-            deleteAll(DataModel.byClassifierId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(DataModel.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
+        return []
     }
 
     @Override

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -896,14 +896,15 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
     }
 
     @Override
-    List<DataModel> deleteAllInContainer(Container container, boolean updateSecurity = false) {
+    List<DataModel> deleteAllInContainer(Container container, boolean updateSecurity = true) {
+        List<DataModel> dataModels = []
         if (container.instanceOf(Folder)) {
-            return deleteAll(DataModel.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
+            dataModels = DataModel.byFolderId(container.id).list()
+        } else if (container.instanceOf(Classifier)) {
+            dataModels = DataModel.byClassifierId(container.id).list()
         }
-        if (container.instanceOf(Classifier)) {
-            return deleteAll(DataModel.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
-        }
-        return []
+        deleteAll(dataModels.id as List<UUID>, true, updateSecurity)
+        return dataModels
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelService.groovy
@@ -610,13 +610,14 @@ class ReferenceDataModelService extends ModelService<ReferenceDataModel> impleme
     }
 
     @Override
-    void deleteAllInContainer(Container container) {
+    List<ReferenceDataModel> deleteAllInContainer(Container container, boolean updateSecurity = true) {
         if (container.instanceOf(Folder)) {
-            deleteAll(ReferenceDataModel.byFolderId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(ReferenceDataModel.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
         if (container.instanceOf(Classifier)) {
-            deleteAll(ReferenceDataModel.byClassifierId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(ReferenceDataModel.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
+        return []
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelService.groovy
@@ -611,13 +611,15 @@ class ReferenceDataModelService extends ModelService<ReferenceDataModel> impleme
 
     @Override
     List<ReferenceDataModel> deleteAllInContainer(Container container, boolean updateSecurity = true) {
+
+        List<ReferenceDataModel> referenceDataModels = []
         if (container.instanceOf(Folder)) {
-            return deleteAll(ReferenceDataModel.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
+            referenceDataModels = ReferenceDataModel.byFolderId(container.id).list()
+        } else if (container.instanceOf(Classifier)) {
+            referenceDataModels = ReferenceDataModel.byClassifierId(container.id).list()
         }
-        if (container.instanceOf(Classifier)) {
-            return deleteAll(ReferenceDataModel.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
-        }
-        return []
+        deleteAll(referenceDataModels.id as List<UUID>, true, updateSecurity)
+        return referenceDataModels
     }
 
     @Override

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
@@ -316,13 +316,14 @@ class CodeSetService extends ModelService<CodeSet> {
     }
 
     @Override
-    void deleteAllInContainer(Container container) {
+    List<CodeSet> deleteAllInContainer(Container container, boolean updateSecurity = true) {
         if (container.instanceOf(Folder)) {
-            deleteAll(CodeSet.byFolderId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(CodeSet.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
         if (container.instanceOf(Classifier)) {
-            deleteAll(CodeSet.byClassifierId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(CodeSet.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
+        return []
     }
 
     @Override

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
@@ -317,13 +317,15 @@ class CodeSetService extends ModelService<CodeSet> {
 
     @Override
     List<CodeSet> deleteAllInContainer(Container container, boolean updateSecurity = true) {
+
+        List<CodeSet> codeSets = []
         if (container.instanceOf(Folder)) {
-            return deleteAll(CodeSet.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
+            codeSets = CodeSet.byFolderId(container.id).list()
+        } else if (container.instanceOf(Classifier)) {
+            codeSets = CodeSet.byClassifierId(container.id).list()
         }
-        if (container.instanceOf(Classifier)) {
-            return deleteAll(CodeSet.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
-        }
-        return []
+        deleteAll(codeSets.id as List<UUID>, true, updateSecurity)
+        return codeSets
     }
 
     @Override

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
@@ -605,13 +605,14 @@ class TerminologyService extends ModelService<Terminology> {
     }
 
     @Override
-    void deleteAllInContainer(Container container) {
+    List<Terminology> deleteAllInContainer(Container container, boolean updateSecurity = true) {
         if (container.instanceOf(Folder)) {
-            deleteAll(Terminology.byFolderId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(Terminology.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
         if (container.instanceOf(Classifier)) {
-            deleteAll(Terminology.byClassifierId(container.id).id().list() as List<UUID>, true)
+            return deleteAll(Terminology.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
         }
+        return []
     }
 
     @Override

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
@@ -606,13 +606,15 @@ class TerminologyService extends ModelService<Terminology> {
 
     @Override
     List<Terminology> deleteAllInContainer(Container container, boolean updateSecurity = true) {
+
+        List<Terminology> terminologies = []
         if (container.instanceOf(Folder)) {
-            return deleteAll(Terminology.byFolderId(container.id).id().list() as List<UUID>, true, updateSecurity)
+            terminologies = Terminology.byFolderId(container.id).list()
+        } else if (container.instanceOf(Classifier)) {
+            terminologies = Terminology.byClassifierId(container.id).list()
         }
-        if (container.instanceOf(Classifier)) {
-            return deleteAll(Terminology.byClassifierId(container.id).id().list() as List<UUID>, true, updateSecurity)
-        }
-        return []
+        deleteAll(terminologies.id as List<UUID>, true, updateSecurity)
+        return terminologies
     }
 
     @Override

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/GroupBasedSecurityPolicyManagerService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/GroupBasedSecurityPolicyManagerService.groovy
@@ -25,6 +25,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.container.VersionedFolder
 import uk.ac.ox.softeng.maurodatamapper.core.model.Container
 import uk.ac.ox.softeng.maurodatamapper.core.model.ContainerService
 import uk.ac.ox.softeng.maurodatamapper.core.model.Model
+import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
 import uk.ac.ox.softeng.maurodatamapper.security.CatalogueUser
 import uk.ac.ox.softeng.maurodatamapper.security.CatalogueUserService
 import uk.ac.ox.softeng.maurodatamapper.security.SecurableResource
@@ -70,6 +71,8 @@ class GroupBasedSecurityPolicyManagerService implements SecurityPolicyManagerSer
 
     GrailsApplication grailsApplication
     GrailsCacheManager grailsCacheManager
+
+    List<ModelService> modelServices
 
     @Autowired(required = false)
     List<ContainerService> containerServices = []
@@ -421,8 +424,15 @@ class GroupBasedSecurityPolicyManagerService implements SecurityPolicyManagerSer
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as HashSet
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRolesForParents = [] as HashSet
 
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+
+
         virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService
-                                                   .buildForSecurableResource(securableResource)
+                                                   .buildForSecurableResource(securableResource, folderModelMap)
                                                    .withAccessLevel(readerRole.groupRole))
 
         if (Utils.parentClassIsAssignableFromChild(Container, securableResource.class)) {
@@ -440,7 +450,7 @@ class GroupBasedSecurityPolicyManagerService implements SecurityPolicyManagerSer
             virtualSecurableResourceGroupRolesForParents.addAll(
                 containerService.findAllWhereDirectParentOfContainer(securableResource as Container)
                     .collect { container ->
-                        virtualSecurableResourceGroupRoleService.buildForSecurableResource(container as Container)
+                        virtualSecurableResourceGroupRoleService.buildForSecurableResource(container as Container, folderModelMap)
                             .withAccessLevel(readerRole.groupRole)
                     })
         }
@@ -451,7 +461,7 @@ class GroupBasedSecurityPolicyManagerService implements SecurityPolicyManagerSer
             virtualSecurableResourceGroupRolesForParents.addAll(
                 folderService.findAllWhereDirectParentOfModel(securableResource as Model)
                     .collect { folder ->
-                        virtualSecurableResourceGroupRoleService.buildForSecurableResource(folder)
+                        virtualSecurableResourceGroupRoleService.buildForSecurableResource(folder, folderModelMap)
                             .withAccessLevel(readerRole.groupRole)
                     })
         }

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/GroupBasedSecurityPolicyManagerService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/GroupBasedSecurityPolicyManagerService.groovy
@@ -72,6 +72,7 @@ class GroupBasedSecurityPolicyManagerService implements SecurityPolicyManagerSer
     GrailsApplication grailsApplication
     GrailsCacheManager grailsCacheManager
 
+    @Autowired(required = false)
     List<ModelService> modelServices
 
     @Autowired(required = false)
@@ -424,11 +425,14 @@ class GroupBasedSecurityPolicyManagerService implements SecurityPolicyManagerSer
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as HashSet
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRolesForParents = [] as HashSet
 
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
+        Map<UUID, List<Model>> folderModelMap = [:]
+        if(modelServices) {
+            List<Model> allModels = modelServices.collectMany {service ->
+                service.list()
+            } as List<Model>
+             folderModelMap = allModels.groupBy { it.folder.id}
+        }
 
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
 
 
         virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/UserSecurityPolicyService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/UserSecurityPolicyService.groovy
@@ -313,10 +313,16 @@ class UserSecurityPolicyService {
         // Only deal with folders, there is a question around if you can see a model can you read all its classifiers??
         // We need to make the tree of folders down to the model readable so that the tree can be rendered,
         // As these are virtual roles we dont iterate into any of the folders, we just want to make that folder and its parents readable
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+
         folderService
             .findAllWhereDirectParentOfModel(model)
             .collect {folder ->
-                virtualSecurableResourceGroupRoleService.buildForSecurableResource(folder)
+                virtualSecurableResourceGroupRoleService.buildForSecurableResource(folder, folderModelMap)
                     .withAccessLevel(readerRole.groupRole)
                     .definedByGroup(userGroup)
                     .definedByAccessLevel(appliedGroupRole)
@@ -332,6 +338,12 @@ class UserSecurityPolicyService {
         VirtualGroupRole virtualGroupRole = groupRoleService.getFromCache(highestRole.name)
         Set<GroupRole> inheritedUserRoles = virtualGroupRole.allowedRoles
         List<CatalogueUser> users = catalogueUserService.list([:])
+
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
 
         users.each {user ->
             virtualSecurableResourceGroupRoles.addAll(
@@ -372,13 +384,19 @@ class UserSecurityPolicyService {
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as Set
         Set<GroupRole> inheritedContainerRoles = groupRoleService.getFromCache(GroupRole.CONTAINER_ADMIN_ROLE_NAME).allowedRoles
         // Don't bother with usergroups or users as these will be implicitly defined by the other roles under application_admin
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+
         securableResourceServices.findAll {!it.handles(UserGroup) && !it.handles(CatalogueUser)}.each {service ->
 
             List<SecurableResource> resources = service.list() as List<SecurableResource>
             resources.each {securableResource ->
                 virtualSecurableResourceGroupRoles.addAll(
                     inheritedContainerRoles.collect {igr ->
-                        virtualSecurableResourceGroupRoleService.buildForSecurableResource(securableResource)
+                        virtualSecurableResourceGroupRoleService.buildForSecurableResource(securableResource, folderModelMap)
                             .definedByAccessLevel(accessRole.groupRole)
                             .withAccessLevel(igr)
                     }
@@ -448,11 +466,17 @@ class UserSecurityPolicyService {
     private Set<VirtualSecurableResourceGroupRole> buildReadableByEveryone() {
         VirtualGroupRole readerRole = groupRoleService.getFromCache(GroupRole.READER_ROLE_NAME)
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as HashSet
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+
         containerServices.each {service ->
             List<Container> containers = service.findAllReadableByEveryone() as List<Container>
             containers.each {container ->
                 // Add reader access on each container
-                virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(container)
+                virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(container, folderModelMap)
                                                            .withAccessLevel(readerRole.groupRole))
                 // Make sure contents of container are all readable as well
                 virtualSecurableResourceGroupRoles.addAll(
@@ -465,32 +489,37 @@ class UserSecurityPolicyService {
                 )
             }
         }
-        modelServices.each {service ->
-            List<Model> models = service.findAllReadableByEveryone() as List<Model>
-            models.each {model ->
-                // Add reader access on each container
-                virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(model)
-                                                           .withAccessLevel(readerRole.groupRole)
-                )
+        allModels.findAll { it.readableByEveryone}.each {model ->
+            // Add reader access on each container
+            virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(model, folderModelMap)
+                                                       .withAccessLevel(readerRole.groupRole)
+            )
 
-                // Need to make sure the owning folders are readable
-                virtualSecurableResourceGroupRoles.addAll(buildReadableContainerInheritance(model.folder,
-                                                                                            readerRole.allowedRoles,
-                                                                                            null,
-                                                                                            readerRole.groupRole))
-            }
+            // Need to make sure the owning folders are readable
+            virtualSecurableResourceGroupRoles.addAll(buildReadableContainerInheritance(model.folder,
+                                                                                        readerRole.allowedRoles,
+                                                                                        null,
+                                                                                        readerRole.groupRole))
+
         }
         virtualSecurableResourceGroupRoles
     }
 
     private Set<VirtualSecurableResourceGroupRole> buildReadableByAuthenticatedUsers() {
+
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+
         VirtualGroupRole readerRole = groupRoleService.getFromCache(GroupRole.READER_ROLE_NAME)
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as HashSet
         containerServices.each {service ->
             List<Container> containers = service.findAllReadableByAuthenticatedUsers() as List<Container>
             containers.each {container ->
                 // Add reader access on each container
-                virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(container)
+                virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(container, folderModelMap)
                                                            .withAccessLevel(readerRole.groupRole))
                 // Make sure contents of container are all readable as well
                 virtualSecurableResourceGroupRoles.addAll(
@@ -503,21 +532,20 @@ class UserSecurityPolicyService {
                 )
             }
         }
-        modelServices.each {service ->
-            List<Model> models = service.findAllReadableByAuthenticatedUsers() as List<Model>
-            models.each {model ->
-                // Add reader access on each container
-                virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(model)
-                                                           .withAccessLevel(readerRole.groupRole)
-                )
+
+        allModels.findAll { it.readableByAuthenticatedUsers }.each {model ->
+            // Add reader access on each container
+            virtualSecurableResourceGroupRoles.add(virtualSecurableResourceGroupRoleService.buildForSecurableResource(model, folderModelMap)
+                                                       .withAccessLevel(readerRole.groupRole)
+            )
 
 
-                // Need to make sure the owning folders are readable
-                virtualSecurableResourceGroupRoles.addAll(buildReadableContainerInheritance(model.folder,
-                                                                                            readerRole.allowedRoles,
-                                                                                            null,
-                                                                                            readerRole.groupRole))
-            }
+            // Need to make sure the owning folders are readable
+            virtualSecurableResourceGroupRoles.addAll(buildReadableContainerInheritance(model.folder,
+                                                                                        readerRole.allowedRoles,
+                                                                                        null,
+                                                                                        readerRole.groupRole))
+
         }
         virtualSecurableResourceGroupRoles
     }
@@ -528,8 +556,14 @@ class UserSecurityPolicyService {
 
         if (!container) return [] as HashSet
 
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
+
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = accessRoles.collect {igr ->
-            virtualSecurableResourceGroupRoleService.buildForSecurableResource(container)
+            virtualSecurableResourceGroupRoleService.buildForSecurableResource(container, folderModelMap)
                 .withAccessLevel(igr)
                 .definedByGroup(userGroup)
                 .definedByAccessLevel(appliedGroupRole)
@@ -543,7 +577,7 @@ class UserSecurityPolicyService {
             ContainerService containerService = containerServices.find {it.handles(container.domainType)}
             containerService.getAll(ids).each {alternateContainer ->
                 virtualSecurableResourceGroupRoles.addAll(accessRoles.collect {igr ->
-                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(alternateContainer as Container)
+                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(alternateContainer as Container, folderModelMap)
                         .withAccessLevel(igr)
                         .definedByGroup(userGroup)
                         .definedByAccessLevel(appliedGroupRole)
@@ -561,19 +595,24 @@ class UserSecurityPolicyService {
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as Set
 
         // Load models
-        modelServices.each {modelService ->
+        List<Model> allModels = modelServices.collectMany {service ->
+            service.list()
+        } as List<Model>
 
-            List<Model> models = modelService.findAllByContainerId(container.id) as List<Model>
+        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        List<Model> models = folderModelMap[container.id]
+        if(models) {
             models.each {Model model ->
                 virtualSecurableResourceGroupRoles.addAll(
                     accessRoles.collect {igr ->
                         virtualSecurableResourceGroupRoleService
-                            .buildForSecurableResource(model)
+                            .buildForSecurableResource(model, folderModelMap)
                             .withAccessLevel(igr)
                             .definedByGroup(userGroup)
                             .definedByAccessLevel(appliedGroupRole)
                     }
                 )
+
             }
         }
 

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/UserSecurityPolicyService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/UserSecurityPolicyService.groovy
@@ -409,34 +409,35 @@ class UserSecurityPolicyService {
             // Load in the actual securable resource
             sgr.setSecurableResource(securableResourceGroupRoleService.findSecurableResource(sgr.securableResourceDomainType,
                                                                                              sgr.securableResourceId), true)
-            // Setup all the direct virtual roles
-            Set<GroupRole> allowedRoles = groupRoleService.getFromCache(sgr.groupRole.name).allowedRoles
-            virtualSecurableResourceGroupRoles.addAll(
-                allowedRoles.collect {igr ->
-                    virtualSecurableResourceGroupRoleService.buildFromSecurableResourceGroupRole(sgr)
-                        .withAccessLevel(igr)
+            if(sgr.securableResource) {
+                // Setup all the direct virtual roles
+                Set<GroupRole> allowedRoles = groupRoleService.getFromCache(sgr.groupRole.name).allowedRoles
+                virtualSecurableResourceGroupRoles.addAll(
+                    allowedRoles.collect {igr ->
+                        virtualSecurableResourceGroupRoleService.buildFromSecurableResourceGroupRole(sgr)
+                            .withAccessLevel(igr)
+                    }
+                )
+
+                if ((sgr.securableResource as GormEntityApi).instanceOf(Container)) {
+                    // If we're securing a container then we need to create virtual roles for all its contents
+                    ContainerService containerService = containerServices.find {it.handles(sgr.securableResourceDomainType)}
+                    if (containerService) {
+                        virtualSecurableResourceGroupRoles.addAll(buildControlledAccessToContentsOfContainer(sgr.securableResource as Container,
+                                                                                                             containerService,
+                                                                                                             allowedRoles,
+                                                                                                             sgr.userGroup,
+                                                                                                             sgr.groupRole))
+
+                    }
                 }
-            )
-
-            if ((sgr.securableResource as GormEntityApi).instanceOf(Container)) {
-                // If we're securing a container then we need to create virtual roles for all its contents
-                ContainerService containerService = containerServices.find {it.handles(sgr.securableResourceDomainType)}
-                if (containerService) {
-                    virtualSecurableResourceGroupRoles.addAll(buildControlledAccessToContentsOfContainer(sgr.securableResource as Container,
-                                                                                                         containerService,
-                                                                                                         allowedRoles,
-                                                                                                         sgr.userGroup,
-                                                                                                         sgr.groupRole))
-
+                else if ((sgr.securableResource as GormEntityApi).instanceOf(Model)) {
+                    // If we're securing a model we need to make sure the model's folder tree is readable
+                    // As we're only adding the folder as readable the other contents wont be visible as they arent iterated through
+                    virtualSecurableResourceGroupRoles.addAll(buildControlledAccessToFoldersOfModel(sgr.securableResource as Model,
+                                                                                                    sgr.userGroup,
+                                                                                                    sgr.groupRole))
                 }
-            }
-
-            if ((sgr.securableResource as GormEntityApi).instanceOf(Model)) {
-                // If we're securing a model we need to make sure the model's folder tree is readable
-                // As we're only adding the folder as readable the other contents wont be visible as they arent iterated through
-                virtualSecurableResourceGroupRoles.addAll(buildControlledAccessToFoldersOfModel(sgr.securableResource as Model,
-                                                                                                sgr.userGroup,
-                                                                                                sgr.groupRole))
             }
         }
 

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/UserSecurityPolicyService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/policy/UserSecurityPolicyService.groovy
@@ -283,12 +283,14 @@ class UserSecurityPolicyService {
                                                                                           appliedGroupRole)
         } else virtualSecurableResourceGroupRoles = [] as HashSet
 
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
+
         // Load sub containers
         List<Container> subContainers = containerService.findAllContainersInside(container.path.last()) as List<Container>
         subContainers.each {subContainer ->
             virtualSecurableResourceGroupRoles.addAll(
                 accessRoles.collect {igr ->
-                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(subContainer)
+                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(subContainer, folderModelMap)
                         .withAccessLevel(igr)
                         .definedByGroup(userGroup)
                         .definedByAccessLevel(appliedGroupRole)
@@ -313,11 +315,7 @@ class UserSecurityPolicyService {
         // Only deal with folders, there is a question around if you can see a model can you read all its classifiers??
         // We need to make the tree of folders down to the model readable so that the tree can be rendered,
         // As these are virtual roles we dont iterate into any of the folders, we just want to make that folder and its parents readable
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
-
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
 
         folderService
             .findAllWhereDirectParentOfModel(model)
@@ -339,16 +337,12 @@ class UserSecurityPolicyService {
         Set<GroupRole> inheritedUserRoles = virtualGroupRole.allowedRoles
         List<CatalogueUser> users = catalogueUserService.list([:])
 
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
-
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
 
         users.each {user ->
             virtualSecurableResourceGroupRoles.addAll(
                 inheritedUserRoles.collect {iur ->
-                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(user)
+                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(user, folderModelMap)
                         .definedByAccessLevel(highestRole)
                         .withAccessLevel(iur)
                 }
@@ -367,10 +361,12 @@ class UserSecurityPolicyService {
         Set<GroupRole> inheritedUserRoles = virtualGroupRole.allowedRoles
         List<UserGroup> userGroups = userGroupService.list([:])
 
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
+
         userGroups.each {user ->
             virtualSecurableResourceGroupRoles.addAll(
                 inheritedUserRoles.collect {iur ->
-                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(user)
+                    virtualSecurableResourceGroupRoleService.buildForSecurableResource(user, folderModelMap)
                         .definedByAccessLevel(highestRole)
                         .withAccessLevel(iur)
                 }
@@ -384,11 +380,7 @@ class UserSecurityPolicyService {
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as Set
         Set<GroupRole> inheritedContainerRoles = groupRoleService.getFromCache(GroupRole.CONTAINER_ADMIN_ROLE_NAME).allowedRoles
         // Don't bother with usergroups or users as these will be implicitly defined by the other roles under application_admin
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
-
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
 
         securableResourceServices.findAll {!it.handles(UserGroup) && !it.handles(CatalogueUser)}.each {service ->
 
@@ -466,11 +458,9 @@ class UserSecurityPolicyService {
     private Set<VirtualSecurableResourceGroupRole> buildReadableByEveryone() {
         VirtualGroupRole readerRole = groupRoleService.getFromCache(GroupRole.READER_ROLE_NAME)
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as HashSet
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
 
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        List<Model> allModels = getAllModels()
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap(allModels)
 
         containerServices.each {service ->
             List<Container> containers = service.findAllReadableByEveryone() as List<Container>
@@ -507,11 +497,8 @@ class UserSecurityPolicyService {
 
     private Set<VirtualSecurableResourceGroupRole> buildReadableByAuthenticatedUsers() {
 
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
-
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        List<Model> allModels = getAllModels()
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap(allModels)
 
         VirtualGroupRole readerRole = groupRoleService.getFromCache(GroupRole.READER_ROLE_NAME)
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as HashSet
@@ -556,11 +543,7 @@ class UserSecurityPolicyService {
 
         if (!container) return [] as HashSet
 
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
-
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
 
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = accessRoles.collect {igr ->
             virtualSecurableResourceGroupRoleService.buildForSecurableResource(container, folderModelMap)
@@ -595,11 +578,8 @@ class UserSecurityPolicyService {
         Set<VirtualSecurableResourceGroupRole> virtualSecurableResourceGroupRoles = [] as Set
 
         // Load models
-        List<Model> allModels = modelServices.collectMany {service ->
-            service.list()
-        } as List<Model>
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
 
-        Map<UUID, List<Model>> folderModelMap = allModels.groupBy { it.id}
         List<Model> models = folderModelMap[container.id]
         if(models) {
             models.each {Model model ->
@@ -623,8 +603,10 @@ class UserSecurityPolicyService {
     private Set<VirtualSecurableResourceGroupRole> buildIndividualCatalogueUserVirtualRoles(CatalogueUser catalogueUser,
                                                                                             VirtualGroupRole applicationRole) {
 
+        Map<UUID, List<Model>> folderModelMap = calculateFolderModelMap()
+
         applicationRole.allowedRoles.collect {iur ->
-            virtualSecurableResourceGroupRoleService.buildForSecurableResource(catalogueUser)
+            virtualSecurableResourceGroupRoleService.buildForSecurableResource(catalogueUser, folderModelMap)
                 .definedByAccessLevel(applicationRole.groupRole)
                 .withAccessLevel(iur)
         }.toSet()
@@ -646,5 +628,22 @@ class UserSecurityPolicyService {
             allRolesToRemove.removeAll(canBeRemoved)
             removeRolesWithNoRequiredAccess(userSecurityPolicy, allRolesToRemove)
         }
+    }
+
+    List<Model> getAllModels() {
+        if (modelServices) {
+            modelServices.collectMany {service -> service.list()} as List<Model>
+        } else {
+            []
+        }
+    }
+
+    Map<UUID, List<Model>> calculateFolderModelMap() {
+        calculateFolderModelMap(getAllModels())
+    }
+
+
+    Map<UUID, List<Model>> calculateFolderModelMap(List<Model> allModels) {
+        return allModels.groupBy {it.folder.id}
     }
 }

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/VirtualSecurableResourceGroupRoleService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/VirtualSecurableResourceGroupRoleService.groovy
@@ -48,7 +48,7 @@ class VirtualSecurableResourceGroupRoleService {
             List<Model> allModels = modelServices.collectMany {service ->
                 service.list()
             } as List<Model>
-             folderModelMap = allModels.groupBy { it.id}
+             folderModelMap = allModels.groupBy { it.folder.id}
         }
 
 
@@ -73,7 +73,7 @@ class VirtualSecurableResourceGroupRoleService {
             virtualRole
                 .withDependencyOnAccessToDomainId((securableResource as Folder).parentFolder?.id)
                 .asVersionControlled(versionedFolderService.hasVersionedFolderParent(securableResource as Folder))
-                .withVersionedContents(versionedFolderService.doesDepthTreeContainVersionedFolder(securableResource as Folder) ||
+                .withVersionedContents(versionedFolderService.doesDepthTreeContainVersionedFolder(securableResource as Folder, folderModelMap) ||
                                        versionedFolderService.doesDepthTreeContainFinalisedModel(securableResource as Folder, folderModelMap))
         } else if (Utils.parentClassIsAssignableFromChild(Classifier, securableResource.class)) {
             virtualRole.withDependencyOnAccessToDomainId((securableResource as Classifier).parentClassifier?.id)

--- a/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/VirtualSecurableResourceGroupRoleService.groovy
+++ b/mdm-security/grails-app/services/uk/ac/ox/softeng/maurodatamapper/security/role/VirtualSecurableResourceGroupRoleService.groovy
@@ -23,25 +23,47 @@ import uk.ac.ox.softeng.maurodatamapper.core.container.VersionedFolder
 import uk.ac.ox.softeng.maurodatamapper.core.container.VersionedFolderService
 import uk.ac.ox.softeng.maurodatamapper.core.gorm.constraint.callable.VersionAwareConstraints
 import uk.ac.ox.softeng.maurodatamapper.core.model.Model
+import uk.ac.ox.softeng.maurodatamapper.core.model.ModelService
 import uk.ac.ox.softeng.maurodatamapper.security.SecurableResource
 import uk.ac.ox.softeng.maurodatamapper.util.Utils
 
+import grails.core.support.proxy.ProxyHandler
 import grails.gorm.transactions.Transactional
+import org.springframework.beans.factory.annotation.Autowired
 
 @Transactional
 class VirtualSecurableResourceGroupRoleService {
 
+    @Autowired(required = false)
+    List<ModelService> modelServices
+
+    @Autowired
+    ProxyHandler proxyHandler
+
     VersionedFolderService versionedFolderService
 
     VirtualSecurableResourceGroupRole buildFromSecurableResourceGroupRole(SecurableResourceGroupRole securableResourceGroupRole) {
-        this.buildForSecurableResource(securableResourceGroupRole.securableResource)
+        Map<UUID, List<Model>> folderModelMap = null
+        if(modelServices) {
+            List<Model> allModels = modelServices.collectMany {service ->
+                service.list()
+            } as List<Model>
+             folderModelMap = allModels.groupBy { it.id}
+        }
+
+
+        this.buildForSecurableResource(securableResourceGroupRole.securableResource, folderModelMap)
             .definedByGroup(securableResourceGroupRole.userGroup)
             .definedByAccessLevel(securableResourceGroupRole.groupRole)
     }
 
-    VirtualSecurableResourceGroupRole buildForSecurableResource(SecurableResource securableResource) {
+    VirtualSecurableResourceGroupRole buildForSecurableResource(SecurableResource securableResource, Map<UUID, List<Model>> folderModelMap = [:]) {
+
+        securableResource = (SecurableResource) proxyHandler.unwrapIfProxy(securableResource)
+
         VirtualSecurableResourceGroupRole virtualRole = new VirtualSecurableResourceGroupRole()
             .forSecurableResource(securableResource)
+
 
         if (securableResource.domainType == VersionedFolder.simpleName) {
             virtualRole.withAlternateDomainType(Folder.simpleName)
@@ -52,7 +74,7 @@ class VirtualSecurableResourceGroupRoleService {
                 .withDependencyOnAccessToDomainId((securableResource as Folder).parentFolder?.id)
                 .asVersionControlled(versionedFolderService.hasVersionedFolderParent(securableResource as Folder))
                 .withVersionedContents(versionedFolderService.doesDepthTreeContainVersionedFolder(securableResource as Folder) ||
-                                       versionedFolderService.doesDepthTreeContainFinalisedModel(securableResource as Folder))
+                                       versionedFolderService.doesDepthTreeContainFinalisedModel(securableResource as Folder, folderModelMap))
         } else if (Utils.parentClassIsAssignableFromChild(Classifier, securableResource.class)) {
             virtualRole.withDependencyOnAccessToDomainId((securableResource as Classifier).parentClassifier?.id)
         }
@@ -71,7 +93,7 @@ class VirtualSecurableResourceGroupRoleService {
         }
 
         if (Utils.parentClassIsAssignableFromChild(VersionedFolder, securableResource.class)) {
-            VersionedFolder versionedFolder = securableResource as VersionedFolder
+            VersionedFolder versionedFolder = (VersionedFolder) proxyHandler.unwrapIfProxy(securableResource)
             virtualRole.asFinalised(versionedFolder.finalised)
                 .asFinalisable(versionedFolder.branchName == VersionAwareConstraints.DEFAULT_BRANCH_NAME)
                 .asVersionable(true)

--- a/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessWithoutUpdatingFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/UserAccessWithoutUpdatingFunctionalSpec.groovy
@@ -189,7 +189,7 @@ abstract class UserAccessWithoutUpdatingFunctionalSpec extends ReadOnlyUserAcces
             // Seems to be possible in the UserGroupFS to get a result in groupsLeftOver which is then empty on the second call, possibly a timing issue
             if (groupsToDelete*.id) {
                 // This is purely here to provide info about roles and resources which havent been cleaned up
-                // It should not be used to perform cleanp of these roles and resources
+                // It should not be used to perform cleanup of these roles and resources
                 List<SecurableResourceGroupRole> rolesLeftOver = SecurableResourceGroupRole.byUserGroupIds(groupsToDelete*.id).list()
 
                 if (rolesLeftOver) {


### PR DESCRIPTION
This PR massively speeds up the deletion of Versioned Folders by reducing the number of queries and not building the breadcrumb tree white so often