### PR TITLE
gh-479 Merge Versioned Folders that are under sub-folder in the catalogue

### DIFF
--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/path/Path.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/path/Path.groovy
@@ -148,10 +148,10 @@ class Path implements Serializable, Cloneable {
         getPathString(modelIdentifierOverride)
     }
 
-    Path clone() {
+    Path clone(String modelIdentifierOverride = null) {
         Path local = this
         new Path().tap {
-            pathNodes = local.pathNodes.collect {it.clone()}
+            pathNodes = local.pathNodes.collect {it.clone(modelIdentifierOverride) }
         }
     }
 
@@ -183,22 +183,25 @@ class Path implements Serializable, Cloneable {
     /**
      * Reduce a path by removing it's relative root path and return a copy of the new path.
      * @param basePath The base path to remove from the front of this path
+     * @param modelIdentifierOverride A model identifier to override this path before reducing further. If not required, set to null
      * @return The new copy of this path without the base path at the front.
      */
-    Path reduce(Path basePath) {
-        if (basePath == this) {
+    Path reduce(Path basePath, String modelIdentifierOverride = null) {
+        Path workingPath = modelIdentifierOverride ? this.clone(modelIdentifierOverride) : this
+
+        if (basePath == workingPath) {
             return this
         }
 
         PathNode lastNodeFromBase = basePath.last()
-        int lastNodeIndex = this.pathNodes.findIndexOf {pathNode -> pathNode == lastNodeFromBase }
+        int lastNodeIndex = workingPath.pathNodes.findIndexOf {pathNode -> pathNode == lastNodeFromBase }
         if (lastNodeIndex == -1) {
             // Not found
             return this
         }
 
-        List<PathNode> reducedPathNodes = this.pathNodes
-            .subList(lastNodeIndex, this.pathNodes.size())
+        List<PathNode> reducedPathNodes = workingPath.pathNodes
+            .subList(lastNodeIndex, workingPath.pathNodes.size())
             .collect {pathNode -> pathNode.clone() }
 
         Path reducedPath = new Path().tap {

--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/path/Path.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/path/Path.groovy
@@ -180,6 +180,34 @@ class Path implements Serializable, Cloneable {
         resolved
     }
 
+    /**
+     * Reduce a path by removing it's relative root path and return a copy of the new path.
+     * @param basePath The base path to remove from the front of this path
+     * @return The new copy of this path without the base path at the front.
+     */
+    Path reduce(Path basePath) {
+        if (basePath == this) {
+            return this
+        }
+
+        PathNode lastNodeFromBase = basePath.last()
+        int lastNodeIndex = this.pathNodes.findIndexOf {pathNode -> pathNode == lastNodeFromBase }
+        if (lastNodeIndex == -1) {
+            // Not found
+            return this
+        }
+
+        List<PathNode> reducedPathNodes = this.pathNodes
+            .subList(lastNodeIndex, this.pathNodes.size())
+            .collect {pathNode -> pathNode.clone() }
+
+        Path reducedPath = new Path().tap {
+            it.pathNodes = reducedPathNodes
+        }
+
+        reducedPath
+    }
+
     boolean startsWith(PathNode pathNode, String modelIdentifierOverride = null) {
         pathNode.matches(first(), modelIdentifierOverride)
     }

--- a/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/path/PathNode.groovy
+++ b/mdm-common/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/path/PathNode.groovy
@@ -194,8 +194,13 @@ class PathNode implements Serializable, Cloneable {
         false
     }
 
-    PathNode clone() {
-        new PathNode(this.prefix, this.identifier, this.modelIdentifier, this.attribute)
+    PathNode clone(String modelIdentifierOverride = null) {
+        boolean hasModelIdentifier = this.modelIdentifier && !this.modelIdentifier.empty
+        new PathNode(
+            this.prefix,
+            this.identifier,
+            modelIdentifierOverride && hasModelIdentifier ? modelIdentifierOverride : this.modelIdentifier,
+            this.attribute)
     }
 
     double getLatitudeValue() {

--- a/mdm-common/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/path/PathSpec.groovy
+++ b/mdm-common/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/path/PathSpec.groovy
@@ -125,25 +125,48 @@ class PathSpec extends Specification {
         childPath.first().identifier == 'test2'
     }
 
-    void "should reduce from base path: #testCase"(String testCase, String original, String base, String expected) {
+    void "should clone a path"(String original, String modelIdentifierOverride) {
+        given: "the paths to use"
+        Path originalPath = Path.from(original)
+
+        when: "the path is cloned"
+        Path clonedPath = originalPath.clone(modelIdentifierOverride)
+
+        then: "the result is as expected"
+        !clonedPath.is(originalPath)    // Test object references are different
+        clonedPath.toString() == originalPath.toString(modelIdentifierOverride)
+
+        where:
+        original | modelIdentifierOverride
+        'dm:Data Model' | null
+        'dm:Data Model$main' | null
+        'dm:Data Model$main' | 'another'
+        'dm:Data Model$main|dc:Data Class|de:Data Element' | null
+        'dm:Data Model$main|dc:Data Class|de:Data Element' | 'another'
+        'vf:Versioned Folder$main|dm:Data Model$main|dc:Data Class' | null
+        'vf:Versioned Folder$main|dm:Data Model$main|dc:Data Class' | 'another'
+    }
+
+    void "should reduce from base path: #testCase"(String testCase, String original, String base, String expected, String modelIdentifierOverride) {
         given: "the paths to use"
         Path originalPath = Path.from(original)
         Path basePath = Path.from(base)
         Path expectedPath = Path.from(expected)
 
         when: "the path is reduced"
-        Path actualPath = originalPath.reduce(basePath)
+        Path actualPath = originalPath.reduce(basePath, modelIdentifierOverride)
 
         then: "the returned path is correct"
         actualPath == expectedPath
 
         where:
-        testCase | original | base | expected
-        'Relative Root Not Found'                   | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'dm:Data Model$main' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
-        'Relative Root Not Found using sub-folders' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'dm:Data Model$main' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
-        'Relative Root Is Same'                     | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
-        'VersionedFolder under one sub-folder'      | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
-        'VersionedFolder under two sub-folders'     | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
-        'VersionedFolder under three sub-folders'   | 'fo:Testing Folder|fo:Branches|fo:Sub-Branch|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|fo:Branches|fo:Sub-Branch|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+        testCase | original | base | expected | modelIdentifierOverride
+        'Relative Root Not Found'                   | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'dm:Data Model$main' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | null
+        'Relative Root Not Found using sub-folders' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'dm:Data Model$main' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | null
+        'Relative Root Is Same'                     | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | null
+        'VersionedFolder under one sub-folder'      | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | null
+        'VersionedFolder under two sub-folders'     | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | null
+        'VersionedFolder under three sub-folders'   | 'fo:Testing Folder|fo:Branches|fo:Sub-Branch|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|fo:Branches|fo:Sub-Branch|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | null
+        'Override Model Identifier on VersionedFolder' | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch|dm:Test Versioned Data Model$another-branch@description' | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$main' | 'vf:Test Versioned Folder$main|dm:Test Versioned Data Model$main@description' | 'main'
     }
 }

--- a/mdm-common/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/path/PathSpec.groovy
+++ b/mdm-common/src/test/groovy/uk/ac/ox/softeng/maurodatamapper/path/PathSpec.groovy
@@ -124,4 +124,26 @@ class PathSpec extends Specification {
         childPath.first().prefix == 'dc'
         childPath.first().identifier == 'test2'
     }
+
+    void "should reduce from base path: #testCase"(String testCase, String original, String base, String expected) {
+        given: "the paths to use"
+        Path originalPath = Path.from(original)
+        Path basePath = Path.from(base)
+        Path expectedPath = Path.from(expected)
+
+        when: "the path is reduced"
+        Path actualPath = originalPath.reduce(basePath)
+
+        then: "the returned path is correct"
+        actualPath == expectedPath
+
+        where:
+        testCase | original | base | expected
+        'Relative Root Not Found'                   | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'dm:Data Model$main' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+        'Relative Root Not Found using sub-folders' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'dm:Data Model$main' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+        'Relative Root Is Same'                     | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+        'VersionedFolder under one sub-folder'      | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+        'VersionedFolder under two sub-folders'     | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+        'VersionedFolder under three sub-folders'   | 'fo:Testing Folder|fo:Branches|fo:Sub-Branch|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch' | 'fo:Testing Folder|fo:Branches|fo:Sub-Branch|vf:Test Versioned Folder$another-branch' | 'vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch'
+    }
 }

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -1081,46 +1081,57 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
     void processCreationPatchIntoVersionedFolder(FieldPatchData creationPatch, VersionedFolder targetVersionedFolder,
                                                  VersionedFolder sourceVersionedFolder,
                                                  UserSecurityPolicyManager userSecurityPolicyManager) {
-        MdmDomain domainInTarget = pathService.findResourceByPathFromRootResource(targetVersionedFolder, creationPatch.relativePathToRoot,
-                                                                                  getModelIdentifier(targetVersionedFolder))
-        MdmDomain domainToCopy = domainInTarget ?: pathService.findResourceByPathFromRootResource(sourceVersionedFolder, creationPatch.path)
+        Path creationPath = creationPatch.path.reduce(sourceVersionedFolder.path)
+        Path creationPathRelativeToRoot = creationPath.childPath
+
+        MdmDomain domainInTarget = pathService.findResourceByPathFromRootResource(
+            targetVersionedFolder,
+            creationPathRelativeToRoot,  //creationPatch.relativePathToRoot,
+            getModelIdentifier(targetVersionedFolder))
+
+        MdmDomain domainToCopy = domainInTarget ?: pathService.findResourceByPathFromRootResource(sourceVersionedFolder, creationPath)
         if (!domainToCopy) {
-            log.warn('Could not process creation patch into versioned folder at path [{}] as no such path exists in the source', creationPatch.path)
+            log.warn('Could not process creation patch into versioned folder at path [{}] as no such path exists in the source', creationPath)
             return
         }
-        log.debug('Creating [{}]', creationPatch.path.toString(getModelIdentifier(targetVersionedFolder)))
+        log.debug('Creating [{}]', creationPath.toString(getModelIdentifier(targetVersionedFolder)))
         String mergeEditDescription = "Item created in '$sourceVersionedFolder.label\$$sourceVersionedFolder.branchName'"
 
         // Potential creations are folders, models, modelItems or facets
         if (Utils.parentClassIsAssignableFromChild(Folder, domainToCopy.class)) {
-            processCreationPatchOfFolder(domainToCopy as Folder, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
+            processCreationPatchOfFolder(domainToCopy as Folder, targetVersionedFolder, creationPathRelativeToRoot.parent,
                                          userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(Model, domainToCopy.class)) {
-            processCreationPatchOfModel(domainToCopy as Model, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
+            processCreationPatchOfModel(domainToCopy as Model, targetVersionedFolder, creationPathRelativeToRoot.parent,
                                         userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domainToCopy.class)) {
-            processCreationPatchOfModelItem(domainToCopy as ModelItem, targetVersionedFolder, creationPatch.relativePathToRoot,
+            processCreationPatchOfModelItem(domainToCopy as ModelItem, targetVersionedFolder, creationPathRelativeToRoot,
                                             userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domainToCopy.class)) {
-            processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetVersionedFolder, creationPatch.relativePathToRoot.parent,
+            processCreationPatchOfFacet(domainToCopy as MultiFacetItemAware, targetVersionedFolder, creationPathRelativeToRoot.parent,
                                         userSecurityPolicyManager, mergeEditDescription)
         }
     }
 
     void processDeletionPatchIntoVersionedFolder(FieldPatchData deletionPatch, VersionedFolder targetVersionedFolder, VersionedFolder sourceVersionedFolder,
                                                  UserSecurityPolicyManager userSecurityPolicyManager) {
-        MdmDomain domain =
-            pathService.findResourceByPathFromRootResource(targetVersionedFolder, deletionPatch.relativePathToRoot,
-                                                           getModelIdentifier(targetVersionedFolder))
+        Path deletionPath = deletionPatch.path.reduce(targetVersionedFolder.path)
+        Path deletionPathRelativeToRoot = deletionPath.childPath
+
+        MdmDomain domain = pathService.findResourceByPathFromRootResource(
+            targetVersionedFolder,
+            deletionPathRelativeToRoot,
+            getModelIdentifier(targetVersionedFolder))
+
         if (!domain) {
             log.warn('Could not process deletion patch from versioned folder at path [{}] as no such path exists in the target',
-                     deletionPatch.relativePathToRoot)
+                     deletionPathRelativeToRoot)
             return
         }
-        log.debug('Deleting [{}]', deletionPatch.path.toString(getModelIdentifier(targetVersionedFolder)))
+        log.debug('Deleting [{}]', deletionPath.toString(getModelIdentifier(targetVersionedFolder)))
 
         String itemRemovedLabel = (domain as InformationAware)?.label
         String mergeEditSuffix = itemRemovedLabel ?: domain.domainType ?: ""
@@ -1134,27 +1145,32 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             processDeletionPatchOfModel(domain as Model, targetVersionedFolder, userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(ModelItem, domain.class)) {
-            processDeletionPatchOfModelItem(domain as ModelItem, targetVersionedFolder, deletionPatch.relativePathToRoot,
+            processDeletionPatchOfModelItem(domain as ModelItem, targetVersionedFolder, deletionPathRelativeToRoot,
                                             userSecurityPolicyManager, mergeEditDescription)
         }
         if (Utils.parentClassIsAssignableFromChild(MultiFacetItemAware, domain.class)) {
-            processDeletionPatchOfFacet(domain as MultiFacetItemAware, targetVersionedFolder, deletionPatch.relativePathToRoot,
+            processDeletionPatchOfFacet(domain as MultiFacetItemAware, targetVersionedFolder, deletionPathRelativeToRoot,
                                         userSecurityPolicyManager, mergeEditDescription)
         }
     }
 
     void processModificationPatchIntoVersionedFolder(FieldPatchData modificationPatch, VersionedFolder targetVersionedFolder,
                                                      VersionedFolder sourceVersionedFolder, UserSecurityPolicyManager userSecurityPolicyManager) {
-        MdmDomain domain =
-            pathService.findResourceByPathFromRootResource(targetVersionedFolder, modificationPatch.relativePathToRoot,
-                                                           getModelIdentifier(targetVersionedFolder))
+        Path modificationPath = modificationPatch.path.reduce(targetVersionedFolder.path)
+        Path modificationPathRelativeToRoot = modificationPath.childPath
+
+        MdmDomain domain = pathService.findResourceByPathFromRootResource(
+            targetVersionedFolder,
+            modificationPathRelativeToRoot,
+            getModelIdentifier(targetVersionedFolder))
+
         if (!domain) {
             log.warn('Could not process modification patch into model at path [{}] as no such path exists in the target',
-                     modificationPatch.relativePathToRoot)
+                     modificationPathRelativeToRoot)
             return
         }
         String fieldName = modificationPatch.fieldName
-        log.debug('Modifying [{}] in [{}]', fieldName, modificationPatch.path.toString(getModelIdentifier(targetVersionedFolder)))
+        log.debug('Modifying [{}] in [{}]', fieldName, modificationPath.toString(getModelIdentifier(targetVersionedFolder)))
 
         MdmDomainService domainService = getDomainServices().find {it.handles(domain.class)}
         if (!domainService) throw new ApiInternalException('MSXX', "No domain service to handle modification of [${domain.domainType}]")

--- a/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
+++ b/mdm-core/grails-app/services/uk/ac/ox/softeng/maurodatamapper/core/container/VersionedFolderService.groovy
@@ -1118,20 +1118,21 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
     void processDeletionPatchIntoVersionedFolder(FieldPatchData deletionPatch, VersionedFolder targetVersionedFolder, VersionedFolder sourceVersionedFolder,
                                                  UserSecurityPolicyManager userSecurityPolicyManager) {
-        Path deletionPath = deletionPatch.path.reduce(targetVersionedFolder.path)
+        String targetModelIdentifier = getModelIdentifier(targetVersionedFolder)
+        Path deletionPath = deletionPatch.path.reduce(targetVersionedFolder.path, targetModelIdentifier)
         Path deletionPathRelativeToRoot = deletionPath.childPath
 
         MdmDomain domain = pathService.findResourceByPathFromRootResource(
             targetVersionedFolder,
             deletionPathRelativeToRoot,
-            getModelIdentifier(targetVersionedFolder))
+            targetModelIdentifier)
 
         if (!domain) {
             log.warn('Could not process deletion patch from versioned folder at path [{}] as no such path exists in the target',
                      deletionPathRelativeToRoot)
             return
         }
-        log.debug('Deleting [{}]', deletionPath.toString(getModelIdentifier(targetVersionedFolder)))
+        log.debug('Deleting [{}]', deletionPath.toString(targetModelIdentifier))
 
         String itemRemovedLabel = (domain as InformationAware)?.label
         String mergeEditSuffix = itemRemovedLabel ?: domain.domainType ?: ""
@@ -1156,13 +1157,14 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
 
     void processModificationPatchIntoVersionedFolder(FieldPatchData modificationPatch, VersionedFolder targetVersionedFolder,
                                                      VersionedFolder sourceVersionedFolder, UserSecurityPolicyManager userSecurityPolicyManager) {
-        Path modificationPath = modificationPatch.path.reduce(targetVersionedFolder.path)
+        String targetModelIdentifier = getModelIdentifier(targetVersionedFolder)
+        Path modificationPath = modificationPatch.path.reduce(targetVersionedFolder.path, targetModelIdentifier)
         Path modificationPathRelativeToRoot = modificationPath.childPath
 
         MdmDomain domain = pathService.findResourceByPathFromRootResource(
             targetVersionedFolder,
             modificationPathRelativeToRoot,
-            getModelIdentifier(targetVersionedFolder))
+            targetModelIdentifier)
 
         if (!domain) {
             log.warn('Could not process modification patch into model at path [{}] as no such path exists in the target',
@@ -1170,7 +1172,7 @@ class VersionedFolderService extends ContainerService<VersionedFolder> implement
             return
         }
         String fieldName = modificationPatch.fieldName
-        log.debug('Modifying [{}] in [{}]', fieldName, modificationPath.toString(getModelIdentifier(targetVersionedFolder)))
+        log.debug('Modifying [{}] in [{}]', fieldName, modificationPath.toString(targetModelIdentifier))
 
         MdmDomainService domainService = getDomainServices().find {it.handles(domain.class)}
         if (!domainService) throw new ApiInternalException('MSXX', "No domain service to handle modification of [${domain.domainType}]")


### PR DESCRIPTION
Resolves #479 

# Overview

If you structured a Versioned Folder at the root of the catalogue, it would be able to be merged into another root level Versioned Folder. But, if the VFs were under sub-folders themselves, the paths would be absolute to the catalogue root and then resources like models would not be located through the `PathService` at all.

I've fixed this by reducing all paths used in the merge down to the source/target locations of the versioned folders, removing all ancestor path nodes until the expected VF paths are reached. For example, if a creation patch had this path:

```
fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch
```

Where the Versioned Folder source was `fo:Testing Folder|fo:Branches|vf:Test Versioned Folder$another-branch`, then the creation source path is reduced to:

```
vf:Test Versioned Folder$another-branch|te:Test Versioned Terminology$another-branch
```

This means the `PathService.findResourceByPathFromRootResource()` method will work with this path.

- Updated `Path` to include a `reduce()` method
- Updated the unit tests of `Path` to verify `reduce()` works

# Testing

There are no new automated tests, but the existing tests still pass.

I tested manually by creating some VFs in this structure - note that I created multiple sub-folders to ensure that the paths could be reduced correctly:

![image](https://github.com/user-attachments/assets/843c4e75-1f18-40dc-8ea0-a236447ad1c1)

Create/modify/delete from the other branch and merge into the `main` branch - this should then correctly work.