### PR TITLE
gh-475 Edit history for merged items under versioned folders

### DIFF
--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -56,6 +56,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.rest.converter.json.OffsetDateTimeC
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.FieldPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.ObjectPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.VersionTreeModel
+import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.EditHistoryAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.MultiFacetItemAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MdmDomainService
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MultiFacetItemAwareService
@@ -1088,18 +1089,19 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         // Potential creations are folders, models, modelItems or facets
         if (Utils.parentClassIsAssignableFromChild(Folder, domainToCopy.class)) {
             processCreationPatchOfFolder(domainToCopy as Folder, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
-                                         userSecurityPolicyManager)
+                                         userSecurityPolicyManager, sourceVersionedFolder)
         }
         if (Utils.parentClassIsAssignableFromChild(Model, domainToCopy.class)) {
             processCreationPatchOfModel(domainToCopy as Model, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
-                                        userSecurityPolicyManager)
+                                        userSecurityPolicyManager, sourceVersionedFolder)
         }
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domainToCopy.class)) {
             processCreationPatchOfModelItem(domainToCopy as ModelItem, targetVersionedFolder, creationPatch.relativePathToRoot,
-                                            userSecurityPolicyManager)
+                                            userSecurityPolicyManager, sourceVersionedFolder)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domainToCopy.class)) {
-            processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetVersionedFolder, creationPatch.relativePathToRoot.parent)
+            processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
+                                        userSecurityPolicyManager, sourceVersionedFolder)
         }
     }
 
@@ -1208,40 +1210,49 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     }
 
     void processCreationPatchOfFolder(Folder folderToCopy, VersionedFolder targetVersionedFolder, Path relativeParentPathToCopyTo,
-                                      UserSecurityPolicyManager userSecurityPolicyManager) {
+                                      UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
         log.debug('Creating Folder into VersionedFolder at [{}]', relativeParentPathToCopyTo)
         Folder parentFolder =
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, relativeParentPathToCopyTo,
                                                            getModelIdentifier(targetVersionedFolder)) as Folder
-        folderService.copyFolder(folderToCopy, parentFolder, userSecurityPolicyManager.user, true, targetVersionedFolder.branchName,
-                                 targetVersionedFolder.documentationVersion, false, userSecurityPolicyManager)
+        def copiedFolder = folderService.copyFolder(folderToCopy, parentFolder, userSecurityPolicyManager.user, true, targetVersionedFolder.branchName,
+                                                            targetVersionedFolder.documentationVersion, false, userSecurityPolicyManager)
+
+        copiedFolder.addMergeEdit(userSecurityPolicyManager.user, "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'")
     }
 
     void processCreationPatchOfModel(Model modelToCopy, VersionedFolder targetVersionedFolder, Path relativeParentPathToCopyTo,
-                                     UserSecurityPolicyManager userSecurityPolicyManager) {
+                                     UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
         ModelService modelService = folderService.findModelServiceForModel(modelToCopy)
         log.debug('Creating Model into VersionedFolder at [{}]', relativeParentPathToCopyTo)
         Folder parentFolder =
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, relativeParentPathToCopyTo,
                                                            getModelIdentifier(targetVersionedFolder)) as Folder
-        modelService.copyModelAndValidateAndSave(modelToCopy, parentFolder, userSecurityPolicyManager.user, true, modelToCopy.label,
-                                                 modelToCopy.documentationVersion,
-                                                 targetVersionedFolder.branchName, false, userSecurityPolicyManager)
+        def copiedModel = modelService.copyModelAndValidateAndSave(modelToCopy, parentFolder, userSecurityPolicyManager.user, true, modelToCopy.label,
+                                                                            modelToCopy.documentationVersion,
+                                                                            targetVersionedFolder.branchName, false, userSecurityPolicyManager)
+
+        copiedModel.addMergeEdit(userSecurityPolicyManager.user, "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'")
     }
 
     void processCreationPatchOfModelItem(ModelItem modelItemToCopy, VersionedFolder targetVersionedFolder, Path relativePathToCopyTo,
-                                         UserSecurityPolicyManager userSecurityPolicyManager) {
+                                         UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
 
         Map<String, Object> modelInformation =
             findModelInformationForModelItemMergePatch(targetVersionedFolder, relativePathToCopyTo, modelItemToCopy.domainType)
+
+        String mergeEditDescription = "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'"
+
         (modelInformation.modelService as ModelService).processCreationPatchOfModelItem(modelItemToCopy,
                                                                                         modelInformation.targetModel as Model,
                                                                                         (modelInformation.modelItemToModelAbsolutePath as Path),
                                                                                         userSecurityPolicyManager,
+                                                                                        mergeEditDescription,
                                                                                         true)
     }
 
-    void processCreationPatchOfFacet(MultiFacetItemAware multiFacetItemAwareToCopy, VersionedFolder targetVersionedFolder, Path parentPathToCopyTo) {
+    void processCreationPatchOfFacet(MultiFacetItemAware multiFacetItemAwareToCopy, VersionedFolder targetVersionedFolder, Path parentPathToCopyTo,
+                                     UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
         MultiFacetItemAwareService multiFacetItemAwareService = multiFacetItemAwareServices.find {it.handles(multiFacetItemAwareToCopy.class)}
         if (!multiFacetItemAwareService) {
             throw new ApiInternalException('MSXX',
@@ -1257,6 +1268,11 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         if (!copy.validate()) throw new ApiInvalidModelException('MS01', 'Copied Facet is invalid', copy.errors, messageSource)
 
         multiFacetItemAwareService.save(copy, flush: false, validate: false)
+        if (Utils.parentClassIsAssignableFromChild(EditHistoryAware, copy.class)) {
+            (copy as EditHistoryAware).addMergeEdit(
+                userSecurityPolicyManager.user,
+                "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'")
+        }
     }
 
     @Override

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -57,6 +57,7 @@ import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.FieldPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.ObjectPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.VersionTreeModel
 import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.EditHistoryAware
+import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.InformationAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.MultiFacetItemAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MdmDomainService
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MultiFacetItemAwareService
@@ -1043,9 +1044,11 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                     return processCreationPatchIntoVersionedFolder(fieldPatch, target, get(sourceVersionedFolder.id),
                                                                    userSecurityPolicyManager)
                 case 'deletion':
-                    return processDeletionPatchIntoVersionedFolder(fieldPatch, target)
+                    return processDeletionPatchIntoVersionedFolder(fieldPatch, target, get(sourceVersionedFolder.id),
+                                                                   userSecurityPolicyManager)
                 case 'modification':
-                    return processModificationPatchIntoVersionedFolder(fieldPatch, target)
+                    return processModificationPatchIntoVersionedFolder(fieldPatch, target, get(sourceVersionedFolder.id),
+                                                                       userSecurityPolicyManager)
                 default:
                     log.warn('Unknown field patch type [{}]', fieldPatch.type)
             }
@@ -1086,26 +1089,29 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             return
         }
         log.debug('Creating [{}]', creationPatch.path.toString(getModelIdentifier(targetVersionedFolder)))
+        String mergeEditDescription = "Item created in '$sourceVersionedFolder.label\$$sourceVersionedFolder.branchName'"
+
         // Potential creations are folders, models, modelItems or facets
         if (Utils.parentClassIsAssignableFromChild(Folder, domainToCopy.class)) {
             processCreationPatchOfFolder(domainToCopy as Folder, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
-                                         userSecurityPolicyManager, sourceVersionedFolder)
+                                         userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(Model, domainToCopy.class)) {
             processCreationPatchOfModel(domainToCopy as Model, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
-                                        userSecurityPolicyManager, sourceVersionedFolder)
+                                        userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domainToCopy.class)) {
             processCreationPatchOfModelItem(domainToCopy as ModelItem, targetVersionedFolder, creationPatch.relativePathToRoot,
-                                            userSecurityPolicyManager, sourceVersionedFolder)
+                                            userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domainToCopy.class)) {
             processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
-                                        userSecurityPolicyManager, sourceVersionedFolder)
+                                        userSecurityPolicyManager, mergeEditDescription)
         }
     }
 
-    void processDeletionPatchIntoVersionedFolder(FieldPatchData deletionPatch, VersionedFolder targetVersionedFolder) {
+    void processDeletionPatchIntoVersionedFolder(FieldPatchData deletionPatch, VersionedFolder targetVersionedFolder, VersionedFolder sourceVersionedFolder,
+                                                 UserSecurityPolicyManager userSecurityPolicyManager) {
         MdmDomain domain =
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, deletionPatch.relativePathToRoot,
                                                            getModelIdentifier(targetVersionedFolder))
@@ -1116,22 +1122,29 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         }
         log.debug('Deleting [{}]', deletionPatch.path.toString(getModelIdentifier(targetVersionedFolder)))
 
+        String itemRemovedLabel = (domain as InformationAware)?.label
+        String mergeEditSuffix = itemRemovedLabel ?: domain.domainType ?: ""
+        String mergeEditDescription = "Item removed from '$sourceVersionedFolder.label\$$sourceVersionedFolder.branchName' - $mergeEditSuffix"
+
         // Potential deletions are folders, models, modelItems or facets
         if (Utils.parentClassIsAssignableFromChild(Folder, domain.class)) {
-            processDeletionPatchOfFolder(domain as Folder)
+            processDeletionPatchOfFolder(domain as Folder, targetVersionedFolder, userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(Model, domain.class)) {
-            processDeletionPatchOfModel(domain as Model)
+            processDeletionPatchOfModel(domain as Model, targetVersionedFolder, userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domain.class)) {
-            processDeletionPatchOfModelItem(domain as ModelItem, targetVersionedFolder, deletionPatch.relativePathToRoot)
+            processDeletionPatchOfModelItem(domain as ModelItem, targetVersionedFolder, deletionPatch.relativePathToRoot,
+                                            userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domain.class)) {
-            processDeletionPatchOfFacet(domain as MultiFacetItemAware, targetVersionedFolder, deletionPatch.relativePathToRoot)
+            processDeletionPatchOfFacet(domain as MultiFacetItemAware, targetVersionedFolder, deletionPatch.relativePathToRoot,
+                                        userSecurityPolicyManager, mergeEditDescription)
         }
     }
 
-    void processModificationPatchIntoVersionedFolder(FieldPatchData modificationPatch, VersionedFolder targetVersionedFolder) {
+    void processModificationPatchIntoVersionedFolder(FieldPatchData modificationPatch, VersionedFolder targetVersionedFolder,
+                                                     VersionedFolder sourceVersionedFolder, UserSecurityPolicyManager userSecurityPolicyManager) {
         MdmDomain domain =
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, modificationPatch.relativePathToRoot,
                                                            getModelIdentifier(targetVersionedFolder))
@@ -1156,27 +1169,45 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         domainService.validate(domain)
         if (domain.hasErrors()) throw new ApiInvalidModelException('MS01', 'Modified domain is invalid', domain.errors, messageSource)
         domainService.save(domain, flush: false, validate: false)
+
+        if (domain instanceof EditHistoryAware) {
+            String mergeEditDescription = "Item modified in '$sourceVersionedFolder.label\$$sourceVersionedFolder.branchName'"
+            (domain as EditHistoryAware).addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
     }
 
-    void processDeletionPatchOfFolder(Folder folder) {
+    void processDeletionPatchOfFolder(Folder folder, Container defaultParent,
+                                      UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
+        Container parent = folder.parent ?: defaultParent
+
         log.debug('Deleting Folder from VersionedFolder')
         folderService.delete(folder, true, false)
+
+        parent.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
-    void processDeletionPatchOfModel(Model model) {
+    void processDeletionPatchOfModel(Model model, Container defaultParent,
+                                     UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
+        Container parent = model.folder ?: defaultParent
         ModelService modelService = folderService.findModelServiceForModel(model)
+
         log.debug('Deleting Model from VersionedFolder')
         modelService.delete(model, true, false)
+
+        parent.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
-    void processDeletionPatchOfModelItem(ModelItem modelItem, VersionedFolder targetVersionedFolder, Path relativePathToRemoveFrom) {
+    void processDeletionPatchOfModelItem(ModelItem modelItem, VersionedFolder targetVersionedFolder, Path relativePathToRemoveFrom,
+                                         UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         Map<String, Object> modelInformation =
             findModelInformationForModelItemMergePatch(targetVersionedFolder, relativePathToRemoveFrom, modelItem.domainType)
 
-        (modelInformation.modelService as ModelService).processDeletionPatchOfModelItem(modelItem, modelInformation.targetModel as Model, relativePathToRemoveFrom)
+        (modelInformation.modelService as ModelService).processDeletionPatchOfModelItem(modelItem, modelInformation.targetModel as Model,
+                                                                                        relativePathToRemoveFrom, userSecurityPolicyManager, mergeEditDescription)
     }
 
-    MultiFacetAware processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, VersionedFolder targetVersionedFolder, Path path) {
+    MultiFacetAware processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, VersionedFolder targetVersionedFolder, Path path,
+                                                UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         MultiFacetItemAwareService multiFacetItemAwareService = multiFacetItemAwareServices.find {it.handles(multiFacetItemAware.class)}
         if (!multiFacetItemAwareService) throw new ApiInternalException('MSXX',
                                                                         "No domain service to handle deletion of [${multiFacetItemAware.domainType}]")
@@ -1206,11 +1237,19 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                 (multiFacetAwareItem as Model).versionLinks.remove(multiFacetItemAware)
                 break
         }
+
+        if (multiFacetItemAware instanceof EditHistoryAware) {
+            (multiFacetItemAware as EditHistoryAware).addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
+        else {
+            targetVersionedFolder.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
+
         multiFacetAwareItem
     }
 
     void processCreationPatchOfFolder(Folder folderToCopy, VersionedFolder targetVersionedFolder, Path relativeParentPathToCopyTo,
-                                      UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
+                                      UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         log.debug('Creating Folder into VersionedFolder at [{}]', relativeParentPathToCopyTo)
         Folder parentFolder =
             pathService.findResourceByPathFromRootResource(targetVersionedFolder, relativeParentPathToCopyTo,
@@ -1218,11 +1257,11 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         def copiedFolder = folderService.copyFolder(folderToCopy, parentFolder, userSecurityPolicyManager.user, true, targetVersionedFolder.branchName,
                                                             targetVersionedFolder.documentationVersion, false, userSecurityPolicyManager)
 
-        copiedFolder.addMergeEdit(userSecurityPolicyManager.user, "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'")
+        copiedFolder.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
     void processCreationPatchOfModel(Model modelToCopy, VersionedFolder targetVersionedFolder, Path relativeParentPathToCopyTo,
-                                     UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
+                                     UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         ModelService modelService = folderService.findModelServiceForModel(modelToCopy)
         log.debug('Creating Model into VersionedFolder at [{}]', relativeParentPathToCopyTo)
         Folder parentFolder =
@@ -1232,16 +1271,13 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
                                                                             modelToCopy.documentationVersion,
                                                                             targetVersionedFolder.branchName, false, userSecurityPolicyManager)
 
-        copiedModel.addMergeEdit(userSecurityPolicyManager.user, "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'")
+        copiedModel.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
     void processCreationPatchOfModelItem(ModelItem modelItemToCopy, VersionedFolder targetVersionedFolder, Path relativePathToCopyTo,
-                                         UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
-
+                                         UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         Map<String, Object> modelInformation =
             findModelInformationForModelItemMergePatch(targetVersionedFolder, relativePathToCopyTo, modelItemToCopy.domainType)
-
-        String mergeEditDescription = "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'"
 
         (modelInformation.modelService as ModelService).processCreationPatchOfModelItem(modelItemToCopy,
                                                                                         modelInformation.targetModel as Model,
@@ -1252,7 +1288,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     }
 
     void processCreationPatchOfFacet(MultiFacetItemAware multiFacetItemAwareToCopy, VersionedFolder targetVersionedFolder, Path parentPathToCopyTo,
-                                     UserSecurityPolicyManager userSecurityPolicyManager, VersionedFolder sourceVersionedFolder) {
+                                     UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         MultiFacetItemAwareService multiFacetItemAwareService = multiFacetItemAwareServices.find {it.handles(multiFacetItemAwareToCopy.class)}
         if (!multiFacetItemAwareService) {
             throw new ApiInternalException('MSXX',
@@ -1268,10 +1304,8 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
         if (!copy.validate()) throw new ApiInvalidModelException('MS01', 'Copied Facet is invalid', copy.errors, messageSource)
 
         multiFacetItemAwareService.save(copy, flush: false, validate: false)
-        if (Utils.parentClassIsAssignableFromChild(EditHistoryAware, copy.class)) {
-            (copy as EditHistoryAware).addMergeEdit(
-                userSecurityPolicyManager.user,
-                "Merged from '$sourceVersionedFolder.label:$sourceVersionedFolder.branchName'")
+        if (copy instanceof EditHistoryAware) {
+            (copy as EditHistoryAware).addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
         }
     }
 

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -714,11 +714,14 @@ abstract class ModelService<K extends Model>
 
     }
 
-    void processDeletionPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToDelete) {
+    void processDeletionPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToDelete,
+                                         UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         ModelItemService modelItemService = modelItemServices.find {it.handles(modelItem.class)}
         if (!modelItemService) throw new ApiInternalException('MSXX', "No domain service to handle deletion of [${modelItem.domainType}]")
         log.debug('Deleting ModelItem from Model')
         modelItemService.delete(modelItem)
+
+        targetModel.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
     CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path) {

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -753,7 +753,8 @@ abstract class ModelService<K extends Model>
     }
 
     void processCreationPatchOfModelItem(ModelItem modelItemToCopy, Model targetModel, Path pathToCopy,
-                                         UserSecurityPolicyManager userSecurityPolicyManager, boolean flush = false) {
+                                         UserSecurityPolicyManager userSecurityPolicyManager,
+                                         String mergeEditDescription, boolean flush = false) {
         ModelItemService modelItemService = modelItemServices.find {it.handles(modelItemToCopy.class)}
         if (!modelItemService) throw new ApiInternalException('MSXX', "No domain service to handle creation of [${modelItemToCopy.domainType}]")
         log.debug('Creating [{}] ModelItem into Model at [{}]', pathToCopy, pathToCopy.parent)
@@ -765,6 +766,8 @@ abstract class ModelService<K extends Model>
             throw new ApiInvalidModelException('MS01', 'Copied ModelItem is invalid', copy.errors, messageSource)
 
         modelItemService.save(copy, flush: flush, validate: false)
+
+        copy.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
     void processCreationPatchOfFacet(MultiFacetItemAware multiFacetItemAwareToCopy, Model targetModel, Path parentPathToCopyTo) {

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/model/ModelService.groovy
@@ -56,6 +56,8 @@ import uk.ac.ox.softeng.maurodatamapper.core.rest.converter.json.OffsetDateTimeC
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.FieldPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.merge.ObjectPatchData
 import uk.ac.ox.softeng.maurodatamapper.core.rest.transport.model.VersionTreeModel
+import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.EditHistoryAware
+import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.InformationAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.domain.MultiFacetItemAware
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MdmDomainService
 import uk.ac.ox.softeng.maurodatamapper.core.traits.service.MultiFacetItemAwareService
@@ -614,9 +616,9 @@ abstract class ModelService<K extends Model>
                 case 'creation':
                     return processCreationPatchIntoModel(fieldPatch, targetModel, sourceModel, userSecurityPolicyManager)
                 case 'deletion':
-                    return processDeletionPatchIntoModel(fieldPatch, targetModel)
+                    return processDeletionPatchIntoModel(fieldPatch, targetModel, sourceModel, userSecurityPolicyManager)
                 case 'modification':
-                    return processModificationPatchIntoModel(fieldPatch, targetModel)
+                    return processModificationPatchIntoModel(fieldPatch, targetModel, sourceModel, userSecurityPolicyManager)
                 default:
                     log.warn('Unknown field patch type [{}]', fieldPatch.type)
             }
@@ -648,16 +650,20 @@ abstract class ModelService<K extends Model>
             return
         }
         log.debug('Creating [{}] into [{}]', creationPatch.path, creationPatch.relativePathToRoot.parent)
+        String mergeEditDescription = "Item created in '$sourceModel.label\$$sourceModel.branchName'"
+
         // Potential creations are modelitems or facets from model or modelitem
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domainToCopy.class)) {
-            processCreationPatchOfModelItem(domainToCopy as ModelItem, targetModel, creationPatch.relativePathToRoot, userSecurityPolicyManager)
+            processCreationPatchOfModelItem(domainToCopy as ModelItem, targetModel, creationPatch.relativePathToRoot,
+                                            userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domainToCopy.class)) {
-            processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetModel, creationPatch.relativePathToRoot.parent)
+            processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetModel, creationPatch.relativePathToRoot.parent,
+                                        userSecurityPolicyManager, mergeEditDescription)
         }
     }
 
-    void processDeletionPatchIntoModel(FieldPatchData deletionPatch, K targetModel) {
+    void processDeletionPatchIntoModel(FieldPatchData deletionPatch, K targetModel, K sourceModel, UserSecurityPolicyManager userSecurityPolicyManager) {
         MdmDomain domain = pathService.findResourceByPathFromRootResource(targetModel, deletionPatch.relativePathToRoot)
         if (!domain) {
             customProcessPatchIntoModelForUnfoundPath(deletionPatch, targetModel)
@@ -665,16 +671,20 @@ abstract class ModelService<K extends Model>
         }
         log.debug('Deleting [{}]', deletionPatch.relativePathToRoot)
 
+        String itemRemovedLabel = (domain as InformationAware)?.label
+        String mergeEditSuffix = itemRemovedLabel ?: domain.domainType ?: ""
+        String mergeEditDescription = "Item removed from '$sourceModel.label\$$sourceModel.branchName' - $mergeEditSuffix"
+
         // Potential deletions are modelitems or facets from model or modelitem
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domain.class)) {
-            processDeletionPatchOfModelItem(domain as ModelItem, targetModel, deletionPatch.relativePathToRoot)
+            processDeletionPatchOfModelItem(domain as ModelItem, targetModel, deletionPatch.relativePathToRoot, userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domain.class)) {
-            processDeletionPatchOfFacet(domain as MultiFacetItemAware, targetModel, deletionPatch.relativePathToRoot)
+            processDeletionPatchOfFacet(domain as MultiFacetItemAware, targetModel, deletionPatch.relativePathToRoot, userSecurityPolicyManager, mergeEditDescription)
         }
     }
 
-    void processModificationPatchIntoModel(FieldPatchData modificationPatch, K targetModel) {
+    void processModificationPatchIntoModel(FieldPatchData modificationPatch, K targetModel, K sourceModel, UserSecurityPolicyManager userSecurityPolicyManager) {
         MdmDomain domain = pathService.findResourceByPathFromRootResource(targetModel, modificationPatch.relativePathToRoot)
         if (!domain) {
             customProcessPatchIntoModelForUnfoundPath(modificationPatch, targetModel)
@@ -695,6 +705,11 @@ abstract class ModelService<K extends Model>
         if (!domain.validate())
             throw new ApiInvalidModelException('MS01', 'Modified domain is invalid', domain.errors, messageSource)
         domainService.save(domain, flush: false, validate: false)
+
+        if (domain instanceof EditHistoryAware) {
+            String mergeEditDescription = "Item modified in '$sourceModel.label\$$sourceModel.branchName'"
+            (domain as EditHistoryAware).addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
     }
 
     void customProcessPatchIntoModelForUnfoundPath(FieldPatchData fieldPatchData, K targetModel) {
@@ -724,7 +739,8 @@ abstract class ModelService<K extends Model>
         targetModel.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
-    CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path) {
+    CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path,
+                                              UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         MultiFacetItemAwareService multiFacetItemAwareService = multiFacetItemAwareServices.find {it.handles(multiFacetItemAware.class)}
         if (!multiFacetItemAwareService) throw new ApiInternalException('MSXX',
                                                                         "No domain service to handle deletion of [${multiFacetItemAware.domainType}]")
@@ -752,6 +768,14 @@ abstract class ModelService<K extends Model>
                 (catalogueItem as Model).versionLinks.remove(multiFacetItemAware)
                 break
         }
+
+        if (multiFacetItemAware instanceof EditHistoryAware) {
+            (multiFacetItemAware as EditHistoryAware).addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
+        else {
+            targetModel.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
+
         catalogueItem
     }
 
@@ -773,7 +797,8 @@ abstract class ModelService<K extends Model>
         copy.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
-    void processCreationPatchOfFacet(MultiFacetItemAware multiFacetItemAwareToCopy, Model targetModel, Path parentPathToCopyTo) {
+    void processCreationPatchOfFacet(MultiFacetItemAware multiFacetItemAwareToCopy, Model targetModel, Path parentPathToCopyTo,
+                                     UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         MultiFacetItemAwareService multiFacetItemAwareService = multiFacetItemAwareServices.find {it.handles(multiFacetItemAwareToCopy.class)}
         if (!multiFacetItemAwareService) {
             throw new ApiInternalException('MSXX',
@@ -788,6 +813,10 @@ abstract class ModelService<K extends Model>
             throw new ApiInvalidModelException('MS01', 'Copied Facet is invalid', copy.errors, messageSource)
 
         multiFacetItemAwareService.save(copy, flush: false, validate: false)
+
+        if (copy instanceof EditHistoryAware) {
+            (copy as EditHistoryAware).addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
+        }
     }
 
     List<VersionTreeModel> buildModelVersionTree(K instance, VersionLinkType versionLinkType,

--- a/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/domain/EditHistoryAware.groovy
+++ b/mdm-core/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/core/traits/domain/EditHistoryAware.groovy
@@ -92,6 +92,10 @@ trait EditHistoryAware {
         addToEditsTransactionally EditTitle.CHANGENOTICE, changer, changeNotice
     }
 
+    void addMergeEdit(User merger, String description) {
+        addToEditsTransactionally(EditTitle.MERGE, merger, description)
+    }
+
     List<Edit> getEdits() {
         Edit.findAllByResource(domainType, id)
     }

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -1132,7 +1132,8 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
     }
 
     @Override
-    void processDeletionPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToDelete) {
+    void processDeletionPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToDelete,
+                                         UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         // If the path to copy endswith the model item's path being copied then the model item cannot be inside the target model as the model item would already exist
         // and the path to copy must also therefore include a fully resolved model path after a modelitem path
         // This is indicitive of an imported object
@@ -1164,7 +1165,7 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
             }
             return
         }
-        super.processDeletionPatchOfModelItem(modelItem, targetModel, pathToDelete)
+        super.processDeletionPatchOfModelItem(modelItem, targetModel, pathToDelete, userSecurityPolicyManager, mergeEditDescription)
     }
 
     @Override

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -89,8 +89,6 @@ import static uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType.
 import static uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType.MODEL_DATA_DOMAIN_TYPE
 import static uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType.PRIMITIVE_DOMAIN_TYPE
 import static uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType.REFERENCE_DOMAIN_TYPE
-import static uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType.count
-import static uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType.get
 
 @Slf4j
 @Transactional
@@ -1169,8 +1167,9 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
     }
 
     @Override
-    CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path) {
-        CatalogueItem catalogueItem = super.processDeletionPatchOfFacet(multiFacetItemAware, targetModel, path)
+    CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path,
+                                              UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
+        CatalogueItem catalogueItem = super.processDeletionPatchOfFacet(multiFacetItemAware, targetModel, path, userSecurityPolicyManager, mergeEditDescription)
 
         if (multiFacetItemAware.domainType == SummaryMetadata.simpleName) {
             (catalogueItem as SummaryMetadataAware).summaryMetadata.remove(multiFacetItemAware)

--- a/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
+++ b/mdm-plugin-datamodel/grails-app/services/uk/ac/ox/softeng/maurodatamapper/datamodel/DataModelService.groovy
@@ -1093,7 +1093,8 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
 
     @Override
     void processCreationPatchOfModelItem(ModelItem modelItemToCopy, Model targetModel, Path pathToCopy,
-                                         UserSecurityPolicyManager userSecurityPolicyManager, boolean flush = false) {
+                                         UserSecurityPolicyManager userSecurityPolicyManager,
+                                         String mergeEditDescription, boolean flush = false) {
 
         // If the path to copy endswith the model item's path being copied then the model item cannot be inside the target model as the model item would already exist
         // and the path to copy must also therefore include a fully resolved model path after a modelitem path
@@ -1127,7 +1128,7 @@ class DataModelService extends ModelService<DataModel> implements SummaryMetadat
             }
             return
         }
-        super.processCreationPatchOfModelItem(modelItemToCopy, targetModel, pathToCopy, userSecurityPolicyManager, flush)
+        super.processCreationPatchOfModelItem(modelItemToCopy, targetModel, pathToCopy, userSecurityPolicyManager, mergeEditDescription, flush)
     }
 
     @Override

--- a/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelService.groovy
+++ b/mdm-plugin-referencedata/grails-app/services/uk/ac/ox/softeng/maurodatamapper/referencedata/ReferenceDataModelService.groovy
@@ -735,8 +735,9 @@ class ReferenceDataModelService extends ModelService<ReferenceDataModel> impleme
     }
 
     @Override
-    CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path) {
-        CatalogueItem catalogueItem = super.processDeletionPatchOfFacet(multiFacetItemAware, targetModel, path)
+    CatalogueItem processDeletionPatchOfFacet(MultiFacetItemAware multiFacetItemAware, Model targetModel, Path path,
+                                              UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
+        CatalogueItem catalogueItem = super.processDeletionPatchOfFacet(multiFacetItemAware, targetModel, path, userSecurityPolicyManager, mergeEditDescription)
 
         if (multiFacetItemAware.domainType == ReferenceSummaryMetadata.simpleName) {
             (catalogueItem as ReferenceSummaryMetadataAware).referenceSummaryMetadata.remove(multiFacetItemAware)

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
@@ -463,7 +463,8 @@ class CodeSetService extends ModelService<CodeSet> {
 
     @Override
     void processCreationPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToCopy,
-                                         UserSecurityPolicyManager userSecurityPolicyManager, boolean flush = false) {
+                                         UserSecurityPolicyManager userSecurityPolicyManager,
+                                         String mergeEditDescription, boolean flush = false) {
         if (!Utils.parentClassIsAssignableFromChild(Term, modelItem.class)) {
             throw new ApiInternalException('CSXX', "Cannot create [${modelItem.domainType}] into a CodeSet")
         }
@@ -471,6 +472,7 @@ class CodeSetService extends ModelService<CodeSet> {
 
         (targetModel as CodeSet).addToTerms(modelItem as Term)
         save(targetModel as CodeSet, flush: flush, validate: false)
+        targetModel.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
     @Override

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/CodeSetService.groovy
@@ -476,7 +476,8 @@ class CodeSetService extends ModelService<CodeSet> {
     }
 
     @Override
-    void processDeletionPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToDelete) {
+    void processDeletionPatchOfModelItem(ModelItem modelItem, Model targetModel, Path pathToDelete,
+                                         UserSecurityPolicyManager userSecurityPolicyManager, String mergeEditDescription) {
         if (!Utils.parentClassIsAssignableFromChild(Term, modelItem.class)) {
             throw new ApiInternalException('CSXX', "Cannot delete [${modelItem.domainType}] from CodeSet")
         }
@@ -484,6 +485,8 @@ class CodeSetService extends ModelService<CodeSet> {
 
         (targetModel as CodeSet).removeFromTerms(modelItem as Term)
         save(targetModel as CodeSet, flush: false, validate: false)
+
+        targetModel.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
     }
 
     @Override

--- a/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
+++ b/mdm-plugin-terminology/grails-app/services/uk/ac/ox/softeng/maurodatamapper/terminology/TerminologyService.groovy
@@ -816,15 +816,17 @@ class TerminologyService extends ModelService<Terminology> {
 
     @Override
     void processCreationPatchOfModelItem(ModelItem modelItemToCopy, Model targetModel, Path pathToCopy,
-                                         UserSecurityPolicyManager userSecurityPolicyManager, boolean flush = false) {
+                                         UserSecurityPolicyManager userSecurityPolicyManager,
+                                         String mergeEditDescription, boolean flush = false) {
         if (modelItemToCopy.domainType == TermRelationship.simpleName) {
             TermRelationship copy = termRelationshipService.copy(targetModel, modelItemToCopy as TermRelationship, null, userSecurityPolicyManager)
             if (!copy.validate())
                 throw new ApiInvalidModelException('MS01', 'Copied ModelItem is invalid', copy.errors, messageSource)
 
             termRelationshipService.save(copy, flush: flush, validate: false)
+            copy.addMergeEdit(userSecurityPolicyManager.user, mergeEditDescription)
             return
         }
-        super.processCreationPatchOfModelItem(modelItemToCopy, targetModel, pathToCopy, userSecurityPolicyManager, flush)
+        super.processCreationPatchOfModelItem(modelItemToCopy, targetModel, pathToCopy, userSecurityPolicyManager, mergeEditDescription, flush)
     }
 }

--- a/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/versionedfolder/container/VersionedFolderFunctionalSpec.groovy
+++ b/mdm-testing-functional/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/testing/functional/versionedfolder/container/VersionedFolderFunctionalSpec.groovy
@@ -2770,6 +2770,14 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         then:
         responseBody().description == 'DescriptionLeft'
 
+        when: "checking the edit history"
+        GET("dataModels/$targetDataModelMap.dataModelId/edits", MAP_ARG, true)
+
+        then: "the edit history contains merge actions"
+        def dataModelEdits = responseBody()
+        def dataModelMergeEdits = (dataModelEdits.items as ArrayList).findAll { edit -> edit.title == 'MERGE' }
+        dataModelMergeEdits.size() == 4
+
         when:
         GET("dataModels/$targetDataModelMap.dataModelId/dataClasses?all=true", MAP_ARG, true)
 
@@ -2788,6 +2796,8 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         responseBody().items.find {dataClass -> dataClass.label == 'Functional Test DataClass Importable Add'}.imported
         responseBody().items.find {dataClass -> dataClass.label == 'Functional Test DataClass Importable Add 2'}.imported
 
+        def dataClassEditTrackingId = responseBody().items.find {dataClass -> dataClass.label == 'addAndAddReturningDifference'}.id
+
         when:
         GET("dataModels/$targetDataModelMap.dataModelId/dataClasses/$targetDataModelMap.existingClass/dataClasses", MAP_ARG, true)
 
@@ -2795,6 +2805,14 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         responseBody().items.label as Set == ['addRightToExistingClass', 'addLeftToExistingClass',
                                               'Functional Test DataClass Importable', 'Functional Test DataClass Importable Add',
                                               'Functional Test DataClass Importable Add 2'] as Set
+
+        when: "checking the edit history"
+        GET("dataClasses/$dataClassEditTrackingId/edits", MAP_ARG, true)
+
+        then: "the edit history contains merge actions"
+        def dataClassEdits = responseBody()
+        def dataClassMergeEdits = (dataClassEdits.items as ArrayList).findAll { edit -> edit.title == 'MERGE' }
+        dataClassMergeEdits.size() == 1
 
         when:
         GET("dataModels/$targetDataModelMap.dataModelId/dataClasses/$targetDataModelMap.existingClass/dataElements", MAP_ARG, true)
@@ -2808,6 +2826,16 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
             'Functional Test DataElement Importable', 'Functional Test DataElement Importable Add', 'Functional Test DataElement Importable Add 2'] as Set
         responseBody().items.find {dc -> dc.label == 'Functional Test DataElement Importable'}.imported
         responseBody().items.find {dc -> dc.label == 'Functional Test DataElement Importable Add'}.imported
+
+        def dataElementTrackingId = responseBody().items.find {dc -> dc.label == 'addLeftOnly'}.id
+
+        when: "checking the edit history"
+        GET("dataElements/$dataElementTrackingId/edits", MAP_ARG, true)
+
+        then: "the edit history contains merge actions"
+        def dataElementEdits = responseBody()
+        def dataElementMergeEdits = (dataElementEdits.items as ArrayList).findAll { edit -> edit.title == 'MERGE' }
+        dataElementMergeEdits.size() == 1
 
         when:
         GET("dataModels/$targetDataModelMap.dataModelId/dataTypes", MAP_ARG, true)
@@ -2851,6 +2879,14 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         then:
         responseBody().description == 'DescriptionLeft'
 
+        when: "checking the edit history"
+        GET("terminologies/$targetTerminologyMap.terminologyId/edits", MAP_ARG, true)
+
+        then: "the edit history contains merge actions"
+        def terminologyEdits = responseBody()
+        def terminologyMergeEdits = (terminologyEdits.items as ArrayList).findAll { edit -> edit.title == 'MERGE' }
+        terminologyMergeEdits.size() == 5
+
         when:
         GET("terminologies/$targetTerminologyMap.terminologyId/terms", MAP_ARG, true)
 
@@ -2860,6 +2896,16 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         responseBody().items.find { term -> term.code == 'AAARD' }.description == 'DescriptionLeft'
         responseBody().items.find { term -> term.code == 'MAMRD' }.description == 'DescriptionLeft'
         responseBody().items.find { term -> term.code == 'MLO' }.description == 'Description'
+
+        def termEditTrackingId = responseBody().items.find { term -> term.code == 'MAD' }.id
+
+        when: "checking the edit history"
+        GET("terms/$termEditTrackingId/edits", MAP_ARG, true)
+
+        then: "the edit history contains merge actions"
+        def termEdits = responseBody()
+        def termMergeEdits = (termEdits.items as ArrayList).findAll { edit -> edit.title == 'MERGE' }
+        termMergeEdits.size() == 1
 
         when:
         GET("terminologies/$targetTerminologyMap.terminologyId/termRelationshipTypes", MAP_ARG, true)
@@ -2936,6 +2982,14 @@ class VersionedFolderFunctionalSpec extends UserAccessAndPermissionChangingFunct
         responseBody().items.each { t ->
             Assert.assertEquals("${t.code} has correct terminology", targetTerminologyMap.terminologyId, t.model)
         }
+
+        when: "checking the edit history"
+        GET("codeSets/$targetCodeSetMap.codeSetId/edits", MAP_ARG, true)
+
+        then: "the edit history contains merge actions"
+        def codeSetEdits = responseBody()
+        def codeSetMergeEdits = (codeSetEdits.items as ArrayList).findAll { edit -> edit.title == 'MERGE' }
+        codeSetMergeEdits.size() == 4
 
         when:
         GET("codeSets/$targetCodeSetMap.codeSetId/metadata", MAP_ARG, true)


### PR DESCRIPTION
Resolves #475 

Track at an item level changes that have happened to items under a versioned folder during a merge:

- Created/modified items have a `MERGE` edit history record attached to them.
- Deleted items have a `MERGE` edit history record attached to their parent (or the target versioned folder if not available).

This then results in a visible change history at the item level, as well as the `CHANGELOG` entry recorded on the versioned folder itself.

![image](https://github.com/user-attachments/assets/57a02dbc-f213-445a-b0ff-4e1fd281790b)

I have adjusted the `mdm-testing-functional` tests for Versioned Folder merging to carry out some spot checks to ensure that these `MERGE` history entries are at least being recorded.