### PR TITLE
gh-482 fixed history totalcount bug

### DIFF
--- a/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/EditController.groovy
+++ b/mdm-core/grails-app/controllers/uk/ac/ox/softeng/maurodatamapper/core/facet/EditController.groovy
@@ -20,6 +20,7 @@ package uk.ac.ox.softeng.maurodatamapper.core.facet
 
 import uk.ac.ox.softeng.maurodatamapper.core.traits.controller.MdmController
 
+import grails.gorm.PagedResultList
 import grails.rest.RestfulController
 
 class EditController extends RestfulController<Edit> implements MdmController {
@@ -43,7 +44,15 @@ class EditController extends RestfulController<Edit> implements MdmController {
         params.sort = params.sort ?: 'dateCreated'
         params.order = params.order ?: 'asc'
 
-        List<Edit> edits = editService.findAllByResource(params.resourceDomainType, params.resourceId, params)
-        edits.collect {editService.populateEditUser(it)}
+        PagedResultList<Edit> edits = editService.findAllByResource(params.resourceDomainType, params.resourceId, params)
+        List<Edit> transformedEdits = edits.collect { edit ->
+            editService.populateEditUser(edit)
+        }
+
+        // Since we cannot directly create a new PagedResultList with a modified list,
+        // and we still need the totalCount field which this function destroys
+        // we're abusing modify by reference to edit the items within the edits structure.
+        return edits
+
     }
 }

--- a/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/facet/Edit.groovy
+++ b/mdm-core/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/core/facet/Edit.groovy
@@ -23,6 +23,8 @@ import uk.ac.ox.softeng.maurodatamapper.gorm.constraint.callable.MdmDomainConstr
 import uk.ac.ox.softeng.maurodatamapper.security.User
 import uk.ac.ox.softeng.maurodatamapper.traits.domain.MdmDomain
 
+import grails.gorm.DetachedCriteria
+
 class Edit implements MdmDomain {
 
     UUID id
@@ -64,12 +66,28 @@ class Edit implements MdmDomain {
         title
     }
 
-    @SuppressWarnings('UnnecessaryQualifiedReference')
+        //previous findbyx does return with a totalcount value or in the correct object
     static List<Edit> findAllByResource(String resourceDomainType, UUID resourceId, Map pagination = [:]) {
-        Edit.findAllByResourceDomainTypeAndResourceId(resourceDomainType, resourceId, pagination)
+        byResourceCriteria(resourceDomainType, resourceId).list(pagination)
+    }
+
+    static DetachedCriteria<Edit> byResourceCriteria(String resourceDomainTypeValue, UUID resourceIdValue) {
+        where {
+            resourceDomainType == resourceDomainTypeValue
+            resourceId == resourceIdValue
+        }
     }
 
     static List<Edit> findAllByResourceAndTitle(String resourceDomainType, UUID resourceId, EditTitle title, Map pagination = [:]) {
-        Edit.findAllByResourceDomainTypeAndResourceIdAndTitle(resourceDomainType, resourceId, title, pagination)
+        byResourceAndTitleCritera(resourceDomainType, resourceId, title).list(pagination)
     }
+
+    static DetachedCriteria<Edit> byResourceAndTitleCritera(String resourceDomainTypeValue, UUID resourceIdValue, EditTitle titleValue) {
+        where {
+            resourceDomainType == resourceDomainTypeValue
+            resourceId == resourceIdValue
+            title == titleValue
+        }
+    }
+
 }


### PR DESCRIPTION
Supports gh-890 on mdm ui

closes #482 

The history tab was not receiving the correct totalcount of records when requesting the history of an item. This caused the paginator to not function at all. 
This was caused by two problems. 
First the call to access the database used the gorm getAllByX notation, which does not return the paginatedResponse object.
Second, the controller was forming a collect function on the list to populate the users, which was bricking the totalCount by converting the PagedResponseObject into a List object.
This caused the gson view to see default to the non paged response format and return the call as a simple list with count = to the current query count.

Solution was to refactor the call to a detachedCritera call which does return a pagedResponseObject (if you know why this is a bad idea please tell me, its been used elsewhere but I'm a little wary of the word detached)

And to modify the objects by value rather than by reference and return the original pagedResponseObject, preserving the count.

Testing:
see 
gh-890 on mdm ui


